### PR TITLE
Localize remaining hardcoded Chinese UI strings

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -313,6 +313,18 @@
         "deleteWarning": "This action is irreversible. All data for this digital employee will be permanently deleted.",
         "confirmDelete": "Confirm Delete",
         "typeToConfirm": "Type the agent name to confirm"
+      },
+      "expiry": {
+        "renew": "Renew",
+        "setExpiry": "Set Expiry",
+        "title": "Agent Expiry",
+        "expired": "Expired",
+        "currentExpiry": "Current expiry:",
+        "neverExpires": "Never expires",
+        "quickRenew": "Quick renew (from current base)",
+        "days": "{{count}}d",
+        "customDeadline": "Custom deadline",
+        "saving": "Saving..."
       }
     },
     "tools": {
@@ -425,6 +437,14 @@
     "placeholder": "Type a message...",
     "send": "Send"
   },
+  "messages": {
+    "title": "Messages",
+    "markAllRead": "Mark all as read ({{count}})",
+    "empty": "No messages",
+    "justNow": "Just now",
+    "minutesAgo": "{{count}} minutes ago",
+    "hoursAgo": "{{count}} hours ago"
+  },
   "enterprise": {
     "title": "Enterprise Settings",
     "tabs": {
@@ -472,7 +492,9 @@
       "collapse": "Collapse",
       "saveConfig": "Save Config",
       "description": "Description",
-      "parameters": "Parameters"
+      "parameters": "Parameters",
+      "initBuiltinsHint": "Start the backend first to initialize built-in tools.",
+      "emptyState": "No data. Start the backend first to initialize built-in tools."
     },
     "org": {
       "feishuSync": "Feishu Directory Sync",
@@ -519,7 +541,11 @@
       "time": "Time",
       "user": "User",
       "action": "Action",
-      "target": "Target"
+      "target": "Target",
+      "filterAll": "All",
+      "filterBackground": "Background",
+      "filterActions": "User Actions",
+      "records": "{{count}} records"
     },
     "notificationBar": {
       "title": "Notification Bar",
@@ -545,7 +571,12 @@
     "yes": "Yes",
     "no": "No",
     "all": "All",
-    "none": "None"
+    "none": "None",
+    "channels": {
+      "feishu": "Feishu",
+      "discord": "Discord",
+      "slack": "Slack"
+    }
   },
   "channelGuide": {
     "setupGuide": "Setup Guide",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -312,6 +312,18 @@
         "deleteWarning": "此操作不可逆，将永久删除此数字员工及其所有数据。",
         "confirmDelete": "确认删除",
         "typeToConfirm": "输入数字员工名称以确认"
+      },
+      "expiry": {
+        "renew": "续期",
+        "setExpiry": "设置过期",
+        "title": "Agent 过期时间",
+        "expired": "已过期",
+        "currentExpiry": "当前过期时间：",
+        "neverExpires": "永不过期",
+        "quickRenew": "快速续期（从当前基础上）",
+        "days": "{{count}}天",
+        "customDeadline": "自定义截止时间",
+        "saving": "保存中..."
       }
     },
     "tools": {
@@ -424,6 +436,14 @@
     "placeholder": "输入消息...",
     "send": "发送"
   },
+  "messages": {
+    "title": "消息中心",
+    "markAllRead": "全部标为已读 ({{count}})",
+    "empty": "暂无消息",
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}} 分钟前",
+    "hoursAgo": "{{count}} 小时前"
+  },
   "enterprise": {
     "title": "企业设置",
     "tabs": {
@@ -471,7 +491,9 @@
       "collapse": "收起",
       "saveConfig": "保存配置",
       "description": "描述",
-      "parameters": "参数配置"
+      "parameters": "参数配置",
+      "initBuiltinsHint": "请先启动后端以初始化内置工具。",
+      "emptyState": "暂无数据。请先启动后端以初始化内置工具。"
     },
     "org": {
       "feishuSync": "飞书通讯录同步配置",
@@ -529,7 +551,11 @@
       "time": "时间",
       "user": "用户",
       "action": "操作",
-      "target": "对象"
+      "target": "对象",
+      "filterAll": "全部",
+      "filterBackground": "后台服务",
+      "filterActions": "用户操作",
+      "records": "{{count}} 条记录"
     },
     "notificationBar": {
       "title": "顶部通知条",
@@ -555,7 +581,12 @@
     "yes": "是",
     "no": "否",
     "all": "全部",
-    "none": "无"
+    "none": "无",
+    "channels": {
+      "feishu": "飞书",
+      "discord": "Discord",
+      "slack": "Slack"
+    }
   },
   "channelGuide": {
     "setupGuide": "配置说明",

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -486,7 +486,7 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
 }
 
 export default function AgentDetail() {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -1292,7 +1292,7 @@ export default function AgentDetail() {
                                         style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '11px', color: 'var(--text-tertiary)', padding: '1px 4px', borderRadius: '4px', lineHeight: 1 }}
                                         onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-secondary)')}
                                         onMouseLeave={e => (e.currentTarget.style.background = 'none')}
-                                    >✏️ {(agent as any).expires_at || (agent as any).is_expired ? '续期' : '设置过期'}</button>
+                                    >✏️ {t((agent as any).expires_at || (agent as any).is_expired ? 'agent.settings.expiry.renew' : 'agent.settings.expiry.setExpiry')}</button>
                                 )}
                             </p>
                         </div>
@@ -1911,7 +1911,11 @@ export default function AgentDetail() {
                                         ) : sessions.map((s: any) => {
                                             const isActive = activeSession?.id === s.id;
                                             const isOwn = s.user_id === String(currentUser?.id);
-                                            const channelLabel: Record<string, string> = { feishu: '飞书', discord: 'Discord', slack: 'Slack' };
+                                            const channelLabel: Record<string, string> = {
+                                                feishu: t('common.channels.feishu'),
+                                                discord: t('common.channels.discord'),
+                                                slack: t('common.channels.slack'),
+                                            };
                                             const chLabel = channelLabel[s.source_channel];
                                             return (
                                                 <div key={s.id} onClick={() => selectSession(s)}
@@ -1924,7 +1928,9 @@ export default function AgentDetail() {
                                                     </div>
                                                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
                                                         {isOwn && isActive && wsConnected && <span className="status-dot running" style={{ width: '5px', height: '5px', flexShrink: 0 }} />}
-                                                        {s.last_message_at ? new Date(s.last_message_at).toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : new Date(s.created_at).toLocaleString('zh-CN', { month: 'short', day: 'numeric' })}
+                                                        {s.last_message_at
+                                                            ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+                                                            : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
                                                         {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
                                                     </div>
                                                 </div>
@@ -1958,9 +1964,17 @@ export default function AgentDetail() {
                                                             onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}>
                                                             <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '1px' }}>
                                                                 <div style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-primary)', flex: 1 }}>{s.title}</div>
-                                                                {({ feishu: '飞书', discord: 'Discord', slack: 'Slack' } as Record<string, string>)[s.source_channel] && (
+                                                                {({
+                                                                    feishu: t('common.channels.feishu'),
+                                                                    discord: t('common.channels.discord'),
+                                                                    slack: t('common.channels.slack'),
+                                                                } as Record<string, string>)[s.source_channel] && (
                                                                     <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>
-                                                                        {({ feishu: '飞书', discord: 'Discord', slack: 'Slack' } as Record<string, string>)[s.source_channel]}
+                                                                        {({
+                                                                            feishu: t('common.channels.feishu'),
+                                                                            discord: t('common.channels.discord'),
+                                                                            slack: t('common.channels.slack'),
+                                                                        } as Record<string, string>)[s.source_channel]}
                                                                     </span>
                                                                 )}
                                                             </div>
@@ -3212,21 +3226,26 @@ export default function AgentDetail() {
                         <div style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-subtle)', borderRadius: '12px', padding: '24px', width: '360px', maxWidth: '90vw' }}
                             onClick={e => e.stopPropagation()}>
                             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '16px' }}>
-                                <h3 style={{ margin: 0, fontSize: '15px', fontWeight: 600 }}>⏰ Agent 过期时间</h3>
+                                <h3 style={{ margin: 0, fontSize: '15px', fontWeight: 600 }}>⏰ {t('agent.settings.expiry.title')}</h3>
                                 <button onClick={() => setShowExpiryModal(false)} style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--text-tertiary)', fontSize: '18px', lineHeight: 1 }}>×</button>
                             </div>
                             <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '16px' }}>
                                 {(agent as any).is_expired
-                                    ? <span style={{ color: 'var(--error)', fontWeight: 600 }}>⏰ 已过期</span>
+                                    ? <span style={{ color: 'var(--error)', fontWeight: 600 }}>⏰ {t('agent.settings.expiry.expired')}</span>
                                     : (agent as any).expires_at
-                                        ? <>当前过期时间：<strong>{new Date((agent as any).expires_at).toLocaleString()}</strong></>
-                                        : <span style={{ color: 'var(--success)' }}>永不过期</span>
+                                        ? <>{t('agent.settings.expiry.currentExpiry')} <strong>{new Date((agent as any).expires_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US')}</strong></>
+                                        : <span style={{ color: 'var(--success)' }}>{t('agent.settings.expiry.neverExpires')}</span>
                                 }
                             </div>
                             <div style={{ marginBottom: '16px' }}>
-                                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '8px' }}>快速续期（从当前基础上）</div>
+                                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '8px' }}>{t('agent.settings.expiry.quickRenew')}</div>
                                 <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                                    {([['+ 24h', 24], ['+ 7天', 168], ['+ 30天', 720], ['+ 90天', 2160]] as [string, number][]).map(([label, h]) => (
+                                    {([
+                                        ['+ 24h', 24],
+                                        [`+ ${t('agent.settings.expiry.days', { count: 7 })}`, 168],
+                                        [`+ ${t('agent.settings.expiry.days', { count: 30 })}`, 720],
+                                        [`+ ${t('agent.settings.expiry.days', { count: 90 })}`, 2160],
+                                    ] as [string, number][]).map(([label, h]) => (
                                         <button key={h} onClick={() => addHours(h)}
                                             style={{ padding: '4px 10px', borderRadius: '6px', border: '1px solid var(--border-subtle)', background: 'var(--bg-primary)', cursor: 'pointer', fontSize: '12px', color: 'var(--text-primary)' }}>
                                             {label}
@@ -3235,24 +3254,24 @@ export default function AgentDetail() {
                                 </div>
                             </div>
                             <div style={{ marginBottom: '20px' }}>
-                                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '6px' }}>自定义截止时间</div>
+                                <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginBottom: '6px' }}>{t('agent.settings.expiry.customDeadline')}</div>
                                 <input type="datetime-local" value={expiryValue} onChange={e => setExpiryValue(e.target.value)}
                                     style={{ width: '100%', padding: '8px 10px', borderRadius: '8px', border: '1px solid var(--border-subtle)', background: 'var(--bg-primary)', color: 'var(--text-primary)', fontSize: '13px', boxSizing: 'border-box' }} />
                             </div>
                             <div style={{ display: 'flex', gap: '8px', justifyContent: 'space-between', alignItems: 'center' }}>
                                 <button onClick={() => saveExpiry(true)} disabled={expirySaving}
                                     style={{ padding: '7px 12px', borderRadius: '8px', border: '1px solid var(--border-subtle)', background: 'none', cursor: 'pointer', fontSize: '12px', color: 'var(--text-secondary)' }}>
-                                    🔓 永不过期
+                                    🔓 {t('agent.settings.expiry.neverExpires')}
                                 </button>
                                 <div style={{ display: 'flex', gap: '8px' }}>
                                     <button onClick={() => setShowExpiryModal(false)} disabled={expirySaving}
                                         style={{ padding: '7px 14px', borderRadius: '8px', border: '1px solid var(--border-subtle)', background: 'none', cursor: 'pointer', fontSize: '13px', color: 'var(--text-secondary)' }}>
-                                        取消
+                                        {t('common.cancel')}
                                     </button>
                                     <button onClick={() => saveExpiry(false)} disabled={expirySaving || !expiryValue}
                                         className="btn btn-primary"
                                         style={{ opacity: !expiryValue ? 0.5 : 1 }}>
-                                        {expirySaving ? '保存中…' : '保存'}
+                                        {expirySaving ? t('agent.settings.expiry.saving') : t('common.save')}
                                     </button>
                                 </div>
                             </div>

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -899,7 +899,11 @@ export default function EnterpriseSettings() {
                     <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
                         {/* Sub-filter pills */}
                         <div style={{ display: 'flex', gap: '8px', padding: '8px 12px', borderBottom: '1px solid var(--border-color)' }}>
-                            {([['all', '📋 全部'], ['background', '⚙️ 后台服务'], ['actions', '👤 用户操作']] as const).map(([key, label]) => (
+                            {([
+                                ['all', `📋 ${t('enterprise.audit.filterAll')}`],
+                                ['background', `⚙️ ${t('enterprise.audit.filterBackground')}`],
+                                ['actions', `👤 ${t('enterprise.audit.filterActions')}`],
+                            ] as const).map(([key, label]) => (
                                 <button key={key}
                                     onClick={() => setAuditFilter(key as any)}
                                     style={{
@@ -912,7 +916,7 @@ export default function EnterpriseSettings() {
                                 >{label}</button>
                             ))}
                             <span style={{ marginLeft: 'auto', fontSize: '11px', color: 'var(--text-tertiary)', alignSelf: 'center' }}>
-                                {filteredAuditLogs.length} 条记录
+                                {t('enterprise.audit.records', { count: filteredAuditLogs.length })}
                             </span>
                         </div>
                         {/* Log entries */}
@@ -1325,7 +1329,7 @@ export default function EnterpriseSettings() {
                                         </div>
                                     );
                                 })}
-                                {allTools.length === 0 && <div style={{ textAlign: 'center', padding: '40px', color: 'var(--text-tertiary)' }}>{t('common.noData')}。请先启动后端以初始化内置工具。</div>}
+                                {allTools.length === 0 && <div style={{ textAlign: 'center', padding: '40px', color: 'var(--text-tertiary)' }}>{t('enterprise.tools.emptyState')}</div>}
                             </div>
                         </>}
                     </div>

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -10,7 +10,7 @@ const ACTION_ICONS: Record<string, string> = {
 };
 
 export default function Messages() {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const queryClient = useQueryClient();
     const { data: messages = [], isLoading } = useQuery({
         queryKey: ['messages-inbox'],
@@ -41,29 +41,29 @@ export default function Messages() {
         const d = new Date(iso);
         const now = new Date();
         const diffMs = now.getTime() - d.getTime();
-        if (diffMs < 60000) return '刚刚';
-        if (diffMs < 3600000) return `${Math.floor(diffMs / 60000)} 分钟前`;
-        if (diffMs < 86400000) return `${Math.floor(diffMs / 3600000)} 小时前`;
-        return d.toLocaleDateString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+        if (diffMs < 60000) return t('messages.justNow');
+        if (diffMs < 3600000) return t('messages.minutesAgo', { count: Math.floor(diffMs / 60000) });
+        if (diffMs < 86400000) return t('messages.hoursAgo', { count: Math.floor(diffMs / 3600000) });
+        return d.toLocaleDateString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
     };
 
     return (
         <div style={{ maxWidth: '800px', margin: '0 auto', padding: '24px' }}>
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '20px' }}>
-                <h1 style={{ fontSize: '20px', fontWeight: 600, margin: 0 }}>消息中心</h1>
+                <h1 style={{ fontSize: '20px', fontWeight: 600, margin: 0 }}>{t('messages.title')}</h1>
                 {unreadCount > 0 && (
                     <button
                         className="btn btn-ghost"
                         onClick={() => markAllReadMutation.mutate()}
                         style={{ fontSize: '13px', color: 'var(--accent)' }}
                     >
-                        全部标为已读 ({unreadCount})
+                        {t('messages.markAllRead', { count: unreadCount })}
                     </button>
                 )}
             </div>
 
             {isLoading && (
-                <div style={{ textAlign: 'center', padding: '40px', color: 'var(--text-tertiary)' }}>加载中...</div>
+                <div style={{ textAlign: 'center', padding: '40px', color: 'var(--text-tertiary)' }}>{t('common.loading')}</div>
             )}
 
             {!isLoading && messages.length === 0 && (
@@ -71,8 +71,8 @@ export default function Messages() {
                     textAlign: 'center', padding: '60px 20px', color: 'var(--text-tertiary)',
                     background: 'var(--bg-secondary)', borderRadius: '12px',
                 }}>
-                    <div style={{ fontSize: '13px', marginBottom: '12px', color: 'var(--text-tertiary)' }}>暂无消息</div>
-                    <div>暂无消息</div>
+                    <div style={{ fontSize: '13px', marginBottom: '12px', color: 'var(--text-tertiary)' }}>{t('messages.empty')}</div>
+                    <div>{t('messages.empty')}</div>
                 </div>
             )}
 


### PR DESCRIPTION
## Summary
- localize remaining hardcoded Chinese strings in agent expiry UI, messages, and enterprise audit filters
- add missing translation keys for the affected frontend surfaces
- use locale-aware channel labels and date formatting in the updated views

## Validation
- `docker compose up -d --build`
- verified rebuilt services start successfully
- IDE lint check on updated frontend files
