### PR TITLE
fix(i18n): add Chinese translations for Max Tool Call Rounds section

### DIFF
--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -270,6 +270,9 @@
       "currentUsage": "当前用量",
       "today": "今日",
       "month": "本月",
+      "maxToolRounds": "最大工具调用轮次",
+      "maxToolRoundsLabel": "每条消息的最大轮次",
+      "maxToolRoundsDesc": "智能体每条消息可执行的工具调用轮次数（搜索、写入等）。默认值：50",
       "saveSettings": "保存设置",
       "saved": "已保存",
       "autonomy": {


### PR DESCRIPTION
## Summary
- Fixes #31
- Added missing Chinese (zh) translations for the "Max Tool Call Rounds" section on the Agent Settings page:
  - `agent.settings.maxToolRounds` → 最大工具调用轮次
  - `agent.settings.maxToolRoundsLabel` → 每条消息的最大轮次
  - `agent.settings.maxToolRoundsDesc` → 智能体每条消息可执行的工具调用轮次数（搜索、写入等）。默认值：50

## Test plan
- [ ] Set language to 中文, navigate to Agent Settings page
- [ ] Verify "Max Tool Call Rounds" section displays in Chinese

Please review @wisdomqin 