### PR TITLE
Restore forgot-password email delivery in Docker deployments

### DIFF
--- a/backend/app/services/system_email_service.py
+++ b/backend/app/services/system_email_service.py
@@ -156,4 +156,9 @@ def run_background_email_job(job, *args, **kwargs) -> None:
     """Bridge Starlette background tasks to async email jobs."""
     result = job(*args, **kwargs)
     if inspect.isawaitable(result):
-        fire_and_forget(result)
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(result)
+        else:
+            fire_and_forget(result)

--- a/backend/tests/test_password_reset_and_notifications.py
+++ b/backend/tests/test_password_reset_and_notifications.py
@@ -320,6 +320,17 @@ def test_send_system_email_uses_configured_timeout(monkeypatch):
     assert captured["to"] == ["alice@example.com"]
 
 
+def test_run_background_email_job_executes_awaitable_without_running_loop():
+    captured = {"value": None}
+
+    async def fake_job(value: str):
+        captured["value"] = value
+
+    system_email_service.run_background_email_job(fake_job, "sent")
+
+    assert captured["value"] == "sent"
+
+
 @pytest.mark.asyncio
 async def test_reset_password_updates_user(monkeypatch):
     user = make_user(password_hash=auth_api.hash_password("old-password"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
         CLAWITH_PIP_TRUSTED_HOST: ${CLAWITH_PIP_TRUSTED_HOST:-}
     restart: unless-stopped
     command: ["/bin/bash", "/app/entrypoint.sh"]
+    env_file:
+      - ./.env
     environment:
       DATABASE_URL: postgresql+asyncpg://clawith:clawith@postgres:5432/clawith
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
Fixes #235

  ## Summary
  - inject `.env` mail/reset settings into the Docker `backend` service with `env_file`
  - fix async email background-job execution when Starlette runs the task in a threadpool without a running event loop
  - add a regression test covering the no-running-loop path

  ## Root Cause
  There were two separate issues affecting forgot-password in Docker deployments:

  1. `docker-compose.yml` did not inject the SMTP and reset-password related values from `.env` into the `backend` container, so the backend could start without the expected
  mail configuration.
  2. The forgot-password email job was dispatched through a sync background-task bridge that called `asyncio.create_task()` from a Starlette threadpool worker, which raised
  `RuntimeError: no running event loop` and prevented the mail from being sent even though the API returned a success response.

  ## Changes
  - added `env_file: ./.env` to the Docker `backend` service
  - updated `run_background_email_job()` to:
    - use `asyncio.run()` when no running event loop exists
    - keep the existing fire-and-forget path when a loop is available
  - added a regression test to ensure awaitable email jobs execute correctly from a sync context without an active event loop

  ## Test Plan
  - [x] `cd backend && .venv/bin/python -m pytest tests/test_password_reset_and_notifications.py -k 'run_background_email_job_executes_awaitable_without_running_loop or
  hides_email_delivery_failures or send_system_email_uses_configured_timeout' -q`
  - [x] `docker compose config | rg 'SYSTEM_EMAIL_FROM_ADDRESS|PUBLIC_BASE_URL|PASSWORD_RESET_TOKEN_EXPIRE_MINUTES'`
  - [x] Verify forgot-password end-to-end on the deployed Docker environment

  ## Notes
  - This PR does not change the forgot-password response semantics.
  - This PR is scoped only to the Docker env injection issue and the background email task execution bug.