### PR TITLE
fix(agent): make `context_window_size` persist and take effect in context loading

### DIFF
--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -1232,8 +1232,9 @@ async def _call_agent_llm(db: AsyncSession, agent_id: uuid.UUID, user_text: str,
 
     # Build conversation messages (without system prompt — call_llm adds it)
     messages: list[dict] = []
+    ctx_size = agent.context_window_size or 100
     if history:
-        messages.extend(history[-10:])
+        messages.extend(history[-ctx_size:])
     messages.append({"role": "user", "content": user_text})
 
     # Use actual user_id so the system prompt knows who it's chatting with

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -541,7 +541,7 @@ async def websocket_chat(
                     select(ChatMessage)
                     .where(ChatMessage.agent_id == agent_id, ChatMessage.conversation_id == conv_id)
                     .order_by(ChatMessage.created_at.desc())
-                    .limit(20)
+                    .limit(ctx_size)
                 )
                 history_messages = list(reversed(history_result.scalars().all()))
                 logger.info(f"[WS] Loaded {len(history_messages)} history messages for session {conv_id}")

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -182,7 +182,7 @@ class AgentUpdate(BaseModel):
     autonomy_policy: dict | None = None
     primary_model_id: uuid.UUID | None = None
     fallback_model_id: uuid.UUID | None = None
-    context_window_size: int | None = None
+    context_window_size: int | None = Field(default=None, ge=1, le=500)
     max_tokens_per_day: int | None = None
     max_tokens_per_month: int | None = None
     max_tool_rounds: int | None = None


### PR DESCRIPTION
## Summary

This PR contains two commits that fix context_window_size end-to-end:

1. fix(agent): accept and return context_window_size in API (ab186dd)
  - Add `context_window_size` to `AgentUpdate` so `PATCH /agents/{id}` accepts it
  - Add `context_window_size` to `AgentOut` so `GET /agents/{id}` returns it
  - Fixes the issue where frontend setting existed but backend ignored/omitted it
2. fix(context): apply context_window_size to history loading (75da0e7)
  - WebSocket chat history loading now uses `context_window_size` instead of a fixed value
  - Channel-side `_call_agent_llm` history slicing now uses `context_window_size` instead of hardcoded slicing
  - Add backend validation for `AgentUpdate.context_window_size` with `Field(ge=1, le=500)`


## Problem Solved

1. `context_window_size` configured in frontend was not fully wired through backend request/response
2. Context loading still relied on hardcoded windows, so the setting did not truly take effect


## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
