### PR TITLE
fix: use host-safe default AGENT_DATA_DIR for local runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,9 @@ FEISHU_APP_ID=
 FEISHU_APP_SECRET=
 FEISHU_REDIRECT_URI=http://localhost:3000/auth/feishu/callback
 
-# Agent workspace data directory (default: /data/agents for Docker)
-# AGENT_DATA_DIR=./data/agents
+# Agent workspace data directory.
+# Default: local host -> ~/.clawith/data/agents ; container runtime -> /data/agents
+# AGENT_DATA_DIR=
 
 # Jina AI API key (for jina_search and jina_read tools — get one at https://jina.ai)
 # Without a key, the tools still work but with lower rate limits

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,8 +1,33 @@
 """Application configuration."""
 
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic_settings import BaseSettings
+
+
+def _running_in_container() -> bool:
+    """Best-effort container runtime detection."""
+    if Path("/.dockerenv").exists() or Path("/run/.containerenv").exists():
+        return True
+
+    cgroup = Path("/proc/1/cgroup")
+    if not cgroup.exists():
+        return False
+
+    try:
+        content = cgroup.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+    return any(token in content for token in ("docker", "containerd", "kubepods", "podman"))
+
+
+def _default_agent_data_dir() -> str:
+    """Use Docker path in containers, user-writable path on local hosts."""
+    if _running_in_container():
+        return "/data/agents"
+    return str(Path.home() / ".clawith" / "data" / "agents")
 
 
 class Settings(BaseSettings):
@@ -27,7 +52,7 @@ class Settings(BaseSettings):
     JWT_ACCESS_TOKEN_EXPIRE_MINUTES: int = 60 * 24  # 24 hours
 
     # File Storage
-    AGENT_DATA_DIR: str = "/data/agents"
+    AGENT_DATA_DIR: str = _default_agent_data_dir()
     AGENT_TEMPLATE_DIR: str = "/app/agent_template"
 
     # Docker (for Agent containers)


### PR DESCRIPTION
## Summary
- Make `AGENT_DATA_DIR` default environment-aware:
  - local (non-container): `~/.clawith/data/agents`
  - container runtime: `/data/agents` (unchanged)
- Update `.env.example` default behavior note
- Fixes #57

## Why
The previous hardcoded default (`/data/agents`) is container-oriented and can fail in local host environments (especially macOS), where `/data` may be unavailable or read-only. This led to runtime failures when endpoints attempted to create directories under `AGENT_DATA_DIR`.

This change keeps Docker behavior intact while making local defaults writable and cross-platform safe.

## Changes
- `backend/app/config.py`
  - Added `_running_in_container()` for best-effort container detection
  - Added `_default_agent_data_dir()`
  - Changed `AGENT_DATA_DIR` default from hardcoded `/data/agents` to `_default_agent_data_dir()`
- `.env.example`
  - Clarified default data directory behavior for local vs container runs

## Validation
- Ran `python -m compileall backend/app/config.py`
- Verified local default resolves to `~/.clawith/data/agents` when `AGENT_DATA_DIR` is unset
- Verified explicit override still works (`AGENT_DATA_DIR=/tmp/clawith-agents`)
- Confirmed Docker-target default path remains `/data/agents` under container detection