### PR TITLE
fix: handle SSE stream lines without space after "data:" prefix

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -279,10 +279,15 @@ class OpenAICompatibleClient(LLMClient):
         """
         chunk = LLMStreamChunk()
 
-        if not line.startswith("data: "):
+        # SSE spec: "data:" may or may not have a space after the colon
+        if line.startswith("data: "):
+            data_str = line[6:]
+        elif line.startswith("data:"):
+            data_str = line[5:]
+        else:
             return chunk, in_think, tag_buffer
 
-        data_str = line[6:].strip()
+        data_str = data_str.strip()
         if data_str == "[DONE]":
             chunk.is_finished = True
             return chunk, in_think, tag_buffer


### PR DESCRIPTION
Some OpenAI-compatible LLM proxies return SSE data lines as "data:{...}" (no space after colon) instead of "data: {...}". Both formats are valid per the SSE specification. The stream parser previously only accepted the space-delimited form, causing all streaming chunks to be silently skipped and returning empty content for custom provider models.

## Summary

<!-- What does this PR do? Link the related issue: Fixes #<issue_number> -->

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
