### PR TITLE
feat: add Novita AI as an LLM provider

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -1718,6 +1718,13 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
         default_base_url="http://localhost:30000/v1",
         default_max_tokens=4096,
     ),
+    "novita": ProviderSpec(
+        provider="novita",
+        display_name="Novita AI",
+        protocol="openai_compatible",
+        default_base_url="https://api.novita.ai/openai",
+        default_max_tokens=8192,
+    ),
     "custom": ProviderSpec(
         provider="custom",
         display_name="Custom",

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -52,6 +52,7 @@ const FALLBACK_LLM_PROVIDERS: LLMProviderSpec[] = [
     { provider: 'vllm', display_name: 'vLLM', protocol: 'openai_compatible', default_base_url: 'http://localhost:8000/v1', supports_tool_choice: true, default_max_tokens: 4096 },
     { provider: 'ollama', display_name: 'Ollama', protocol: 'openai_compatible', default_base_url: 'http://localhost:11434/v1', supports_tool_choice: true, default_max_tokens: 4096 },
     { provider: 'sglang', display_name: 'SGLang', protocol: 'openai_compatible', default_base_url: 'http://localhost:30000/v1', supports_tool_choice: true, default_max_tokens: 4096 },
+    { provider: 'novita', display_name: 'Novita AI', protocol: 'openai_compatible', default_base_url: 'https://api.novita.ai/openai', supports_tool_choice: true, default_max_tokens: 8192 },
     { provider: 'custom', display_name: 'Custom', protocol: 'openai_compatible', default_base_url: '', supports_tool_choice: true, default_max_tokens: 4096 },
 ];
 


### PR DESCRIPTION
## Summary

- Adds **Novita AI** to the backend `PROVIDER_REGISTRY` in `llm_client.py` as an OpenAI-compatible provider
- Endpoint: `https://api.novita.ai/openai`
- Default max tokens: 8192
- Adds corresponding entry to the frontend `FALLBACK_LLM_PROVIDERS` list in `EnterpriseSettings.tsx`

## Models

Suggested models to configure after adding the provider:
- `moonshotai/kimi-k2.5` (default)
- `deepseek/deepseek-v3.2`
- `zai-org/glm-5`

## Test plan

- [ ] Add a Novita AI entry in Enterprise Settings → LLM Pool with a valid `NOVITA_API_KEY`
- [ ] Verify the provider appears in the provider dropdown
- [ ] Test a chat completion request through an agent configured with the Novita provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)