### PR TITLE
Mount agent data as bind mount for direct host access

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ git pull
 docker compose up -d --build
 ```
 
+**Agent workspace data storage:**
+Agent workspace files (soul.md, memory, skills, workspace files) are stored in `./backend/agent_data/` on the host filesystem. Each agent has its own directory named by its UUID (e.g., `backend/agent_data/<agent-id>/`). This directory is mounted into the backend container at `/data/agents/`, making agent data directly accessible from your local filesystem.
+
 > **🇨🇳 Docker Registry Mirror (China users):** If `docker compose up -d` fails with a timeout, configure a Docker registry mirror first:
 > ```bash
 > sudo tee /etc/docker/daemon.json > /dev/null <<EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/app
-      - agent_data:/data/agents
+      - ./backend/agent_data:/data/agents
       - /var/run/docker.sock:/var/run/docker.sock
       - ./ss-nodes.json:/data/ss-nodes.json:ro
     depends_on:
@@ -79,7 +79,6 @@ services:
 volumes:
   pgdata:
   redisdata:
-  agent_data:
 
 
 networks:


### PR DESCRIPTION
## Summary
- Change `agent_data` from Docker volume to bind mount at `./backend/agent_data`
- Update README to document agent workspace data storage location
- Makes agent workspace files directly accessible from host filesystem

## Why
Previously, agent workspace data was stored in a Docker volume, making it difficult to access directly from the host filesystem. This change mounts the agent data directory as a bind mount, allowing users to:
- Access agent files directly without Docker commands
- Easily backup agent workspace data
- Edit agent files (soul.md, memory, etc.) directly from their IDE

## Changes
- `docker-compose.yml`: Changed `agent_data:/data/agents` to `./backend/agent_data:/data/agents`
- `README.md`: Added documentation section explaining agent workspace data storage

## Validation
- Verified existing agent data can be accessed at `backend/agent_data/<agent-id>/`
- Confirmed Docker Compose configuration is valid