### PR TITLE
fix(migration): use IF NOT EXISTS for thinking column in add_microsof…

### DIFF
--- a/backend/alembic/versions/add_microsoft_teams_support.py
+++ b/backend/alembic/versions/add_microsoft_teams_support.py
@@ -12,7 +12,8 @@ depends_on = None
 def upgrade() -> None:
     # Add 'microsoft_teams' to im_provider_enum
     op.execute("ALTER TYPE im_provider_enum ADD VALUE IF NOT EXISTS 'microsoft_teams'")
-    op.add_column('chat_messages', sa.Column('thinking', sa.Text(), nullable=True))
+    # Add thinking column if not exists (may already exist from create_all)
+    op.execute("ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS thinking TEXT")
     # Add 'microsoft_teams' to channel_type_enum
     op.execute("ALTER TYPE channel_type_enum ADD VALUE IF NOT EXISTS 'microsoft_teams'")
 


### PR DESCRIPTION
…t_teams_support

Problem:
The migration used op.add_column() to add the 'thinking' column to chat_messages table, which fails if the column already exists. In some environments, the column may have been created by SQLAlchemy's create_all() during initial setup, causing migration to fail.

Solution:
Replace op.add_column() with raw SQL:
  ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS thinking TEXT

This makes the migration idempotent - it can be safely run multiple times without causing errors.

Files changed:
- backend/alembic/versions/add_microsoft_teams_support.py

Impact:
Improves migration reliability for environments where the thinking column was pre-created by application startup.

## Summary

<!-- What does this PR do? Link the related issue: Fixes #<issue_number> -->

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
