### PR TITLE
  fix(api): prevent 500 when deleting agents with task logs

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -1,20 +1,84 @@
 """Agent (Digital Employee) API routes."""
 
+import hashlib
+import json
+import secrets
 import uuid
+from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy import select, func
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.core.permissions import check_agent_access, is_agent_creator
-from app.core.security import get_current_user, require_role
+from app.core.security import get_current_user
 from app.database import get_db
 from app.models.agent import Agent, AgentPermission
 from app.models.user import User
 from app.schemas.schemas import AgentCreate, AgentOut, AgentUpdate
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+def _serialize_dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+async def _archive_agent_task_history(db: AsyncSession, agent_id: uuid.UUID, archive_dir: Path) -> Path | None:
+    """Persist task and task-log history into the agent archive directory before DB cleanup."""
+    from app.models.task import Task, TaskLog
+
+    task_result = await db.execute(select(Task).where(Task.agent_id == agent_id).order_by(Task.created_at.asc()))
+    tasks = task_result.scalars().all()
+    if not tasks:
+        return None
+
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "agent_id": str(agent_id),
+        "archived_at": datetime.now(timezone.utc).isoformat(),
+        "tasks": [],
+    }
+
+    for task in tasks:
+        log_result = await db.execute(select(TaskLog).where(TaskLog.task_id == task.id).order_by(TaskLog.created_at.asc()))
+        logs = log_result.scalars().all()
+        payload["tasks"].append(
+            {
+                "id": str(task.id),
+                "title": task.title,
+                "description": task.description,
+                "type": task.type,
+                "status": task.status,
+                "priority": task.priority,
+                "assignee": task.assignee,
+                "created_by": str(task.created_by),
+                "due_date": _serialize_dt(task.due_date),
+                "supervision_target_user_id": (
+                    str(task.supervision_target_user_id) if task.supervision_target_user_id else None
+                ),
+                "supervision_target_name": task.supervision_target_name,
+                "supervision_channel": task.supervision_channel,
+                "remind_schedule": task.remind_schedule,
+                "created_at": _serialize_dt(task.created_at),
+                "updated_at": _serialize_dt(task.updated_at),
+                "completed_at": _serialize_dt(task.completed_at),
+                "logs": [
+                    {
+                        "id": str(log.id),
+                        "content": log.content,
+                        "created_at": _serialize_dt(log.created_at),
+                    }
+                    for log in logs
+                ],
+            }
+        )
+
+    archive_path = archive_dir / "task_history.json"
+    archive_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return archive_path
 
 
 async def _lazy_reset_token_counters(agent: Agent, db: AsyncSession) -> bool:
@@ -224,7 +288,6 @@ async def create_agent(
 
     # For OpenClaw agents: skip file system and container setup, generate API key
     if agent.agent_type == "openclaw":
-        import secrets, hashlib
         raw_key = f"oc-{secrets.token_urlsafe(32)}"
         agent.api_key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
         agent.status = "idle"
@@ -242,13 +305,12 @@ async def create_agent(
     )
 
     # Copy selected skills + mandatory default skills into agent workspace
-    from app.models.skill import Skill, SkillFile
+    from app.models.skill import Skill
     from sqlalchemy.orm import selectinload
-    from pathlib import Path
 
     # Always include default skills
     default_result = await db.execute(
-        select(Skill).where(Skill.is_default == True)
+        select(Skill).where(Skill.is_default)
     )
     default_ids = {s.id for s in default_result.scalars().all()}
 
@@ -497,14 +559,20 @@ async def delete_agent(
 
     # Stop container and archive files (best effort)
     from app.services.agent_manager import agent_manager
+    archive_dir: Path | None = None
     try:
         await agent_manager.remove_container(agent)
     except Exception:
         pass
     try:
-        await agent_manager.archive_agent_files(agent.id)
+        archive_dir = await agent_manager.archive_agent_files(agent.id)
     except Exception:
         pass
+    if archive_dir is not None:
+        try:
+            await _archive_agent_task_history(db, agent.id, archive_dir)
+        except Exception:
+            pass
 
     # Delete related records that reference this agent
     # Use savepoints so a failure in one table doesn't poison the whole transaction
@@ -516,7 +584,6 @@ async def delete_agent(
         "approval_requests",
         "chat_messages",
         "chat_sessions",
-        "tasks",
         "agent_schedules",
         "agent_triggers",
         "channel_configs",
@@ -524,6 +591,8 @@ async def delete_agent(
         "agent_tools",
         "agent_relationships",
         "gateway_messages",
+        "published_pages",
+        "notifications",
     ]
 
     for table in cleanup_tables:
@@ -535,6 +604,8 @@ async def delete_agent(
 
     # Clean up secondary FK columns that also reference agents table
     secondary_fk_cleanups = [
+        "DELETE FROM task_logs WHERE task_id IN (SELECT id FROM tasks WHERE agent_id = :aid)",
+        "DELETE FROM tasks WHERE agent_id = :aid",
         "DELETE FROM chat_sessions WHERE peer_agent_id = :aid",
         "DELETE FROM gateway_messages WHERE sender_agent_id = :aid",
         "UPDATE chat_messages SET sender_agent_id = NULL WHERE sender_agent_id = :aid",
@@ -691,7 +762,6 @@ async def generate_or_reset_api_key(
     if getattr(agent, "agent_type", "native") != "openclaw":
         raise HTTPException(status_code=400, detail="API keys are only available for OpenClaw agents")
 
-    import secrets, hashlib
     raw_key = f"oc-{secrets.token_urlsafe(32)}"
     # Store in plaintext so frontend can retrieve it anytime to display and copy
     agent.api_key_hash = raw_key

--- a/backend/app/services/agent_manager.py
+++ b/backend/app/services/agent_manager.py
@@ -5,7 +5,6 @@ import shutil
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from string import Template
 
 import docker
 from docker.errors import DockerException, NotFound
@@ -237,16 +236,19 @@ class AgentManager:
             logger.error(f"Failed to remove container: {e}")
             return False
 
-    async def archive_agent_files(self, agent_id: uuid.UUID) -> None:
-        """Archive (move) agent files to a backup location."""
+    async def archive_agent_files(self, agent_id: uuid.UUID) -> Path:
+        """Archive agent files to a backup location and return the archive directory."""
         agent_dir = self._agent_dir(agent_id)
+        archive_dir = Path(settings.AGENT_DATA_DIR) / "_archived"
+        archive_dir.mkdir(parents=True, exist_ok=True)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        dest = archive_dir / f"{agent_id}_{timestamp}"
         if agent_dir.exists():
-            archive_dir = Path(settings.AGENT_DATA_DIR) / "_archived"
-            archive_dir.mkdir(parents=True, exist_ok=True)
-            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-            dest = archive_dir / f"{agent_id}_{timestamp}"
             shutil.move(str(agent_dir), str(dest))
             logger.info(f"Archived agent files to {dest}")
+        else:
+            dest.mkdir(parents=True, exist_ok=True)
+        return dest
 
     def get_container_status(self, agent: Agent) -> dict:
         """Get real-time container status."""

--- a/backend/tests/test_agent_delete_api.py
+++ b/backend/tests/test_agent_delete_api.py
@@ -1,0 +1,217 @@
+import json
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.api import agents as agents_api
+from app.models.agent import Agent
+from app.models.user import User
+
+
+class _NestedTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyResult:
+    def __init__(self, values=None):
+        self._values = list(values or [])
+
+    def scalar_one_or_none(self):
+        return self._values[0] if self._values else None
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._values)
+
+
+class RecordingDB:
+    def __init__(self, *, required_cleanup: list[str], responses=None):
+        self.required_cleanup = required_cleanup
+        self.responses = list(responses or [])
+        self.executed_sql: list[str] = []
+        self.deleted: list[object] = []
+        self.committed = False
+
+    def begin_nested(self):
+        return _NestedTransaction()
+
+    async def execute(self, statement, params=None):
+        sql = getattr(statement, "text", str(statement))
+        self.executed_sql.append(sql)
+        if self.responses:
+            return self.responses.pop(0)
+        return DummyResult()
+
+    async def delete(self, obj):
+        self.deleted.append(obj)
+        missing_cleanup = [sql for sql in self.required_cleanup if sql not in self.executed_sql]
+        if missing_cleanup:
+            raise IntegrityError(
+                statement="DELETE FROM agents WHERE id = :aid",
+                params={"aid": getattr(obj, "id", None)},
+                orig=Exception(f"missing cleanup: {missing_cleanup}"),
+            )
+
+    async def commit(self):
+        self.committed = True
+
+
+class TaskCleanupDB(RecordingDB):
+    def __init__(self):
+        super().__init__(
+            required_cleanup=[
+                "DELETE FROM task_logs WHERE task_id IN (SELECT id FROM tasks WHERE agent_id = :aid)",
+                "DELETE FROM tasks WHERE agent_id = :aid",
+                "DELETE FROM published_pages WHERE agent_id = :aid",
+                "DELETE FROM notifications WHERE agent_id = :aid",
+            ]
+        )
+        self.task_rows_remaining = 1
+        self.task_logs_remaining = 1
+
+    async def execute(self, statement, params=None):
+        sql = getattr(statement, "text", str(statement))
+        self.executed_sql.append(sql)
+
+        if sql == "DELETE FROM task_logs WHERE task_id IN (SELECT id FROM tasks WHERE agent_id = :aid)":
+            self.task_logs_remaining = 0
+        elif sql == "DELETE FROM tasks WHERE agent_id = :aid":
+            if self.task_logs_remaining:
+                raise IntegrityError(
+                    statement=sql,
+                    params=params,
+                    orig=Exception("task_logs.task_id foreign key still blocks task deletion"),
+                )
+            self.task_rows_remaining = 0
+
+        if self.responses:
+            return self.responses.pop(0)
+        return DummyResult()
+
+    async def delete(self, obj):
+        if self.task_rows_remaining:
+            raise IntegrityError(
+                statement="DELETE FROM agents WHERE id = :aid",
+                params={"aid": getattr(obj, "id", None)},
+                orig=Exception("tasks.agent_id foreign key still blocks agent deletion"),
+            )
+
+        await super().delete(obj)
+
+
+def make_user(**overrides):
+    values = {
+        "id": uuid.uuid4(),
+        "username": "alice",
+        "email": "alice@example.com",
+        "password_hash": "hashed",
+        "display_name": "Alice",
+        "role": "member",
+        "tenant_id": uuid.uuid4(),
+        "is_active": True,
+    }
+    values.update(overrides)
+    return User(**values)
+
+
+def make_agent(creator_id: uuid.UUID, **overrides):
+    values = {
+        "id": uuid.uuid4(),
+        "name": "Ops Bot",
+        "role_description": "assistant",
+        "creator_id": creator_id,
+        "status": "idle",
+        "agent_type": "native",
+    }
+    values.update(overrides)
+    return Agent(**values)
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_cleans_remaining_foreign_key_rows(monkeypatch):
+    creator = make_user()
+    agent = make_agent(creator.id)
+    db = TaskCleanupDB()
+
+    async def fake_check_agent_access(_db, _current_user, _agent_id):
+        return agent, "manage"
+
+    class FakeAgentManager:
+        async def remove_container(self, _agent):
+            return None
+
+        async def archive_agent_files(self, _agent_id):
+            return None
+
+    monkeypatch.setattr(agents_api, "check_agent_access", fake_check_agent_access)
+    monkeypatch.setattr(agents_api, "is_agent_creator", lambda _user, _agent: True)
+    monkeypatch.setattr("app.services.agent_manager.agent_manager", FakeAgentManager())
+
+    await agents_api.delete_agent(
+        agent_id=agent.id,
+        current_user=creator,
+        db=db,
+    )
+
+    assert db.deleted == [agent]
+    assert db.committed is True
+    assert db.executed_sql.index("DELETE FROM task_logs WHERE task_id IN (SELECT id FROM tasks WHERE agent_id = :aid)") < (
+        db.executed_sql.index("DELETE FROM tasks WHERE agent_id = :aid")
+    )
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_task_history_writes_json_snapshot(tmp_path):
+    agent_id = uuid.uuid4()
+    task_id = uuid.uuid4()
+    created_at = datetime.now(UTC)
+
+    task = SimpleNamespace(
+        id=task_id,
+        title="Review PR",
+        description="Check lore trailers",
+        type="todo",
+        status="done",
+        priority="high",
+        assignee="self",
+        created_by=uuid.uuid4(),
+        due_date=None,
+        supervision_target_user_id=None,
+        supervision_target_name=None,
+        supervision_channel=None,
+        remind_schedule=None,
+        created_at=created_at,
+        updated_at=created_at,
+        completed_at=created_at,
+    )
+    log = SimpleNamespace(
+        id=uuid.uuid4(),
+        content="Completed review and left comments",
+        created_at=created_at,
+    )
+
+    db = RecordingDB(
+        required_cleanup=[],
+        responses=[
+            DummyResult([task]),
+            DummyResult([log]),
+        ],
+    )
+
+    archive_dir = tmp_path / "_archived" / f"{agent_id}_20260325_120000"
+    archive_path = await agents_api._archive_agent_task_history(db, agent_id, archive_dir)
+
+    assert archive_path == archive_dir / "task_history.json"
+    payload = json.loads(archive_path.read_text(encoding="utf-8"))
+    assert payload["agent_id"] == str(agent_id)
+    assert payload["tasks"][0]["id"] == str(task_id)
+    assert payload["tasks"][0]["logs"][0]["content"] == "Completed review and left comments"


### PR DESCRIPTION
  ## Summary
  - delete `task_logs` before `tasks` so agent deletion no longer fails on task-related foreign keys
  - include `published_pages` and `notifications` in the explicit cleanup path
  - archive task history into `task_history.json` alongside archived agent files before DB cleanup
  - add regression coverage for ordered task/task_log cleanup and task history archiving

  Fixes #186

  ## Changed Files
  - `backend/app/api/agents.py`
  - `backend/app/services/agent_manager.py`
  - `backend/tests/test_agent_delete_api.py`

  ## Simplifications
  - reused the existing archive directory flow instead of adding a new storage mechanism
  - kept the fix scoped to ordered cleanup SQL, without introducing schema migrations or new abstractions

  ## Verification
  - `backend/.venv/bin/python -m pytest backend/tests`
  - `backend/.venv/bin/python -m ruff check backend/app/api/agents.py backend/app/services/agent_manager.py backend/tests/test_agent_delete_api.py`
  - local API smoke test: create agent + insert task/task_log + `DELETE /api/agents/{id}` => `204`, zero residual rows
  - manual local UI delete test completed successfully

  ## Remaining Risks
  - delete flow still depends on an explicit cleanup list; future tables referencing `agents.id` or `tasks.id` must be added manually
  - `task_history.json` is only written when the deleted agent actually has DB task records