### PR TITLE
fix: retry A2A LLM failures and surface timeout errors

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -2810,7 +2810,10 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
                 create_llm_client,
                 LLMMessage,
             )
+            from app.services.llm_client import LLMError
             from app.services.agent_tools import get_agent_tools_for_llm, execute_tool
+            import asyncio
+            import httpx
             base_url = get_provider_base_url(target_model.provider, target_model.base_url)
             if not base_url:
                 return f"⚠️ {target.name}'s model has no API base URL configured"
@@ -2836,11 +2839,10 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
                 timeout=120.0,
             )
             try:
-                import asyncio
-                import httpx
                 for _round in range(max_tool_rounds):
-                    # Retry up to 3 times on transient LLM timeouts before aborting
-                    for _attempt in range(3):
+                    max_round_retries = 3
+                    response = None
+                    for attempt in range(1, max_round_retries + 1):
                         try:
                             response = await llm_client.complete(
                                 messages=full_msgs,
@@ -2849,10 +2851,46 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
                                 max_tokens=4096,
                             )
                             break
-                        except httpx.ReadTimeout:
-                            if _attempt == 2:
+                        except Exception as llm_exc:
+                            err_text = str(llm_exc) or type(llm_exc).__name__
+                            is_retryable = isinstance(
+                                llm_exc,
+                                (
+                                    httpx.TimeoutException,
+                                    httpx.TransportError,
+                                ),
+                            )
+
+                            if isinstance(llm_exc, LLMError):
+                                lowered = err_text.lower()
+                                retryable_markers = (
+                                    "http 408",
+                                    "http 429",
+                                    "http 500",
+                                    "http 502",
+                                    "http 503",
+                                    "http 504",
+                                    "timeout",
+                                    "timed out",
+                                    "connection failed",
+                                    "temporarily unavailable",
+                                    "rate limit",
+                                )
+                                is_retryable = is_retryable or any(m in lowered for m in retryable_markers)
+
+                            if not is_retryable or attempt >= max_round_retries:
                                 raise
-                            await asyncio.sleep(2 ** _attempt)  # 1s, then 2s
+
+                            backoff_seconds = float(2 ** (attempt - 1))
+                            logger.warning(
+                                f"[A2A] LLM call failed for {target.name} (round={_round + 1}, "
+                                f"attempt={attempt}/{max_round_retries}): {err_text[:200]}. "
+                                f"Retrying in {backoff_seconds:.1f}s"
+                            )
+                            await asyncio.sleep(backoff_seconds)
+
+                    if response is None:
+                        raise RuntimeError("A2A LLM response is unexpectedly empty after retries")
 
                     # Track tokens from API response
                     real_tokens = extract_usage_tokens(response.usage)
@@ -2962,10 +3000,18 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
             return f"💬 {target.name} replied:\n{target_reply}"
 
     except Exception as e:
-        import traceback
-        traceback.print_exc()
-        err_detail = str(e) or type(e).__name__
-        return f"❌ Message send error: {err_detail[:200]}"
+        logger.exception(
+            f"[A2A] send_message_to_agent failed: from={from_agent_id}, to={args.get('agent_name', '')}"
+        )
+        error_type = type(e).__name__
+        error_detail = (str(e) or "").strip()
+        if not error_detail:
+            timeout_types = {"ReadTimeout", "ConnectTimeout", "TimeoutException"}
+            if error_type in timeout_types:
+                error_detail = "LLM request timed out while waiting for target agent response"
+            else:
+                error_detail = "No detailed error message returned from upstream"
+        return f"❌ Message send error ({error_type}): {error_detail[:200]}"
 
 
 


### PR DESCRIPTION
## Summary

Fixes #143

This PR improves `send_message_to_agent` error handling for long-running agent-to-agent tasks.

Changes included:
- Retry retryable LLM failures inside A2A message handling, including transient timeout/transport errors and upstream `408/429/5xx` responses.
- Apply bounded exponential backoff across retry attempts for each LLM round.
- Return explicit user-facing error messages with the exception type and a fallback detail when `str(e)` is empty.
- Replace `traceback.print_exc()` with structured exception logging for better backend diagnostics.

## Checklist

- [x] Tested locally
- [x] No unrelated changes included

## Validation

Verified locally with a long `send_message_to_agent` request from `Caption` to `Nova`.

Key backend logs:

- `2026-03-20 14:31:26` `Calling tool: send_message_to_agent(... agent_name='Nova' ...)`
- `2026-03-20 14:33:26` `[A2A] LLM call failed for Nova (round=1, attempt=1/3): ReadTimeout. Retrying in 1.0s`
- `2026-03-20 14:38:40` `[A2A] LLM call failed for Nova (round=6, attempt=1/3): ReadTimeout. Retrying in 1.0s`
- `2026-03-20 14:40:46` `[A2A] LLM call failed for Nova (round=7, attempt=1/3): ReadTimeout. Retrying in 1.0s`
- `2026-03-20 14:42:47` `[A2A] LLM call failed for Nova (round=7, attempt=2/3): ReadTimeout. Retrying in 2.0s`
- `2026-03-20 14:44:50` `[A2A] send_message_to_agent failed: from=..., to=Nova`

UI result:

- The frontend now shows an explicit error message instead of an empty `Message send error:`
- Example: `Message send error (ReadTimeout): LLM request timed out while waiting for target agent response`
<img width="1922" height="162" alt="image" src="https://github.com/user-attachments/assets/d84a560f-d80a-4f49-aac7-0c94d4902e3e" />
