### PR TITLE
fix: retry transient LLM timeouts in A2A and surface error type (fixes #143)

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -2802,13 +2802,23 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
                 timeout=120.0,
             )
             try:
+                import asyncio
+                import httpx
                 for _round in range(max_tool_rounds):
-                    response = await llm_client.complete(
-                        messages=full_msgs,
-                        tools=tools_for_llm if tools_for_llm else None,
-                        temperature=0.7,
-                        max_tokens=4096,
-                    )
+                    # Retry up to 3 times on transient LLM timeouts before aborting
+                    for _attempt in range(3):
+                        try:
+                            response = await llm_client.complete(
+                                messages=full_msgs,
+                                tools=tools_for_llm if tools_for_llm else None,
+                                temperature=0.7,
+                                max_tokens=4096,
+                            )
+                            break
+                        except httpx.ReadTimeout:
+                            if _attempt == 2:
+                                raise
+                            await asyncio.sleep(2 ** _attempt)  # 1s, then 2s
 
                     # Track tokens from API response
                     real_tokens = extract_usage_tokens(response.usage)
@@ -2920,7 +2930,8 @@ async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:
     except Exception as e:
         import traceback
         traceback.print_exc()
-        return f"❌ Message send error: {str(e)[:200]}"
+        err_detail = str(e) or type(e).__name__
+        return f"❌ Message send error: {err_detail[:200]}"
 
 
 


### PR DESCRIPTION
## Problem

`_send_message_to_agent` was fragile to transient LLM timeouts during long A2A tasks:

1. A single `httpx.ReadTimeout` anywhere in a multi-step flow (web search + tool calls) aborted the entire task immediately, discarding all progress.
2. `httpx.ReadTimeout.__str__()` returns `""`, so the UI displayed only `"❌ Message send error:"` — no cause, no actionable information.

Reported in #143 with full logs showing the exact failure path.

## Fixes

### 1. Retry on `ReadTimeout` (exponential back-off)

Wrap `llm_client.complete()` in a retry loop — up to **3 attempts** with **1 s → 2 s** back-off before giving up:

```python
for _attempt in range(3):
    try:
        response = await llm_client.complete(...)
        break
    except httpx.ReadTimeout:
        if _attempt == 2:
            raise
        await asyncio.sleep(2 ** _attempt)  # 1 s, then 2 s
```

A single transient timeout now retries silently. Only after all 3 attempts fail does the exception propagate to the outer handler.

### 2. Meaningful error message

```python
# Before
return f"❌ Message send error: {str(e)[:200]}"

# After
err_detail = str(e) or type(e).__name__
return f"❌ Message send error: {err_detail[:200]}"
```

`ReadTimeout` (and any other exception with an empty `str()`) now surfaces its type name instead of a blank string.

## Result

| Scenario | Before | After |
|---|---|---|
| Single transient timeout | Task aborted | Silent retry, task continues |
| 3 consecutive timeouts | `"Message send error:"` | `"Message send error: ReadTimeout"` |
| Other exceptions | May show blank cause | Always shows `type.__name__` as fallback |

## Files changed

- `backend/app/services/agent_tools.py` — `_send_message_to_agent` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)