### PR TITLE
fix(websocket): initialize thinking_content before conditional block

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -602,6 +602,9 @@ async def websocket_chat(
                 content, re.IGNORECASE
             )
 
+            # Track thinking content for storage (initialize before condition)
+            thinking_content = []
+
             # Call LLM with streaming
             if llm_model:
                 try:
@@ -636,10 +639,7 @@ async def websocket_chat(
                                     await _tc_db.commit()
                             except Exception as _tc_err:
                                 print(f"[WS] Failed to save tool_call: {_tc_err}")
-                    
-                    # Track thinking content for storage
-                    thinking_content = []
-                    
+
                     async def thinking_to_ws(text: str):
                         """Send thinking chunks to client for collapsible display."""
                         thinking_content.append(text)


### PR DESCRIPTION
Problem:
The thinking_content list variable was initialized inside the llm_model conditional block, but the thinking_to_ws callback function that uses it was defined outside. This could cause UnboundLocalError when the callback is invoked if llm_model was falsy.

Solution:
Move the thinking_content = [] initialization outside the conditional block, before the llm_model check. This ensures the variable is always available when the thinking_to_ws callback is defined and potentially called.

Files changed:
- backend/app/api/websocket.py

Impact:
Prevents potential runtime errors during WebSocket chat sessions, especially in edge cases where LLM model configuration is missing.

## Summary

<!-- What does this PR do? Link the related issue: Fixes #<issue_number> -->

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
