### PR TITLE
Add optional project-specific PyPI mirror support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ docker compose up -d --build
 > sudo systemctl daemon-reload && sudo systemctl restart docker
 > ```
 > Then re-run `docker compose up -d`.
+>
+> **Optional PyPI mirror:** Backend installs keep the normal `pip` defaults. If you want to opt into a regional mirror for `bash setup.sh` or `docker compose up -d --build`, set:
+> ```bash
+> export CLAWITH_PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple
+> export CLAWITH_PIP_TRUSTED_HOST=pypi.tuna.tsinghua.edu.cn
+> ```
 
 ### First Login
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,7 +8,15 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn .
+ARG CLAWITH_PIP_INDEX_URL
+ARG CLAWITH_PIP_TRUSTED_HOST
+RUN if [ -n "$CLAWITH_PIP_INDEX_URL" ] && [ -n "$CLAWITH_PIP_TRUSTED_HOST" ]; then \
+        pip install --no-cache-dir --index-url "$CLAWITH_PIP_INDEX_URL" --trusted-host "$CLAWITH_PIP_TRUSTED_HOST" .; \
+    elif [ -n "$CLAWITH_PIP_INDEX_URL" ]; then \
+        pip install --no-cache-dir --index-url "$CLAWITH_PIP_INDEX_URL" .; \
+    else \
+        pip install --no-cache-dir .; \
+    fi
 
 # ─── Production ─────────────────────────────────────────
 FROM python:3.12-slim AS production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,11 @@ services:
       retries: 5
 
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      args:
+        CLAWITH_PIP_INDEX_URL: ${CLAWITH_PIP_INDEX_URL:-}
+        CLAWITH_PIP_TRUSTED_HOST: ${CLAWITH_PIP_TRUSTED_HOST:-}
     restart: unless-stopped
     environment:
       DATABASE_URL: postgresql+asyncpg://clawith:clawith@postgres:5432/clawith

--- a/setup.sh
+++ b/setup.sh
@@ -26,8 +26,14 @@ get_server_ip() {
     echo "$ip"
 }
 
-# --- Package mirrors (Tsinghua PyPI + npmmirror, fast globally) ---
-PIP_MIRROR="-i https://pypi.tuna.tsinghua.edu.cn/simple --trusted-host pypi.tuna.tsinghua.edu.cn"
+# --- Optional package mirror overrides ---
+PIP_INSTALL_ARGS=()
+if [ -n "${CLAWITH_PIP_INDEX_URL:-}" ]; then
+    PIP_INSTALL_ARGS+=(--index-url "$CLAWITH_PIP_INDEX_URL")
+fi
+if [ -n "${CLAWITH_PIP_TRUSTED_HOST:-}" ]; then
+    PIP_INSTALL_ARGS+=(--trusted-host "$CLAWITH_PIP_TRUSTED_HOST")
+fi
 NPM_MIRROR="--registry https://registry.npmmirror.com"
 
 echo ""
@@ -350,7 +356,7 @@ else
     PIP_TARGET="."
     echo "  Installing dependencies (this may take 1-2 minutes)..."
 fi
-if .venv/bin/pip install -e "$PIP_TARGET" $PIP_MIRROR 2>&1; then
+if .venv/bin/pip install -e "$PIP_TARGET" "${PIP_INSTALL_ARGS[@]}" 2>&1; then
     echo -e "  ${GREEN}✓${NC} Backend dependencies installed"
 else
     echo -e "  ${RED}✗${NC} Failed to install backend dependencies."


### PR DESCRIPTION
## Summary
- stop hardcoding the Tsinghua PyPI mirror in backend setup paths
- let users opt into a mirror explicitly with `CLAWITH_PIP_INDEX_URL` and `CLAWITH_PIP_TRUSTED_HOST`
- pass the optional mirror settings through Docker Compose and document them in the README

## Why
The current Docker and local setup flow can fail when the hardcoded mirror has TLS/connectivity problems. This keeps the default install path unchanged for most users while still allowing regional mirror configuration when needed.

## Validation
- `bash -n setup.sh`
- `docker compose config`
