### PR TITLE
feat: 添加服务自动重启配置 (restart: unless-stopped)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   postgres:
     image: postgres:15-alpine
+    restart: unless-stopped
     environment:
       POSTGRES_USER: clawith
       POSTGRES_PASSWORD: clawith
@@ -15,6 +16,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    restart: unless-stopped
     volumes:
       - redisdata:/data
     healthcheck:
@@ -60,6 +62,7 @@ services:
         max-file: "3"
   frontend:
     build: ./frontend
+    restart: unless-stopped
     ports:
       - "${FRONTEND_PORT:-3008}:3000"
     environment:


### PR DESCRIPTION
 为 docker-compose.yml 中的所有服务添加 restart: unless-stopped 配置，确保服务在停止后自动重启。
 
# 修改内容：
- postgres 服务添加 restart: unless-stopped
- redis 服务添加 restart: unless-stopped
- frontend 服务添加 restart: unless-stopped