### PR TITLE
feat: add session delete functionality

### DIFF
--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -241,6 +241,38 @@ async def rename_session(
     return {"id": str(session.id), "title": session.title}
 
 
+@router.delete("/{agent_id}/sessions/{session_id}", status_code=204)
+async def delete_session(
+    agent_id: uuid.UUID,
+    session_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Delete a chat session. Only owner, admin, or creator can delete."""
+    result = await db.execute(
+        select(ChatSession).where(ChatSession.id == session_id, ChatSession.agent_id == agent_id)
+    )
+    session = result.scalar_one_or_none()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
+    agent = agent_result.scalar_one_or_none()
+
+    # Permission check: owner, admin, or creator can delete
+    if str(session.user_id) != str(current_user.id) and not _is_admin_or_creator(current_user, agent):
+        raise HTTPException(status_code=403, detail="Not authorized")
+
+    # Delete associated messages first (cascade not configured in model)
+    from sqlalchemy import delete as sql_delete
+    await db.execute(sql_delete(ChatMessage).where(ChatMessage.conversation_id == str(session_id)))
+
+    # Delete the session
+    await db.delete(session)
+    await db.commit()
+    return None
+
+
 @router.get("/{agent_id}/sessions/{session_id}/messages")
 async def get_session_messages(
     agent_id: uuid.UUID,

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -438,7 +438,10 @@
   },
   "chat": {
     "placeholder": "Type a message...",
-    "send": "Send"
+    "send": "Send",
+    "deleteSession": "Delete session",
+    "deleteSessionConfirm": "Delete Session",
+    "deleteSessionMessage": "Are you sure you want to delete this session? This action cannot be undone."
   },
   "messages": {
     "title": "Messages",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -440,7 +440,10 @@
   },
   "chat": {
     "placeholder": "输入消息...",
-    "send": "发送"
+    "send": "发送",
+    "deleteSession": "删除会话",
+    "deleteSessionConfirm": "删除会话",
+    "deleteSessionMessage": "确定要删除这个会话吗？此操作无法撤销。"
   },
   "messages": {
     "title": "消息中心",

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -786,6 +786,7 @@ function AgentDetailInner() {
     const [historyMsgs, setHistoryMsgs] = useState<any[]>([]);
     const [sessionsLoading, setSessionsLoading] = useState(false);
     const [agentExpired, setAgentExpired] = useState(false);
+    const [deleteSessionId, setDeleteSessionId] = useState<string | null>(null);  // For delete confirmation modal
 
     const fetchMySessions = async (silent = false) => {
         if (!id) return;
@@ -829,6 +830,27 @@ function AgentDetailInner() {
         } catch (err: any) {
             console.error('Failed to create session:', err);
             alert(`Failed to create session: ${err.message || err}`);
+        }
+    };
+
+    const handleDeleteSession = async () => {
+        if (!deleteSessionId || !id) return;
+        try {
+            await agentApi.deleteSession(id, deleteSessionId);
+            // Remove from local state
+            setSessions(prev => prev.filter(s => s.id !== deleteSessionId));
+            setAllSessions(prev => prev.filter(s => s.id !== deleteSessionId));
+            // If deleted session was active, clear it
+            if (activeSession?.id === deleteSessionId) {
+                setActiveSession(null);
+                setChatMessages([]);
+                setHistoryMsgs([]);
+            }
+            setDeleteSessionId(null);
+        } catch (err: any) {
+            console.error('Failed to delete session:', err);
+            alert(`Failed to delete session: ${err.message || err}`);
+            setDeleteSessionId(null);
         }
     };
 
@@ -2839,21 +2861,38 @@ function AgentDetailInner() {
                                             };
                                             const chLabel = channelLabel[s.source_channel];
                                             return (
-                                                <div key={s.id} onClick={() => selectSession(s)}
-                                                    style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px' }}
+                                                <div key={s.id}
+                                                    style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px', position: 'relative' }}
                                                     onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; }}
                                                     onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}>
-                                                    <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
-                                                        <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.title}</div>
-                                                        {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
+                                                    <div onClick={() => selectSession(s)}>
+                                                        <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
+                                                            <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.title}</div>
+                                                            {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
+                                                        </div>
+                                                        <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                                            {isOwn && isActive && wsConnected && <span className="status-dot running" style={{ width: '5px', height: '5px', flexShrink: 0 }} />}
+                                                            {s.last_message_at
+                                                                ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+                                                                : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
+                                                            {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
+                                                        </div>
                                                     </div>
-                                                    <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
-                                                        {isOwn && isActive && wsConnected && <span className="status-dot running" style={{ width: '5px', height: '5px', flexShrink: 0 }} />}
-                                                        {s.last_message_at
-                                                            ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-                                                            : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
-                                                        {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
-                                                    </div>
+                                                    {/* Delete button */}
+                                                    <button
+                                                        onClick={(e) => { e.stopPropagation(); setDeleteSessionId(s.id); }}
+                                                        style={{ position: 'absolute', top: '8px', right: '8px', background: 'none', border: 'none', cursor: 'pointer', padding: '4px', opacity: 0.6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                                                        onMouseEnter={e => e.currentTarget.style.opacity = '1'}
+                                                        onMouseLeave={e => e.currentTarget.style.opacity = '0.6'}
+                                                        title={t('chat.deleteSession', 'Delete session')}
+                                                    >
+                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                                            <polyline points="3 6 5 6 21 6"></polyline>
+                                                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                                            <line x1="10" y1="11" x2="10" y2="17"></line>
+                                                            <line x1="14" y1="11" x2="14" y2="17"></line>
+                                                        </svg>
+                                                    </button>
                                                 </div>
                                             );
                                         })
@@ -2879,34 +2918,51 @@ function AgentDetailInner() {
                                                 .map((s: any) => {
                                                     const isActive = activeSession?.id === s.id;
                                                     return (
-                                                        <div key={s.id} onClick={() => selectSession(s)}
-                                                            style={{ padding: '6px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent' }}
+                                                        <div key={s.id}
+                                                            style={{ padding: '6px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', position: 'relative' }}
                                                             onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; }}
                                                             onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}>
-                                                            <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '1px' }}>
-                                                                <div style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-primary)', flex: 1 }}>{s.title}</div>
-                                                                {({
-                                                                    feishu: t('common.channels.feishu'),
-                                                                    discord: t('common.channels.discord'),
-                                                                    slack: t('common.channels.slack'),
-                                                                    dingtalk: t('common.channels.dingtalk'),
-                                                                    wecom: t('common.channels.wecom'),
-                                                                } as Record<string, string>)[s.source_channel] && (
-                                                                        <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>
-                                                                            {({
-                                                                                feishu: t('common.channels.feishu'),
-                                                                                discord: t('common.channels.discord'),
-                                                                                slack: t('common.channels.slack'),
-                                                                                dingtalk: t('common.channels.dingtalk'),
-                                                                                wecom: t('common.channels.wecom'),
-                                                                            } as Record<string, string>)[s.source_channel]}
-                                                                        </span>
-                                                                    )}
+                                                            <div onClick={() => selectSession(s)}>
+                                                                <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '1px' }}>
+                                                                    <div style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-primary)', flex: 1 }}>{s.title}</div>
+                                                                    {({
+                                                                        feishu: t('common.channels.feishu'),
+                                                                        discord: t('common.channels.discord'),
+                                                                        slack: t('common.channels.slack'),
+                                                                        dingtalk: t('common.channels.dingtalk'),
+                                                                        wecom: t('common.channels.wecom'),
+                                                                    } as Record<string, string>)[s.source_channel] && (
+                                                                            <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>
+                                                                                {({
+                                                                                    feishu: t('common.channels.feishu'),
+                                                                                    discord: t('common.channels.discord'),
+                                                                                    slack: t('common.channels.slack'),
+                                                                                    dingtalk: t('common.channels.dingtalk'),
+                                                                                    wecom: t('common.channels.wecom'),
+                                                                                } as Record<string, string>)[s.source_channel]}
+                                                                            </span>
+                                                                        )}
+                                                                </div>
+                                                                <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', gap: '4px' }}>
+                                                                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.username || ''}</span>
+                                                                    <span style={{ flexShrink: 0 }}>{s.last_message_at ? new Date(s.last_message_at).toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}{s.message_count > 0 ? ` · ${s.message_count}` : ''}</span>
+                                                                </div>
                                                             </div>
-                                                            <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', gap: '4px' }}>
-                                                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.username || ''}</span>
-                                                                <span style={{ flexShrink: 0 }}>{s.last_message_at ? new Date(s.last_message_at).toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}{s.message_count > 0 ? ` · ${s.message_count}` : ''}</span>
-                                                            </div>
+                                                            {/* Delete button */}
+                                                            <button
+                                                                onClick={(e) => { e.stopPropagation(); setDeleteSessionId(s.id); }}
+                                                                style={{ position: 'absolute', top: '6px', right: '8px', background: 'none', border: 'none', cursor: 'pointer', padding: '4px', opacity: 0.6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                                                                onMouseEnter={e => e.currentTarget.style.opacity = '1'}
+                                                                onMouseLeave={e => e.currentTarget.style.opacity = '0.6'}
+                                                                title={t('chat.deleteSession', 'Delete session')}
+                                                            >
+                                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                                                    <polyline points="3 6 5 6 21 6"></polyline>
+                                                                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                                                    <line x1="10" y1="11" x2="10" y2="17"></line>
+                                                                    <line x1="14" y1="11" x2="14" y2="17"></line>
+                                                                </svg>
+                                                            </button>
                                                         </div>
                                                     );
                                                 })}
@@ -5102,6 +5158,17 @@ function AgentDetailInner() {
                     </div>
                 )
             }
+
+            {/* Delete session confirmation modal */}
+            {deleteSessionId && (
+                <ConfirmModal
+                    open={!!deleteSessionId}
+                    title={t('chat.deleteSessionConfirm', 'Delete Session')}
+                    message={t('chat.deleteSessionMessage', 'Are you sure you want to delete this session? This action cannot be undone.')}
+                    onConfirm={handleDeleteSession}
+                    onCancel={() => setDeleteSessionId(null)}
+                />
+            )}
 
         </>
     );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -172,6 +172,22 @@ export const agentApi = {
 
     gatewayMessages: (id: string) =>
         request<any[]>(`/agents/${id}/gateway-messages`),
+
+    // Chat sessions
+    listSessions: (agentId: string, scope: 'mine' | 'all' = 'mine') =>
+        request<any[]>(`/agents/${agentId}/sessions?scope=${scope}`),
+
+    createSession: (agentId: string, title?: string) =>
+        request<any>(`/agents/${agentId}/sessions`, {
+            method: 'POST',
+            body: JSON.stringify({ title }),
+        }),
+
+    deleteSession: (agentId: string, sessionId: string) =>
+        request<void>(`/agents/${agentId}/sessions/${sessionId}`, { method: 'DELETE' }),
+
+    getSessionMessages: (agentId: string, sessionId: string) =>
+        request<any[]>(`/agents/${agentId}/sessions/${sessionId}/messages`),
 };
 
 // ─── Tasks ────────────────────────────────────────────


### PR DESCRIPTION
- Backend: add DELETE endpoint in chat_sessions.py to support session deletion
- Frontend: add deleteSession API method in api.ts
- Frontend: add delete button UI in AgentDetail.tsx for both My Sessions and All Users
- i18n: add Chinese and English translations for delete feature

Fixes #71: My Sessions missing delete functionality

## Summary

Add session delete functionality allowing users to delete their own chat sessions with confirmation dialog, fixes #71 .

## Checklist

- [x] Tested locally
- [x] No unrelated changes included
