### PR TITLE
fix(i18n): generate timestamp-based slug for non-Latin company names

### DIFF
--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -251,7 +251,11 @@ export default function Layout() {
     const createCompany = async () => {
         if (!newCompanyName.trim()) return;
         const token = localStorage.getItem('token');
-        const slug = newCompanyName.toLowerCase().replace(/[\s]+/g, '-').replace(/[^a-z0-9_-]/g, '').slice(0, 50);
+        let slug = newCompanyName.toLowerCase().replace(/[\s]+/g, '-').replace(/[^a-z0-9_-]/g, '').slice(0, 50);
+        // Fallback for non-Latin names (e.g., Chinese): use timestamp-based slug
+        if (slug.length < 2) {
+            slug = 'company-' + Date.now().toString(36);
+        }
         await fetch('/api/tenants/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },


### PR DESCRIPTION
Problem:
When creating a company with Chinese, Japanese, or other non-Latin characters, the slug generation logic would strip all non-ASCII characters, resulting in an empty or very short slug. This causes validation errors when creating companies with non-English names.

Example:
- Company name: 测试公司
- Generated slug: '' (empty string after regex)

Solution:
Add a fallback mechanism that generates a timestamp-based slug when the normal slug generation produces an insufficient result:

1. First try: lowercase, replace spaces with dashes, remove non-alphanumerics
2. Fallback: if slug length < 2, use 'company-' + Date.now().toString(36)

Example result:
- Company name: 测试公司
- Generated slug: 'company-m1k2j3n' (timestamp-based)

Files changed:
- frontend/src/pages/Layout.tsx

Impact:
Users can now create companies with Chinese or other non-Latin names without encountering validation errors.

## Summary

<!-- What does this PR do? Link the related issue: Fixes #<issue_number> -->

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
