### PR TITLE
Fix: ensure system message is always first for cross-model compatibility

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -233,7 +233,7 @@ async def call_llm(
         _warn_threshold_96 = _max_tool_rounds - 2
         if round_i == _warn_threshold_80:
             api_messages.append(LLMMessage(
-                role="system",
+                role="user",
                 content=(
                     f"⚠️ 你已使用 {round_i}/{_max_tool_rounds} 轮工具调用。"
                     "如果当前任务尚未完成，请尽快保存进度到 focus.md，"
@@ -242,7 +242,7 @@ async def call_llm(
             ))
         elif round_i == _warn_threshold_96:
             api_messages.append(LLMMessage(
-                role="system",
+                role="user",
                 content=f"🚨 仅剩 2 轮工具调用。请立即保存进度到 focus.md 并设置续接触发器。",
             ))
 


### PR DESCRIPTION
## Problem
Qwen models require system messages to appear at the beginning of the message list.
Currently, Clawith appends dynamic system messages in the middle of the conversation, causing HTTP 400 errors:

    [LLM Error] HTTP 400: {"error":{"message":"System message must be at the beginning."}}

## Solution
Convert the dynamic "system" prompts into "user" messages instead of appending them as system messages.  
This avoids the ordering restriction in Qwen.

Example change:

Before:
```python
api_messages.append(LLMMessage(
    role="system",
    content="🚨 仅剩 2 轮工具调用..."
))
```
After:

```python
api_messages.append(LLMMessage(
    role="user",
    content="🚨 仅剩 2 轮工具调用..."
))
```
## Why this matters
- Fixes Qwen HTTP 400 error due to system message position
- Keeps behavior consistent for other LLMs
- Minimal change, avoids modifying core system message handling

## Testing
- Tested with Qwen → no more 400 error
- No regression observed

AI-assisted: Yes
lobster-biscuit