### PR TITLE
refactor(llm): converge service-level LLM calls to unified client

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -2416,7 +2416,6 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
             # Prepare target LLM
             from app.services.agent_context import build_agent_context
             from app.models.llm import LLMModel
-            import httpx
 
             if not target.primary_model_id:
                 return f"⚠️ {target.name} has no LLM model configured"
@@ -2469,11 +2468,19 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
             await db.commit()
 
             # Call target LLM with tool support (multi-round)
-            from app.services.llm_utils import get_provider_base_url
+            from app.services.llm_utils import (
+                get_provider_base_url,
+                create_llm_client,
+                LLMMessage,
+            )
             from app.services.agent_tools import get_agent_tools_for_llm, execute_tool
             base_url = get_provider_base_url(target_model.provider, target_model.base_url)
-            url = f"{base_url.rstrip('/')}/chat/completions"
-            full_msgs = [{"role": "system", "content": target_system}] + conversation_messages
+            if not base_url:
+                return f"⚠️ {target.name}'s model has no API base URL configured"
+
+            full_msgs: list[LLMMessage] = [LLMMessage(role="system", content=target_system)] + [
+                LLMMessage(role=m["role"], content=m["content"]) for m in conversation_messages
+            ]
 
             # Load tools for target agent
             tools_for_llm = await get_agent_tools_for_llm(target.id)
@@ -2484,67 +2491,72 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
 
             from app.services.token_tracker import record_token_usage, extract_usage_tokens, estimate_tokens_from_chars
 
-            async with httpx.AsyncClient(timeout=120) as client:
+            llm_client = create_llm_client(
+                provider=target_model.provider,
+                api_key=target_model.api_key_encrypted,
+                model=target_model.model,
+                base_url=base_url,
+                timeout=120.0,
+            )
+            try:
                 for _round in range(max_tool_rounds):
-                    req_body: dict = {
-                        "model": target_model.model,
-                        "messages": full_msgs,
-                        "temperature": 0.7,
-                        "max_tokens": 4096,
-                    }
-                    if tools_for_llm:
-                        req_body["tools"] = tools_for_llm
-                        req_body["tool_choice"] = "auto"
-
-                    resp = await client.post(
-                        url,
-                        json=req_body,
-                        headers={"Authorization": f"Bearer {target_model.api_key_encrypted}"},
+                    response = await llm_client.complete(
+                        messages=full_msgs,
+                        tools=tools_for_llm if tools_for_llm else None,
+                        temperature=0.7,
+                        max_tokens=4096,
                     )
-                    data = resp.json()
 
                     # Track tokens from API response
-                    real_tokens = extract_usage_tokens(data.get("usage"))
+                    real_tokens = extract_usage_tokens(response.usage)
                     if real_tokens:
                         _a2a_accumulated_tokens += real_tokens
                     else:
-                        round_chars = sum(len(m.get("content") or '') for m in full_msgs if isinstance(m.get("content"), str))
+                        round_chars = sum(len(m.content or '') for m in full_msgs if isinstance(m.content, str))
                         _a2a_accumulated_tokens += estimate_tokens_from_chars(round_chars)
 
-                    if "choices" not in data or not data["choices"]:
-                        break
-
-                    choice = data["choices"][0]
-                    msg = choice.get("message", {})
-
                     # Check for tool calls
-                    tool_calls = msg.get("tool_calls")
-                    if tool_calls:
+                    if response.tool_calls:
                         # Add assistant message with tool calls to conversation
-                        full_msgs.append(msg)
+                        full_msgs.append(LLMMessage(
+                            role="assistant",
+                            content=response.content or None,
+                            tool_calls=[{
+                                "id": tc.get("id", ""),
+                                "type": "function",
+                                "function": tc.get("function", {}),
+                            } for tc in response.tool_calls],
+                            reasoning_content=response.reasoning_content,
+                        ))
 
                         # Execute each tool call
-                        for tc in tool_calls:
+                        for tc in response.tool_calls:
                             fn = tc.get("function", {})
                             tool_name = fn.get("name", "")
-                            try:
-                                tool_args = json.loads(fn.get("arguments", "{}"))
-                            except Exception:
-                                tool_args = {}
+                            raw_args = fn.get("arguments", "{}")
+                            if isinstance(raw_args, dict):
+                                tool_args = raw_args
+                            else:
+                                try:
+                                    tool_args = json.loads(raw_args) if raw_args else {}
+                                except Exception:
+                                    tool_args = {}
 
                             tool_result = await execute_tool(tool_name, tool_args, target.id, owner_id)
 
                             # Add tool result to conversation
-                            full_msgs.append({
-                                "role": "tool",
-                                "tool_call_id": tc.get("id", ""),
-                                "content": tool_result[:4000],
-                            })
+                            full_msgs.append(LLMMessage(
+                                role="tool",
+                                tool_call_id=tc.get("id", ""),
+                                content=str(tool_result)[:4000],
+                            ))
                         continue  # Next LLM round
 
                     # No tool calls — this is the final text response
-                    target_reply = msg.get("content", "")
+                    target_reply = response.content or ""
                     break
+            finally:
+                await llm_client.close()
 
             # Record accumulated A2A tokens for the target agent
             if _a2a_accumulated_tokens > 0:
@@ -4506,4 +4518,3 @@ async def _handle_email_tool(tool_name: str, agent_id: uuid.UUID, ws: Path, argu
             return f"❌ Unknown email tool: {tool_name}"
     except Exception as e:
         return f"❌ Email tool error: {str(e)[:200]}"
-

--- a/backend/app/services/supervision_reminder.py
+++ b/backend/app/services/supervision_reminder.py
@@ -105,11 +105,14 @@ async def _get_agent_reply(target_agent, message: str, db) -> str | None:
 
     Returns the reply text, or None if the agent can't respond.
     """
-    import json as _json
-    import httpx
     from app.models.llm import LLMModel
     from app.services.agent_context import build_agent_context
-    from app.services.llm_utils import get_provider_base_url
+    from app.services.llm_utils import (
+        get_provider_base_url,
+        create_llm_client,
+        LLMMessage,
+        LLMError,
+    )
 
     model_id = target_agent.primary_model_id or target_agent.fallback_model_id
     if not model_id:
@@ -125,35 +128,36 @@ async def _get_agent_reply(target_agent, message: str, db) -> str | None:
     if not base_url:
         return None
 
-    url = f"{base_url.rstrip('/')}/chat/completions"
     system_prompt = await build_agent_context(
         target_agent.id, target_agent.name, target_agent.role_description or ""
     )
 
     messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": message},
+        LLMMessage(role="system", content=system_prompt),
+        LLMMessage(role="user", content=message),
     ]
 
+    client = create_llm_client(
+        provider=model.provider,
+        api_key=model.api_key_encrypted,
+        model=model.model,
+        base_url=base_url,
+        timeout=60.0,
+    )
     try:
-        async with httpx.AsyncClient(timeout=60) as client:
-            resp = await client.post(
-                url,
-                json={
-                    "model": model.model,
-                    "messages": messages,
-                    "temperature": 0.7,
-                    "max_tokens": 512,
-                },
-                headers={"Authorization": f"Bearer {model.api_key_encrypted}"},
-            )
-            data = resp.json()
-
-        if "choices" in data and data["choices"]:
-            content = data["choices"][0].get("message", {}).get("content", "")
-            return content.strip() if content else None
+        response = await client.complete(
+            messages=messages,
+            temperature=0.7,
+            max_tokens=512,
+        )
+        content = (response.content or "").strip()
+        return content if content else None
+    except LLMError as e:
+        logger.error(f"_get_agent_reply LLM error: {e}")
     except Exception as e:
         logger.error(f"_get_agent_reply LLM call failed: {e}")
+    finally:
+        await client.close()
     return None
 
 


### PR DESCRIPTION
## Summary
This PR converges remaining service-level direct LLM HTTP calls into the unified LLM client abstraction.

It is a preparatory refactor to reduce protocol drift and make future provider expansion (e.g., OpenAI Responses API, Gemini) safer and more localized.

Closes #60

## What Changed
- Replaced direct `/chat/completions` HTTP call path in agent-to-agent messaging with `create_llm_client()` + unified `LLMMessage`/`LLMResponse` flow.
- Replaced direct `/chat/completions` HTTP call path in supervision reminder reply generation with `create_llm_client()` + unified flow.
- Kept existing behavior intent (tool loop, token accounting, message flow, limits) as close as possible.
- Ensured client lifecycle is explicitly closed in refactored paths.

## Why
Previously, these service paths bypassed the unified client and hardcoded request/response assumptions. That made future provider support harder and increased inconsistency risk across runtime flows.

After this change, protocol-specific handling is more centralized in the LLM client layer, which lowers the cost of adding provider types like OpenAI Responses and Gemini.

## Scope Notes
- This PR does **not** introduce new providers.
- This PR does **not** perform a model schema redesign (`provider + protocol`).
- This PR focuses on convergence with minimal behavior disruption.

## Impact
- Feature-level behavior should remain consistent for current providers.
- Future provider onboarding should require fewer service-level edits.

## Validation
- Verified modified Python modules compile successfully.
- Confirmed service-level hardcoded `/chat/completions` usage was removed from the affected paths.