### PR TITLE
fix: reset streaming state on LLM error to re-enable chat input

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -166,6 +166,9 @@ export default function Chat() {
                 if (['thinking', 'chunk', 'tool_call', 'done', 'error', 'quota_exceeded'].includes(data.type)) {
                     setIsWaiting(false);
                 }
+                if (['error', 'quota_exceeded'].includes(data.type)) {
+                    setStreaming(false);
+                }
 
                 if (data.type === 'thinking') {
                     // Accumulate thinking content


### PR DESCRIPTION
Fixes #94

## Root Cause

When the backend returns an `error` or `quota_exceeded` message, only `isWaiting` was reset to `false`, but `streaming` remained `true`.

The chat input is disabled when `streaming || isWaiting` is true:

```tsx
disabled={!connected || isWaiting || streaming}
```

So after an error, the input stayed permanently disabled until the user refreshed the page.

## Fix

Reset `streaming` to `false` when `error` or `quota_exceeded` is received:

```ts
if (['error', 'quota_exceeded'].includes(data.type)) {
    setStreaming(false);
}
```

## Changes

- `frontend/src/pages/Chat.tsx`: 3 lines added, no existing logic changed