### PR TITLE
fix(llm): lower default max_tokens to 8192 for unknown providers

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -838,7 +838,10 @@ PROVIDER_URLS: dict[str, str | None] = {
 # Providers that support tool_choice
 TOOL_CHOICE_PROVIDERS = {"openai", "qwen", "deepseek", "minimax", "openrouter", "custom"}
 
-# Max tokens by provider
+# Safe default for unknown providers (many APIs cap at 4096–8192; avoid 400)
+DEFAULT_MAX_TOKENS = 8192
+
+# Max tokens by provider (only list those that allow more than DEFAULT_MAX_TOKENS)
 MAX_TOKENS_BY_PROVIDER: dict[str, int] = {
     "qwen": 8192,
     "anthropic": 4096,
@@ -876,7 +879,7 @@ def get_max_tokens(provider: str, model: str | None = None) -> int:
         for prefix, limit in MAX_TOKENS_BY_MODEL.items():
             if model.lower().startswith(prefix):
                 return limit
-    return MAX_TOKENS_BY_PROVIDER.get(provider, 16384)
+    return MAX_TOKENS_BY_PROVIDER.get(provider, DEFAULT_MAX_TOKENS)
 
 
 def create_llm_client(


### PR DESCRIPTION
Fixes #89

## Summary

`get_max_tokens(provider, model)` used a fallback of **16384** for any provider/model not in the dicts. Many APIs (DeepSeek, Moonshot, Zhipu, etc.) cap output at 4096–8192, so unknown providers returned `400 Invalid max_tokens`.

## Change

- Introduced `DEFAULT_MAX_TOKENS = 8192` and use it as the fallback in `get_max_tokens()`.
- Unknown or new providers now get 8192 by default, reducing 400 errors without enumerating every model.
- `MAX_TOKENS_BY_PROVIDER` / `MAX_TOKENS_BY_MODEL` continue to override for providers that support more (e.g. minimax 16384, qwen-plus 16384).

## Behavior

| Provider/Model | Before | After |
|----------------|--------|-------|
| Not in dicts (e.g. DeepSeek, new provider) | 16384 → often 400 | 8192 |
| In dict (e.g. minimax, qwen-plus) | unchanged | unchanged |
| anthropic (4096) | unchanged | unchanged |
| qwen / qwen-turbo (8192) | unchanged | unchanged |
| openai (not in dict) | 16384 | 8192 (safe; can add to dict if needed) |

## Test

- Chat with a DeepSeek (or other previously-unknown) model: no more `Invalid max_tokens` 400.
- Chat with existing configured providers (qwen, anthropic, minimax): unchanged limits.