### PR TITLE
fix: Parse soul_template to auto-fill Personality and Boundaries

### DIFF
--- a/backend/app/services/agent_manager.py
+++ b/backend/app/services/agent_manager.py
@@ -74,10 +74,39 @@ class AgentManager:
             soul_content = soul_content.replace("{{creator_name}}", creator_name)
             soul_content = soul_content.replace("{{created_at}}", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
 
-        if personality:
-            soul_content += f"\n\n## Personality\n{personality}\n"
-        if boundaries:
-            soul_content += f"\n## Boundaries\n{boundaries}\n"
+        # Helper function to replace or append sections
+        def replace_or_append_section(content: str, section_name: str, section_content: str) -> str:
+            """Replace existing ## SectionName or append if not found."""
+            if not section_content:
+                return content
+            
+            # Pattern to match existing section (case-insensitive header)
+            import re
+            pattern = rf"^##\s+{re.escape(section_name)}\s*$"
+            lines = content.split('\n')
+            
+            # Find the section header
+            for i, line in enumerate(lines):
+                if re.match(pattern, line.strip(), re.IGNORECASE):
+                    # Found existing section - replace until next ## header or end
+                    section_start = i
+                    section_end = len(lines)
+                    for j in range(i + 1, len(lines)):
+                        if lines[j].strip().startswith('## '):
+                            section_end = j
+                            break
+                    
+                    # Replace the section content (with trailing newline for proper spacing)
+                    new_section = f"## {section_name}\n{section_content}\n"
+                    lines = lines[:section_start] + [new_section] + lines[section_end:]
+                    return '\n'.join(lines)
+            
+            # Section not found - append at the end
+            return content + f"\n## {section_name}\n{section_content}\n"
+
+        # Use the helper to replace or append Personality and Boundaries
+        soul_content = replace_or_append_section(soul_content, "Personality", personality)
+        soul_content = replace_or_append_section(soul_content, "Boundaries", boundaries)
 
         soul_path.write_text(soul_content, encoding="utf-8")
 

--- a/frontend/src/pages/AgentCreate.tsx
+++ b/frontend/src/pages/AgentCreate.tsx
@@ -8,6 +8,56 @@ import ChannelConfig from '../components/ChannelConfig';
 const STEPS = ['basicInfo', 'personality', 'skills', 'permissions', 'channel'] as const;
 const OPENCLAW_STEPS = ['basicInfo', 'permissions'] as const;
 
+/**
+ * Generic parser for soul_template markdown format.
+ * Extracts content from sections by header names (## Header Name).
+ * 
+ * @param soulTemplate - The markdown template string
+ * @param sectionNames - Array of section names to extract (e.g., ['Personality', 'Boundaries'])
+ * @returns Object with extracted section contents (lowercase keys)
+ * 
+ * @example
+ * const sections = parseSoulTemplate(markdown, ['Personality', 'Boundaries', 'Identity']);
+ * // Returns: { personality: '...', boundaries: '...', identity: '...' }
+ */
+function parseSoulTemplate(soulTemplate: string, sectionNames: string[] = []): Record<string, string> {
+    if (!soulTemplate) {
+        const empty: Record<string, string> = {};
+        sectionNames.forEach(name => {
+            empty[name.toLowerCase()] = '';
+        });
+        return empty;
+    }
+
+    const result: Record<string, string> = {};
+    
+    // Initialize all requested sections as empty
+    sectionNames.forEach(name => {
+        result[name.toLowerCase()] = '';
+    });
+
+    // Split by markdown ## headers
+    const sections = soulTemplate.split(/^##\s+/m);
+
+    for (let i = 0; i < sections.length; i++) {
+        const section = sections[i].trim();
+        const firstLineEnd = section.indexOf('\n');
+        const headerName = firstLineEnd > 0 ? section.slice(0, firstLineEnd).trim() : section.trim();
+        const content = firstLineEnd > 0 ? section.slice(firstLineEnd + 1).trim() : '';
+
+        // If this header matches one of our requested sections
+        const matchedSection = sectionNames.find(name => 
+            name.toLowerCase() === headerName.toLowerCase()
+        );
+        
+        if (matchedSection) {
+            result[matchedSection.toLowerCase()] = content;
+        }
+    }
+
+    return result;
+}
+
 export default function AgentCreate() {
     const { t } = useTranslation();
     const navigate = useNavigate();
@@ -513,7 +563,17 @@ For humans, the message is delivered via their available channel (e.g. Feishu).`
                                     {templates.map((tmpl: any) => (
                                         <div
                                             key={tmpl.id}
-                                            onClick={() => setForm({ ...form, template_id: tmpl.id, role_description: tmpl.description })}
+                                            onClick={() => {
+                                                // Parse soul_template to extract personality and boundaries
+                                                const sections = parseSoulTemplate(tmpl.soul_template, ['Personality', 'Boundaries']);
+                                                setForm({
+                                                    ...form,
+                                                    template_id: tmpl.id,
+                                                    role_description: tmpl.description,
+                                                    personality: sections.personality || '',
+                                                    boundaries: sections.boundaries || '',
+                                                });
+                                            }}
                                             style={{
                                                 padding: '12px', borderRadius: '8px', cursor: 'pointer', textAlign: 'center',
                                                 border: `1px solid ${form.template_id === tmpl.id ? 'var(--accent-primary)' : 'var(--border-default)'}`,


### PR DESCRIPTION
## Changes

This PR fixes the issue where Personality and Boundaries parameters were not being extracted from agent templates during creation.

### Frontend Changes
- Added generic `parseSoulTemplate` function to extract markdown sections by header names
- Auto-fill personality and boundaries when selecting agent template in Step 2
- Extensible design for extracting additional sections in the future (Identity, Work Style, etc.)

### Backend Changes
- Fixed duplicate Personality/Boundaries sections in generated soul.md
- Replaced simple append logic with replace-or-append function
- Existing sections are now replaced instead of duplicated

## Related Issue
Fixes the issue where selecting a template in Step 2 did not populate the Personality and Boundaries fields, and creating agents resulted in duplicate sections in soul.md files.