### PR TITLE
fix(ui): improve sidebar icons, pin behavior, and settings layout consistency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "clawith-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@tabler/icons-react": "^3.40.0",
         "@tanstack/react-query": "^5.0.0",
         "i18next": "^24.0.0",
         "i18next-browser-languagedetector": "^8.2.1",
@@ -1164,6 +1165,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.40.0.tgz",
+      "integrity": "sha512-V/Q4VgNPKubRTiLdmWjV/zscYcj5IIk+euicUtaVVqF6luSC9rDngYWgST5/yh3Mrg/mYUwRv1YVTk71Jp0twQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.40.0.tgz",
+      "integrity": "sha512-oO5+6QCnna4a//mYubx4euZfECtzQZFDGsDMIdzZUhbdyBCT+3bRVFBPueGIcemWld4Vb/0UQ39C/cmGfGylAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": "3.40.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tabler/icons-react": "^3.40.0",
     "@tanstack/react-query": "^5.0.0",
     "i18next": "^24.0.0",
     "i18next-browser-languagedetector": "^8.2.1",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -362,6 +362,13 @@ select:focus {
   margin-bottom: var(--space-2);
 }
 
+.sidebar-divider {
+  height: 1px;
+  background: var(--border-subtle);
+  margin: var(--space-2) var(--space-4);
+  opacity: 0.6;
+}
+
 .sidebar-section-title {
   font-size: var(--text-xs);
   font-weight: 600;
@@ -380,7 +387,7 @@ select:focus {
   border-radius: var(--radius-md);
   font-size: var(--text-sm);
   color: var(--text-secondary);
-  transition: all var(--transition-fast);
+  transition: all 0.35s ease-in-out;
   cursor: pointer;
   text-decoration: none;
   white-space: nowrap;
@@ -413,6 +420,14 @@ select:focus {
 /* Sidebar agent item with pin button */
 .sidebar-agent-item {
   position: relative;
+  /* Margin matches sidebar-item horizontal layout to allow absolute pin to stay within 215px */
+  margin: 0 var(--space-3);
+  margin-bottom: 2px;
+}
+
+.sidebar-agent-item .sidebar-item {
+  margin: 0;
+  padding-right: 28px; /* Leave space for pin icon so text doesn't overlap long names */
 }
 
 .sidebar-agent-item.owned .agent-avatar::after {
@@ -438,7 +453,7 @@ select:focus {
   padding: 3px;
   color: var(--text-tertiary);
   opacity: 0;
-  transition: opacity 120ms, color 120ms;
+  transition: opacity 0.35s ease-in-out, color 0.35s ease-in-out, background 0.35s ease-in-out;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -457,6 +472,25 @@ select:focus {
 
 .sidebar-agent-item:hover .sidebar-pin-btn {
   opacity: 1;
+}
+
+/* Pinned icon swap: show pin by default, unpin on hover */
+.sidebar-pin-btn.pinned .pin-hover {
+  display: none;
+}
+
+.sidebar-agent-item:hover .sidebar-pin-btn.pinned .pin-default {
+  display: none;
+}
+
+.sidebar-agent-item:hover .sidebar-pin-btn.pinned .pin-hover {
+  display: inline;
+}
+
+/* When pinned and hovered, turn red to indicate unpin */
+.sidebar-agent-item:hover .sidebar-pin-btn.pinned {
+  color: var(--error);
+  background: var(--error-subtle);
 }
 
 .sidebar-footer {
@@ -1539,7 +1573,8 @@ select:focus {
 }
 
 .wizard-step.completed {
-  color: var(--success);
+  color: var(--accent-text);
+  opacity: 0.8;
 }
 
 .wizard-step-number {
@@ -1562,9 +1597,9 @@ select:focus {
 }
 
 .wizard-step.completed .wizard-step-number {
-  background: var(--accent-primary);
-  border-color: var(--accent-primary);
-  color: var(--text-inverse);
+  background: var(--accent-subtle);
+  border-color: var(--accent-subtle);
+  color: var(--accent-text);
 }
 
 .wizard-connector {

--- a/frontend/src/pages/AdminCompanies.tsx
+++ b/frontend/src/pages/AdminCompanies.tsx
@@ -60,36 +60,25 @@ export default function AdminCompanies() {
     ];
 
     return (
-        <div style={{ maxWidth: '1040px', margin: '0 auto', padding: '32px 24px' }}>
-            {/* Header */}
-            <div style={{ marginBottom: '24px' }}>
-                <h1 style={{ fontSize: '20px', fontWeight: 600, marginBottom: '4px' }}>
-                    {t('admin.platformSettings', 'Platform Settings')}
-                </h1>
-                <p style={{ fontSize: '13px', color: 'var(--text-tertiary)' }}>
-                    {t('admin.platformSettingsDesc', 'Manage platform-wide settings and company tenants.')}
-                </p>
+        <div>
+            <div className="page-header">
+                <div>
+                    <h1 className="page-title">{t('admin.platformSettings', 'Platform Settings')}</h1>
+                    <p className="page-subtitle">
+                        {t('admin.platformSettingsDesc', 'Manage platform-wide settings and company tenants.')}
+                    </p>
+                </div>
             </div>
 
-            {/* Tabs */}
-            <div style={{
-                display: 'flex', gap: '0', borderBottom: '1px solid var(--border-subtle)',
-                marginBottom: '24px',
-            }}>
+            <div className="tabs">
                 {tabs.map(tab => (
-                    <button
+                    <div
                         key={tab.key}
+                        className={`tab ${activeTab === tab.key ? 'active' : ''}`}
                         onClick={() => setActiveTab(tab.key)}
-                        style={{
-                            padding: '8px 16px', fontSize: '13px', fontWeight: 500,
-                            background: 'none', border: 'none', cursor: 'pointer',
-                            color: activeTab === tab.key ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                            borderBottom: activeTab === tab.key ? '2px solid var(--accent-primary)' : '2px solid transparent',
-                            marginBottom: '-1px', transition: 'all 0.15s',
-                        }}
                     >
                         {tab.label}
-                    </button>
+                    </div>
                 ))}
             </div>
 

--- a/frontend/src/pages/AgentCreate.tsx
+++ b/frontend/src/pages/AgentCreate.tsx
@@ -480,23 +480,7 @@ For humans, the message is delivered via their available channel (e.g. Feishu).`
                 ))}
             </div>
 
-            {/* Navigation — sticky between stepper and card */}
-            <div style={{ display: 'flex', justifyContent: 'space-between', maxWidth: '640px', marginBottom: '16px', position: 'sticky', top: 0, zIndex: 10, background: 'var(--bg-primary)', paddingTop: '4px', paddingBottom: '4px' }}>
-                <button className="btn btn-secondary" onClick={() => step > 0 ? setStep(step - 1) : navigate('/')}
-                    disabled={createMutation.isPending}>
-                    {step === 0 ? t('common.cancel') : t('wizard.prev')}
-                </button>
-                {step < STEPS.length - 1 ? (
-                    <button className="btn btn-primary" onClick={handleNext}>
-                        {t('wizard.next')} →
-                    </button>
-                ) : (
-                    <button className="btn btn-primary" onClick={handleFinish}
-                        disabled={createMutation.isPending}>
-                        {createMutation.isPending ? t('common.loading') : t('wizard.finish')}
-                    </button>
-                )}
-            </div>
+            {/* Removed top navigation, moved to bottom */}
 
             {error && (
                 <div style={{ background: 'var(--error-subtle)', color: 'var(--error)', padding: '8px 12px', borderRadius: '6px', fontSize: '13px', marginBottom: '16px' }}>
@@ -784,11 +768,38 @@ For humans, the message is delivered via their available channel (e.g. Feishu).`
 
             {/* Summary sidebar */}
             {selectedModel && (
-                <div style={{ marginTop: '16px', padding: '12px', background: 'var(--bg-elevated)', borderRadius: '8px', fontSize: '12px', color: 'var(--text-secondary)', maxWidth: '640px' }}>
+                <div style={{ marginTop: '16px', padding: '12px', background: 'var(--bg-elevated)', borderRadius: '8px', fontSize: '12px', color: 'var(--text-secondary)', maxWidth: '640px', marginBottom: '80px' }}>
                     <strong>{form.name || t('wizard.summary.unnamed')}</strong> · {t('wizard.summary.model')}: {selectedModel.label}
                     {form.max_tokens_per_day && ` · ${t('wizard.summary.dailyLimit')}: ${Number(form.max_tokens_per_day).toLocaleString()}`}
                 </div>
             )}
+            {!selectedModel && <div style={{ marginBottom: '80px' }}></div>}
+
+            {/* Navigation — sticky footer at the bottom */}
+            <div style={{
+                position: 'fixed', bottom: 0, left: 'var(--sidebar-width)', right: 0,
+                background: 'var(--bg-primary)', borderTop: '1px solid var(--border-subtle)',
+                padding: '16px 32px', zIndex: 100,
+                display: 'flex', justifyContent: 'flex-start',
+                transition: 'left var(--transition-default)'
+            }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', width: '100%', maxWidth: '640px' }}>
+                    <button className="btn btn-secondary" onClick={() => step > 0 ? setStep(step - 1) : navigate('/')}
+                        disabled={createMutation.isPending}>
+                        {step === 0 ? t('common.cancel') : t('wizard.prev')}
+                    </button>
+                    {step < STEPS.length - 1 ? (
+                        <button className="btn btn-primary" onClick={handleNext}>
+                            {t('wizard.next')} →
+                        </button>
+                    ) : (
+                        <button className="btn btn-primary" onClick={handleFinish}
+                            disabled={createMutation.isPending}>
+                            {createMutation.isPending ? t('common.loading') : t('wizard.finish')}
+                        </button>
+                    )}
+                </div>
+            </div>
         </div>
     );
 }

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -298,6 +298,16 @@ function ThemeColorPicker() {
 
 
 
+// Preset common models per provider
+const PRESET_MODELS: Record<string, string[]> = {
+    'openai': ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo', 'o1-preview', 'o1-mini'],
+    'anthropic': ['claude-3-5-sonnet-20241022', 'claude-3-5-sonnet-20240620', 'claude-3-5-haiku-20241022', 'claude-3-opus-20240229'],
+    'google': ['gemini-1.5-pro', 'gemini-1.5-flash', 'gemini-2.0-flash'],
+    'deepseek': ['deepseek-chat', 'deepseek-reasoner'],
+    'ollama': ['llama3.1', 'llama3.2', 'qwen2.5', 'mistral', 'gemma2'],
+    'azure': ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'],
+};
+
 // ─── Main Component ────────────────────────────────
 // ─── Enterprise KB Browser ─────────────────────────
 function EnterpriseKBBrowser({ onRefresh }: { onRefresh: () => void; refreshKey: number }) {
@@ -1292,7 +1302,35 @@ export default function EnterpriseSettings() {
                                     </div>
                                     <div className="form-group">
                                         <label className="form-label">{t('enterprise.llm.model')}</label>
-                                        <input className="form-input" placeholder={t('enterprise.llm.modelPlaceholder')} value={modelForm.model} onChange={e => setModelForm({ ...modelForm, model: e.target.value })} />
+                                        <div style={{ display: 'flex', gap: '8px' }}>
+                                            <select 
+                                                className="form-input" 
+                                                value={(!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') ? 'custom' : modelForm.model} 
+                                                onChange={e => {
+                                                    if (e.target.value === 'custom') {
+                                                        setModelForm({ ...modelForm, model: '' });
+                                                    } else {
+                                                        setModelForm({ ...modelForm, model: e.target.value });
+                                                    }
+                                                }}
+                                                style={{ flex: (!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') ? '1' : '100%' }}
+                                            >
+                                                <option value="" disabled>Select a model</option>
+                                                {(PRESET_MODELS[modelForm.provider] || []).map(m => (
+                                                    <option key={m} value={m}>{m}</option>
+                                                ))}
+                                                <option value="custom">Custom (Type manually)</option>
+                                            </select>
+                                            {(!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') && (
+                                                <input 
+                                                    className="form-input" 
+                                                    placeholder="Type model name" 
+                                                    value={modelForm.model} 
+                                                    onChange={e => setModelForm({ ...modelForm, model: e.target.value })} 
+                                                    style={{ flex: '2' }}
+                                                />
+                                            )}
+                                        </div>
                                     </div>
                                     <div className="form-group">
                                         <label className="form-label">{t('enterprise.llm.label')}</label>
@@ -1390,7 +1428,35 @@ export default function EnterpriseSettings() {
                                                 </div>
                                                 <div className="form-group">
                                                     <label className="form-label">{t('enterprise.llm.model')}</label>
-                                                    <input className="form-input" placeholder={t('enterprise.llm.modelPlaceholder')} value={modelForm.model} onChange={e => setModelForm({ ...modelForm, model: e.target.value })} />
+                                                    <div style={{ display: 'flex', gap: '8px' }}>
+                                                        <select 
+                                                            className="form-input" 
+                                                            value={(!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') ? 'custom' : modelForm.model} 
+                                                            onChange={e => {
+                                                                if (e.target.value === 'custom') {
+                                                                    setModelForm({ ...modelForm, model: '' });
+                                                                } else {
+                                                                    setModelForm({ ...modelForm, model: e.target.value });
+                                                                }
+                                                            }}
+                                                            style={{ flex: (!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') ? '1' : '100%' }}
+                                                        >
+                                                            <option value="" disabled>Select a model</option>
+                                                            {(PRESET_MODELS[modelForm.provider] || []).map(m => (
+                                                                <option key={m} value={m}>{m}</option>
+                                                            ))}
+                                                            <option value="custom">Custom (Type manually)</option>
+                                                        </select>
+                                                        {(!PRESET_MODELS[modelForm.provider]?.includes(modelForm.model) && modelForm.model !== '') && (
+                                                            <input 
+                                                                className="form-input" 
+                                                                placeholder="Type model name" 
+                                                                value={modelForm.model} 
+                                                                onChange={e => setModelForm({ ...modelForm, model: e.target.value })} 
+                                                                style={{ flex: '2' }}
+                                                            />
+                                                        )}
+                                                    </div>
                                                 </div>
                                                 <div className="form-group">
                                                     <label className="form-label">{t('enterprise.llm.label')}</label>

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -4,69 +4,40 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '../stores';
 import { agentApi } from '../services/api';
+import {
+    IconHome,
+    IconPlus,
+    IconSettings,
+    IconUser,
+    IconSun,
+    IconMoon,
+    IconLogout,
+    IconWorld,
+    IconLayoutSidebarLeftCollapse,
+    IconLayoutSidebarLeftExpand,
+    IconBell,
+    IconBuildingMonument,
+    IconSearch,
+    IconX,
+    IconPin,
+    IconPinnedOff,
+    IconArrowUpRight,
+    IconBuilding
+} from '@tabler/icons-react';
 
-/* ────── SVG Icons ────── */
+/* ────── Tabler Icons ────── */
 const SidebarIcons = {
-    home: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M2.5 6.5L8 2l5.5 4.5V13a1 1 0 01-1 1h-3V10H6.5v4h-3a1 1 0 01-1-1V6.5z" />
-        </svg>
-    ),
-    plus: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-            <path d="M8 3v10M3 8h10" />
-        </svg>
-    ),
-    settings: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="8" cy="8" r="2" />
-            <path d="M13.5 8a5.5 5.5 0 00-.3-1.8l1.3-1-1.2-2-1.5.6a5.5 5.5 0 00-1.6-.9L9.8 1.5H7.6l-.4 1.4a5.5 5.5 0 00-1.6.9L4 3.2 2.8 5.2l1.3 1A5.5 5.5 0 003.8 8c0 .6.1 1.2.3 1.8l-1.3 1 1.2 2 1.5-.6c.5.4 1 .7 1.6.9l.4 1.4h2.2l.4-1.4c.6-.2 1.1-.5 1.6-.9l1.5.6 1.2-2-1.3-1c.2-.6.3-1.2.3-1.8z" />
-        </svg>
-    ),
-    user: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="8" cy="5.5" r="2.5" />
-            <path d="M3 14v-1a4 4 0 018 0v1" />
-        </svg>
-    ),
-    sun: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-            <circle cx="8" cy="8" r="3" />
-            <path d="M8 1.5v1.5M8 13v1.5M1.5 8H3M13 8h1.5M3.4 3.4l1 1M11.6 11.6l1 1M3.4 12.6l1-1M11.6 4.4l1-1" />
-        </svg>
-    ),
-    moon: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M13.5 8.5a5.5 5.5 0 01-8-4.5 5.5 5.5 0 003 10c2 0 3.8-1 4.8-2.7a4 4 0 01.2-2.8z" />
-        </svg>
-    ),
-    logout: (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M6 14H3a1 1 0 01-1-1V3a1 1 0 011-1h3M11 11l3-3-3-3M14 8H6" />
-        </svg>
-    ),
-    globe: (
-        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="8" cy="8" r="6" />
-            <path d="M2 8h12M8 2a10 10 0 013 6 10 10 0 01-3 6 10 10 0 01-3-6 10 10 0 013-6z" />
-        </svg>
-    ),
-    collapse: (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M15 18l-6-6 6-6" />
-        </svg>
-    ),
-    expand: (
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M9 18l6-6-6-6" />
-        </svg>
-    ),
-    bell: (
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 6a4 4 0 018 0c0 2 1 3.5 1.5 4.5H2.5C3 9.5 4 8 4 6z" />
-            <path d="M6.5 12.5a1.5 1.5 0 003 0" />
-        </svg>
-    ),
+    home: <IconHome size={16} stroke={1.5} />,
+    plus: <IconPlus size={16} stroke={1.5} />,
+    settings: <IconSettings size={16} stroke={1.5} />,
+    user: <IconUser size={16} stroke={1.5} />,
+    sun: <IconSun size={16} stroke={1.5} />,
+    moon: <IconMoon size={16} stroke={1.5} />,
+    logout: <IconLogout size={16} stroke={1.5} />,
+    globe: <IconWorld size={16} stroke={1.5} />,
+    collapse: <IconLayoutSidebarLeftCollapse size={16} stroke={1.5} />,
+    expand: <IconLayoutSidebarLeftExpand size={16} stroke={1.5} />,
+    bell: <IconBell size={16} stroke={1.5} />,
 };
 
 const fetchJson = async <T,>(url: string): Promise<T> => {
@@ -312,7 +283,9 @@ export default function Layout() {
 
                     <div className="sidebar-section">
                         <NavLink to="/plaza" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`}>
-                            <span className="sidebar-item-icon" style={{ display: 'flex', fontSize: '14px' }}>🏛️</span>
+                            <span className="sidebar-item-icon" style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+                                <IconBuildingMonument size={14} stroke={1.5} />
+                            </span>
                             <span className="sidebar-item-text">{t('nav.plaza', 'Plaza')}</span>
                         </NavLink>
                         <NavLink to="/dashboard" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`}>
@@ -321,14 +294,16 @@ export default function Layout() {
                         </NavLink>
                     </div>
                 </div>
+                
+                <div className="sidebar-divider" />
 
                 <div className="sidebar-scrollable">
                     {/* Sidebar search */}
                     {!isSidebarCollapsed && agents.length >= 5 && (
                         <div style={{ padding: '4px 12px 4px', position: 'relative' }}>
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="var(--text-tertiary)" strokeWidth="2" strokeLinecap="round" style={{ position: 'absolute', left: '20px', top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none' }}>
-                                <circle cx="11" cy="11" r="8" /><path d="M21 21l-4.35-4.35" />
-                            </svg>
+                            <div style={{ position: 'absolute', left: '20px', top: '50%', transform: 'translateY(-50%)', pointerEvents: 'none', color: 'var(--text-tertiary)', display: 'flex' }}>
+                                <IconSearch size={14} stroke={2} />
+                            </div>
                             <input
                                 type="text"
                                 value={sidebarSearch}
@@ -343,7 +318,9 @@ export default function Layout() {
                                 onBlur={e => e.target.style.borderColor = 'var(--border-subtle)'}
                             />
                             {sidebarSearch && (
-                                <button onClick={() => setSidebarSearch('')} style={{ position: 'absolute', right: '18px', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', fontSize: '12px', padding: '2px', lineHeight: 1 }}>&#x2715;</button>
+                                <button onClick={() => setSidebarSearch('')} style={{ position: 'absolute', right: '18px', top: '50%', transform: 'translateY(-50%)', background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', display: 'flex', padding: 0 }}>
+                                    <IconX size={14} stroke={2} />
+                                </button>
                             )}
                         </div>
                     )}
@@ -369,16 +346,12 @@ export default function Layout() {
                                     to={`/agents/${agent.id}`}
                                     className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`}
                                     title={agent.name}
-                                    style={{ paddingRight: '28px' }}
                                 >
                                     <span className="sidebar-item-icon" style={{ position: 'relative' }}>
                                         <span className={`agent-avatar${agent.agent_type === 'openclaw' ? ' openclaw' : ''}`}>{avatarChar}</span>
                                         {agent.agent_type === 'openclaw' && (
-                                            <span className="agent-avatar-link">
-                                                <svg width="6" height="6" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                                                    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-                                                    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-                                                </svg>
+                                            <span className="agent-avatar-link" style={{ display: 'flex' }}>
+                                                <IconArrowUpRight size={10} stroke={2.5} />
                                             </span>
                                         )}
                                         {badge && <span className={`agent-avatar-badge ${badge}`} />}
@@ -391,9 +364,14 @@ export default function Layout() {
                                         className={`sidebar-pin-btn ${pinnedAgents.has(agent.id) ? 'pinned' : ''}`}
                                         title={pinnedAgents.has(agent.id) ? (isChinese ? '取消置顶' : 'Unpin') : (isChinese ? '置顶' : 'Pin to top')}
                                     >
-                                        <svg width="10" height="10" viewBox="0 0 24 24" fill={pinnedAgents.has(agent.id) ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                                            <path d="M12 17v5" /><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16h14v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V5a1 1 0 0 1 1-1h1V2H7v2h1a1 1 0 0 1 1 1z" />
-                                        </svg>
+                                        {pinnedAgents.has(agent.id) ? (
+                                            <>
+                                                <IconPin size={14} stroke={1.5} className="pin-default" />
+                                                <IconPinnedOff size={14} stroke={1.5} className="pin-hover" />
+                                            </>
+                                        ) : (
+                                            <IconPin size={14} stroke={1.5} className="pin-on" />
+                                        )}
                                     </button>
                                 )}
                             </div>
@@ -426,16 +404,14 @@ export default function Layout() {
                         )}
                         {user && ['platform_admin', 'org_admin'].includes(user.role) && (
                             <NavLink to="/enterprise" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`} title={t('nav.enterprise')}>
-                                <span className="sidebar-item-icon" style={{ display: 'flex' }}>{SidebarIcons.settings}</span>
+                                <span className="sidebar-item-icon" style={{ display: 'flex' }}><IconBuilding size={16} stroke={1.5} /></span>
                                 <span className="sidebar-item-text">{t('nav.enterprise')}</span>
                             </NavLink>
                         )}
                         {user && user.role === 'platform_admin' && (
                             <NavLink to="/admin/platform-settings" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`} title={t('nav.platformSettings', 'Platform Settings')}>
                                 <span className="sidebar-item-icon" style={{ display: 'flex' }}>
-                                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                                        <circle cx="8" cy="8" r="2.5" /><path d="M13.5 8a5.5 5.5 0 01-.3 1.8l1.3.8-.8 1.4-1.3-.8a5.5 5.5 0 01-1.5 1l.1 1.5H9.2l.1-1.5a5.5 5.5 0 01-1.5-1l-1.3.8-.8-1.4 1.3-.8A5.5 5.5 0 016.7 8a5.5 5.5 0 01.3-1.8l-1.3-.8.8-1.4 1.3.8a5.5 5.5 0 011.5-1L9.2 2.3h1.6l-.1 1.5a5.5 5.5 0 011.5 1l1.3-.8.8 1.4-1.3.8a5.5 5.5 0 01.5 1.8z" />
-                                    </svg>
+                                    <IconSettings size={16} stroke={1.5} />
                                 </span>
                                 <span className="sidebar-item-text">{t('nav.platformSettings', 'Platform Settings')}</span>
                             </NavLink>


### PR DESCRIPTION
## Summary

- **Replace inline SVGs with @tabler/icons-react**: All sidebar icons (home, settings, bell, search, pin, etc.) now use the Tabler icon library instead of hand-crafted inline SVGs, improving consistency and maintainability.
- **Fix pinned agent icon behavior**: Pinned agents now show a pin icon by default and swap to an unpin icon on hover (with red color hint), making the interaction more intuitive.
- **Unify Platform Settings and Enterprise Settings layout**: Platform Settings page (`AdminCompanies.tsx`) now uses the same CSS classes (`page-header`, `page-title`, `page-subtitle`, `tabs`, `tab`) as Enterprise Settings, ensuring consistent title size, tab style, and spacing across all settings pages.
- **Differentiate sidebar icons for settings pages**: Enterprise Settings now uses `IconBuilding` (building icon) while Platform Settings keeps `IconSettings` (gear icon), making them visually distinguishable in the sidebar.
- **Move agent creation wizard navigation to sticky bottom bar**: The next/prev/finish buttons are now fixed at the bottom of the viewport instead of sticky at the top, improving usability when scrolling through long forms.
- **Add preset model selector for LLM configuration**: The LLM model input in Enterprise Settings now offers a dropdown with common preset models per provider (OpenAI, Anthropic, Google, DeepSeek, etc.), with a "Custom" option for manual input.

## Test Plan

- [ ] Verify pinned agents show pin icon by default, unpin icon on hover with red color
- [ ] Verify unpinned agents show pin icon on hover (unchanged behavior)
- [ ] Verify Platform Settings and Enterprise Settings pages have consistent header and tab styling
- [ ] Verify sidebar shows different icons for Enterprise Settings (building) and Platform Settings (gear)
- [ ] Verify agent creation wizard bottom navigation bar works correctly across all steps
- [ ] Verify LLM model preset dropdown works for all providers and custom input fallback functions correctly
- [ ] Verify light/dark theme compatibility for all changes


Made with [Cursor](https://cursor.com)