### PR TITLE
chore: update agentbay dependency to wuying-agentbay-sdk 0.18.0

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pycryptodome>=3.20.0",
     "loguru>=0.7.0",
     "discord.py>=2.3.0",
-    "agentbay>=0.1.0",
+    "wuying-agentbay-sdk>=0.18.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR updates the `agentbay` dependency to the new `wuying-agentbay-sdk` version `0.18.0`.
The import name in the code remains `agentbay`, so no code changes were required.