### PR TITLE
Fix #138: correct shared-directory write routing, tighten recipient file-send behavior, and add `send_file_to_agent`

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -310,6 +310,31 @@ AGENT_TOOLS = [
     {
         "type": "function",
         "function": {
+            "name": "send_file_to_agent",
+            "description": "Send a workspace file to another digital employee. The file is copied into the target agent's workspace/inbox/files/ directory and a delivery note is created in their inbox.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Target digital employee's name",
+                    },
+                    "file_path": {
+                        "type": "string",
+                        "description": "Workspace-relative path of the source file, e.g. workspace/report.md",
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Optional delivery note for the target digital employee",
+                    },
+                },
+                "required": ["agent_name", "file_path"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "jina_search",
             "description": "Search the internet using Jina AI Search (s.jina.ai). Returns high-quality search results with full page content, not just snippets. Ideal for research, news, technical docs, and any real-time information lookup.",
             "parameters": {
@@ -860,6 +885,7 @@ AGENT_TOOLS = [
 # DB configuration.
 _ALWAYS_INCLUDE_CORE = {
     "send_channel_file",
+    "send_file_to_agent",
     "write_file",
 }
 # Feishu tools are ONLY included when the agent has a configured Feishu channel,
@@ -1053,6 +1079,7 @@ _TOOL_AUTONOMY_MAP = {
     "delete_file": "delete_files",
     "send_feishu_message": "send_feishu_message",
     "send_message_to_agent": "send_feishu_message",
+    "send_file_to_agent": "send_feishu_message",
     "web_search": "web_search",
     "execute_code": "execute_code",
 }
@@ -1103,6 +1130,8 @@ async def _execute_tool_direct(
             return await _send_feishu_message(agent_id, arguments)
         elif tool_name == "send_message_to_agent":
             return await _send_message_to_agent(agent_id, arguments)
+        elif tool_name == "send_file_to_agent":
+            return await _send_file_to_agent(agent_id, ws, arguments)
         else:
             return f"Tool {tool_name} does not support post-approval execution"
     except Exception as e:
@@ -1183,6 +1212,8 @@ async def execute_tool(
             result = await _send_web_message(agent_id, arguments)
         elif tool_name == "send_message_to_agent":
             result = await _send_message_to_agent(agent_id, arguments)
+        elif tool_name == "send_file_to_agent":
+            result = await _send_file_to_agent(agent_id, ws, arguments)
         elif tool_name == "send_channel_file":
             result = await _send_channel_file(agent_id, ws, arguments)
         elif tool_name == "web_search":
@@ -2675,6 +2706,141 @@ async def _send_web_message(agent_id: uuid.UUID, args: dict) -> str:
 
     except Exception as e:
         return f"❌ Web message send error: {str(e)[:200]}"
+
+
+async def _send_file_to_agent(from_agent_id: uuid.UUID, ws: Path, args: dict) -> str:
+    """Send a workspace file to another digital employee (agent)."""
+    agent_name = (args.get("agent_name") or "").strip()
+    rel_path = (args.get("file_path") or "").strip()
+    delivery_note = (args.get("message") or "").strip()
+
+    if not agent_name or not rel_path:
+        return "❌ Please provide both agent_name and file_path"
+
+    # Resolve source file path inside sender workspace
+    source_file_path = (ws / rel_path).resolve()
+    ws_resolved = ws.resolve()
+    sender_root = (WORKSPACE_ROOT / str(from_agent_id)).resolve()
+    if not str(source_file_path).startswith(str(ws_resolved)):
+        source_file_path = (sender_root / rel_path).resolve()
+    if not str(source_file_path).startswith(str(sender_root)):
+        return "❌ Access denied: source path is outside your workspace"
+
+    if not source_file_path.exists():
+        return f"❌ Source file not found: {rel_path}"
+    if not source_file_path.is_file():
+        return f"❌ Source path is not a file: {rel_path}"
+
+    try:
+        from app.models.agent import Agent
+        from app.services.activity_logger import log_activity
+        import shutil
+
+        async with async_session() as db:
+            src_result = await db.execute(select(Agent).where(Agent.id == from_agent_id))
+            source_agent = src_result.scalar_one_or_none()
+            source_name = source_agent.name if source_agent else "Unknown agent"
+
+            target_result = await db.execute(
+                select(Agent).where(Agent.name.ilike(f"%{agent_name}%"), Agent.id != from_agent_id)
+            )
+            target_agent = target_result.scalars().first()
+            if not target_agent:
+                all_r = await db.execute(select(Agent).where(Agent.id != from_agent_id))
+                names = [a.name for a in all_r.scalars().all()]
+                return f"❌ No agent found matching '{agent_name}'. Available: {', '.join(names) if names else 'none'}"
+
+            if target_agent.is_expired or (target_agent.expires_at and datetime.now(timezone.utc) >= target_agent.expires_at):
+                return f"⚠️ {target_agent.name} is currently unavailable — their service period has ended. Please contact the platform administrator."
+
+            target_tenant_id = str(target_agent.tenant_id) if target_agent.tenant_id else None
+            target_name = target_agent.name
+            target_id = target_agent.id
+
+        target_ws = await ensure_workspace(target_id, tenant_id=target_tenant_id)
+        inbox_dir = (target_ws / "workspace" / "inbox").resolve()
+        files_dir = (inbox_dir / "files").resolve()
+        target_ws_resolved = target_ws.resolve()
+        if not str(inbox_dir).startswith(str(target_ws_resolved)) or not str(files_dir).startswith(str(target_ws_resolved)):
+            return "❌ Access denied for target agent inbox path"
+
+        inbox_dir.mkdir(parents=True, exist_ok=True)
+        files_dir.mkdir(parents=True, exist_ok=True)
+
+        ts = datetime.now(timezone.utc)
+        stamp = ts.strftime("%Y%m%d_%H%M%S_%f")
+        delivered_name = source_file_path.name
+        delivered_path = files_dir / delivered_name
+        while delivered_path.exists():
+            delivered_name = f"{stamp}_{source_file_path.name}"
+            delivered_path = files_dir / delivered_name
+
+        shutil.copy2(source_file_path, delivered_path)
+
+        sender_short = str(from_agent_id)[:8]
+        note_path = inbox_dir / f"{stamp}_{sender_short}_file_delivery.md"
+        target_rel_path = f"workspace/inbox/files/{delivered_name}"
+        note_lines = [
+            f"# File delivery from {source_name}",
+            "",
+            f"- Time (UTC): {ts.isoformat()}",
+            f"- Sender: {source_name}",
+            f"- Source path: {rel_path}",
+            f"- Delivered file: {target_rel_path}",
+            "",
+        ]
+        if delivery_note:
+            note_lines.append("## Note")
+            note_lines.append(delivery_note)
+            note_lines.append("")
+        note_lines.append("## Action")
+        note_lines.append(f"- Read the file via `read_file(path=\"{target_rel_path}\")`")
+        note_path.write_text("\n".join(note_lines), encoding="utf-8")
+
+        from app.models.audit import AuditLog
+        async with async_session() as db:
+            db.add(AuditLog(
+                agent_id=from_agent_id,
+                action="collaboration:file_send",
+                details={
+                    "to_agent": str(target_id),
+                    "to_agent_name": target_name,
+                    "source_file": rel_path,
+                    "delivered_file": target_rel_path,
+                },
+            ))
+            db.add(AuditLog(
+                agent_id=target_id,
+                action="collaboration:file_receive",
+                details={
+                    "from_agent": str(from_agent_id),
+                    "from_agent_name": source_name,
+                    "source_file": rel_path,
+                    "delivered_file": target_rel_path,
+                },
+            ))
+            await db.commit()
+
+        await log_activity(
+            from_agent_id,
+            "agent_file_sent",
+            f"Sent file to {target_name}",
+            detail={"target_agent": target_name, "source_file": rel_path, "delivered_file": target_rel_path},
+        )
+        await log_activity(
+            target_id,
+            "agent_file_received",
+            f"Received file from {source_name}",
+            detail={"source_agent": source_name, "source_file": rel_path, "delivered_file": target_rel_path},
+        )
+
+        return (
+            f"✅ File sent to {target_name}.\n"
+            f"- Delivered to: {target_rel_path}\n"
+            f"- Inbox note: workspace/inbox/{note_path.name}"
+        )
+    except Exception as e:
+        return f"❌ Agent file send error: {str(e)[:200]}"
 
 
 async def _send_message_to_agent(from_agent_id: uuid.UUID, args: dict) -> str:

--- a/backend/app/services/tool_seeder.py
+++ b/backend/app/services/tool_seeder.py
@@ -243,6 +243,25 @@ BUILTIN_TOOLS = [
         "config_schema": {},
     },
     {
+        "name": "send_file_to_agent",
+        "display_name": "Agent File Transfer",
+        "description": "Send a workspace file to another digital employee. The file is copied to the target agent's workspace/inbox/files/ and an inbox note is created.",
+        "category": "communication",
+        "icon": "📤",
+        "is_default": True,
+        "parameters_schema": {
+            "type": "object",
+            "properties": {
+                "agent_name": {"type": "string", "description": "Target agent name"},
+                "file_path": {"type": "string", "description": "Workspace-relative source file path"},
+                "message": {"type": "string", "description": "Optional delivery note"},
+            },
+            "required": ["agent_name", "file_path"],
+        },
+        "config": {},
+        "config_schema": {},
+    },
+    {
         "name": "web_search",
         "display_name": "DuckDuckGo Search",
         "description": "Search the internet via DuckDuckGo. May be unavailable on some networks. Use Bing Search as an alternative.",
@@ -1049,4 +1068,3 @@ async def get_atlassian_api_key() -> str:
         if tool and tool.config:
             return tool.config.get("api_key", "")
     return ""
-


### PR DESCRIPTION
Closes #138

## Summary
This PR resolves the file-routing and delivery reliability gaps reported in #138 and introduces agent-to-agent file transfer.

- Fixed tenant-scoped shared directory writes so `write_file("enterprise_info/...")` persists to the actual shared company path.
- Changed `send_channel_file` behavior for explicit recipients: unresolved recipients now return a clear failure instead of silently falling back to a download link.
- Added new `send_file_to_agent` tool to transfer files directly between digital employees by copying to the target agent inbox (`workspace/inbox/files/`) and generating a delivery note.
- Unified execution behavior so both normal tool execution and post-approval direct execution follow the same tenant-aware path logic.

## Root Cause
- `write_file` did not apply the same tenant-aware `enterprise_info/` remapping used by `read_file`/`list_files`.
- `send_channel_file` could silently fall back to a web download-link response when recipient resolution failed, creating misleading outcomes.
- No dedicated tool existed for digital-employee-to-digital-employee file delivery.

## What Changed

### 1) Hotfix: shared directory write routing
- Added tenant-aware lookup helper for agent tenant ID.
- Updated write paths so `enterprise_info/...` writes to tenant-scoped shared storage (same model as read/list).
- Ensured both normal execution and post-approval direct execution use the same tenant-aware logic.

### 2) Hotfix: explicit recipient behavior in `send_channel_file`
- If `member_name` is provided, recipient resolution is now strict.
- If recipient cannot be resolved/reached, return explicit failure instead of silent fallback.
- Web-link fallback now applies only when no explicit recipient is requested.

Commit e52196c61507ddcd2f34cc5d2d9f34b585128156

### 3) Feature: new `send_file_to_agent` capability
- Added new tool `send_file_to_agent(agent_name, file_path, message?)`.
- Resolves target digital employee by name.
- Copies file into target agent workspace: `workspace/inbox/files/`.
- Creates a delivery note in target inbox: `workspace/inbox/<timestamp>_*_file_delivery.md`.
- Adds audit/activity records for send/receive events.
- Registered in tool seeder as a default communication tool.

Commit e20d520c5f58df84527ef7550ffc50730c06ffd9

## Validation Performed
  - Verified `enterprise_info/...` writes land in tenant-shared directory, not agent-private path.
  - Verified explicit `member_name` no longer silently falls back.
  - Verified `send_file_to_agent` path validation + inbox delivery flow.


## Checklist

- [x] Tested locally
- [x] No unrelated changes included
