### PR TITLE
fix: prevent disabling the default company

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -167,6 +167,9 @@ async def toggle_company(
     if not tenant:
         raise HTTPException(status_code=404, detail="Company not found")
 
+    if tenant.slug == "default" and tenant.is_active:
+        raise HTTPException(status_code=400, detail="Cannot disable the default company")
+
     new_state = not tenant.is_active
     tenant.is_active = new_state
 

--- a/frontend/src/pages/AdminCompanies.tsx
+++ b/frontend/src/pages/AdminCompanies.tsx
@@ -320,6 +320,7 @@ export default function AdminCompanies() {
                             <span className={`badge ${c.is_active ? 'badge-success' : 'badge-error'}`} style={{ fontSize: '10px' }}>
                                 {c.is_active ? t('admin.active', 'Active') : t('admin.disabled', 'Disabled')}
                             </span>
+                            {c.slug !== 'default' && (
                             <button
                                 className="btn btn-ghost"
                                 style={{ padding: '2px 6px', fontSize: '10px', color: c.is_active ? 'var(--error)' : 'var(--success)' }}
@@ -327,6 +328,7 @@ export default function AdminCompanies() {
                             >
                                 {c.is_active ? t('admin.disable', 'Disable') : t('admin.enable', 'Enable')}
                             </button>
+                            )}
                         </div>
                     </div>
                 ))}


### PR DESCRIPTION
- Backend: reject toggle requests for the default (slug='default') company with HTTP 400
- Frontend: hide the disable/enable button for the default company

Prevents platform admins from accidentally locking out all users by disabling the default company.

## Checklist

- [x] Tested locally
- [x] No unrelated changes included
