### PR TITLE
fix: add UTF-8 encoding for file writes on Windows

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -274,7 +274,7 @@ async def create_agent(
             for sf in skill.files:
                 file_path = skill_folder / sf.path
                 file_path.parent.mkdir(parents=True, exist_ok=True)
-                file_path.write_text(sf.content)
+                file_path.write_text(sf.content, encoding="utf-8")
 
     # Start container
     await agent_manager.start_container(db, agent)

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -5,6 +5,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import select, func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import get_current_admin, get_current_user, require_role

--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -410,7 +410,7 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                                     _cache.write_text(_cj.dumps(
                                         {"ts": _ct.time(), "users": list(_users.values())},
                                         ensure_ascii=False,
-                                    ))
+                                    ), encoding="utf-8")
                                     import os as _os
                                     _os.chmod(str(_cache), 0o600)
                                 except Exception as _ce:

--- a/backend/app/services/agent_manager.py
+++ b/backend/app/services/agent_manager.py
@@ -107,7 +107,7 @@ class AgentManager:
             state = json.loads(state_path.read_text())
             state["agent_id"] = str(agent.id)
             state["name"] = agent.name
-            state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2))
+            state_path.write_text(json.dumps(state, ensure_ascii=False, indent=2), encoding="utf-8")
 
         logger.info(f"Initialized agent files at {agent_dir}")
 
@@ -154,7 +154,7 @@ class AgentManager:
         config = self._generate_openclaw_config(agent, model)
         config_dir = agent_dir / ".openclaw"
         config_dir.mkdir(parents=True, exist_ok=True)
-        (config_dir / "openclaw.json").write_text(json.dumps(config, indent=2))
+        (config_dir / "openclaw.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
 
         # Create workspace symlink
         workspace_dir = config_dir / "workspace"


### PR DESCRIPTION
- Fix UnicodeEncodeError when writing skill files with Unicode characters
- Add missing SQLAlchemyError import in enterprise.py
- Add encoding=utf-8 to all write_text() calls that may contain Unicode
