### PR TITLE
Fix tenant-aware agent creation and company name display

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -149,14 +149,19 @@ async def create_agent(
     from datetime import datetime, timedelta, timezone as tz
     expires_at = datetime.now(tz.utc) + timedelta(hours=current_user.quota_agent_ttl_hours or 48)
 
-    # Get default limits from tenant
+    # Determine target tenant: normally user's tenant; admins can override via payload
+    target_tenant_id = current_user.tenant_id
+    if current_user.role in ("platform_admin", "org_admin") and data.tenant_id:
+        target_tenant_id = data.tenant_id
+
+    # Get default limits from target tenant
     max_llm_calls = 100
     default_max_triggers = 20
     default_min_poll = 5
     default_webhook_rate = 5
-    if current_user.tenant_id:
+    if target_tenant_id:
         from app.models.tenant import Tenant
-        tenant_result = await db.execute(select(Tenant).where(Tenant.id == current_user.tenant_id))
+        tenant_result = await db.execute(select(Tenant).where(Tenant.id == target_tenant_id))
         tenant = tenant_result.scalar_one_or_none()
         if tenant:
             max_llm_calls = tenant.default_max_llm_calls_per_day or 100
@@ -170,7 +175,7 @@ async def create_agent(
         bio=data.bio,
         avatar_url=data.avatar_url,
         creator_id=current_user.id,
-        tenant_id=current_user.tenant_id,
+        tenant_id=target_tenant_id,
         primary_model_id=data.primary_model_id,
         fallback_model_id=data.fallback_model_id,
         max_tokens_per_day=data.max_tokens_per_day,

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -71,6 +71,8 @@ class AgentCreate(BaseModel):
     permission_scope_type: str = "company"  # company | user
     permission_scope_ids: list[uuid.UUID] = []
     permission_access_level: str = "use"  # use | manage
+    # Target tenant (admin-only override; otherwise ignored)
+    tenant_id: uuid.UUID | None = None
     # Template
     template_id: uuid.UUID | None = None
     # Autonomy

--- a/frontend/src/pages/AgentCreate.tsx
+++ b/frontend/src/pages/AgentCreate.tsx
@@ -12,6 +12,8 @@ export default function AgentCreate() {
     const queryClient = useQueryClient();
     const [step, setStep] = useState(0);
     const [error, setError] = useState('');
+    // Current company (tenant) selection from layout sidebar
+    const [currentTenant] = useState<string | null>(() => localStorage.getItem('current_tenant_id'));
 
     const [form, setForm] = useState({
         name: '',
@@ -96,6 +98,8 @@ export default function AgentCreate() {
             max_tokens_per_month: form.max_tokens_per_month ? Number(form.max_tokens_per_month) : undefined,
             skill_ids: form.skill_ids,
             permission_access_level: form.permission_access_level,
+            // For platform/org admins, backend will honor this tenant_id override
+            tenant_id: currentTenant || undefined,
         });
     };
 

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -207,9 +207,12 @@ export default function Layout() {
     const [newCompanyName, setNewCompanyName] = useState('');
 
     const { data: tenants = [] } = useQuery({
-        queryKey: ['tenants'],
-        queryFn: () => fetchJson<any[]>('/tenants/'),
-        enabled: !!user && user.role === 'platform_admin',
+        queryKey: ['tenants', user?.role],
+        queryFn: () =>
+            user?.role === 'platform_admin'
+                ? fetchJson<any[]>('/tenants/')
+                : fetchJson<any[]>('/tenants/public/list'),
+        enabled: !!user,
     });
 
     // Auto-select user's tenant or first available tenant; also fix stale localStorage values
@@ -247,7 +250,9 @@ export default function Layout() {
         // Notify other components about tenant change
         window.dispatchEvent(new StorageEvent('storage', { key: 'current_tenant_id', newValue: tenantId }));
     };
-    const currentTenantName = tenants.find((t: any) => t.id === currentTenant)?.name;
+    const currentTenantName = tenants.find(
+        (t: any) => t.id === (currentTenant || user?.tenant_id),
+    )?.name;
     const createCompany = async () => {
         if (!newCompanyName.trim()) return;
         const token = localStorage.getItem('token');


### PR DESCRIPTION
## Summary

This PR fixes multi-tenant behavior in two ways:

- Agent creation now respects the selected company (tenant) for platform/org admins instead of always assigning new digital employees to the default tenant.
- The main UI shows the actual company name for the current user instead of the generic "My Company" fallback.

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
