### PR TITLE
fix(ui): display join time with second-level precision

### DIFF
--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -118,7 +118,7 @@ export default function UserManagement() {
     const formatDate = (iso?: string) => {
         if (!iso) return '—';
         const d = new Date(iso);
-        return d.toLocaleDateString(isChinese ? 'zh-CN' : 'en-US', { year: 'numeric', month: '2-digit', day: '2-digit' });
+        return d.toLocaleString(isChinese ? 'zh-CN' : 'en-US', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
     };
 
     // Search filter


### PR DESCRIPTION
## Summary
- Fixes #16
- Changed `formatDate` in `UserManagement.tsx` from `toLocaleDateString` to `toLocaleString` with hour/minute/second options
- Join time now displays as `2025/10/22 14:30:15` instead of `2025/10/22`

## Test plan
- [ ] Open Operations Management > Users page
- [ ] Click on a user's join details popup
- [ ] Verify join time shows full timestamp with seconds (e.g. `2025/10/22 14:30:15`)

Please review @wisdomqin  🙏