### PR TITLE
fix(docker): simplify backend startup with inline alembic stamp command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         CLAWITH_PIP_INDEX_URL: ${CLAWITH_PIP_INDEX_URL:-}
         CLAWITH_PIP_TRUSTED_HOST: ${CLAWITH_PIP_TRUSTED_HOST:-}
     restart: unless-stopped
-    command: ["/bin/bash", "/app/entrypoint.sh"]
+    command: ["/bin/bash", "-c", "alembic stamp head 2>/dev/null || true; exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
     environment:
       DATABASE_URL: postgresql+asyncpg://clawith:clawith@postgres:5432/clawith
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
Problem:
The original entrypoint.sh script had potential issues:
- Additional file to maintain
- Possible permission or path issues in some environments
- Unclear error handling for alembic migrations

Solution:
Replace the entrypoint.sh reference with an inline command that:
- Runs alembic stamp head to mark migrations as applied (for existing DB)
- Silently ignores errors (e.g., if migrations already tracked)
- Directly starts uvicorn for the backend service

Files changed:
- docker-compose.yml

Impact:
Simplifies container startup and reduces potential points of failure. The entrypoint.sh file is still available for more complex scenarios.

## Summary

<!-- What does this PR do? Link the related issue: Fixes #<issue_number> -->

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
