### PR TITLE
feat(chat): add session context budget API and chat budget visibility panel

### DIFF
--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timezone as tz
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +18,7 @@ from app.models.agent import Agent
 from app.models.user import User
 
 router = APIRouter(prefix="/api/agents", tags=["chat-sessions"])
+DEFAULT_CONTEXT_BUDGET_TOKENS = 12000
 
 
 def _is_admin_or_creator(user: User, agent: Agent) -> bool:
@@ -60,6 +61,14 @@ class CreateSessionIn(BaseModel):
 
 class PatchSessionIn(BaseModel):
     title: str
+
+
+class ContextBudgetOut(BaseModel):
+    window_size_messages: int
+    session_messages_total: int
+    estimated_tokens_current_window: int
+    budget_tokens: int
+    usage_ratio: float
 
 
 @router.get("/{agent_id}/sessions")
@@ -284,6 +293,66 @@ async def delete_session(
     await db.delete(session)
     await db.commit()
     return None
+
+
+@router.get("/{agent_id}/sessions/{session_id}/context-budget", response_model=ContextBudgetOut)
+async def get_session_context_budget(
+    agent_id: uuid.UUID,
+    session_id: uuid.UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return a lightweight context-budget snapshot for one chat session."""
+    # Allow looking up sessions where agent_id OR peer_agent_id matches
+    result = await db.execute(
+        select(ChatSession).where(
+            ChatSession.id == session_id,
+            (ChatSession.agent_id == agent_id) | (ChatSession.peer_agent_id == agent_id),
+        )
+    )
+    session = result.scalar_one_or_none()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    # Permission: owner, admin, or creator can view
+    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
+    agent = agent_result.scalar_one_or_none()
+    if str(session.user_id) != str(current_user.id) and not _is_admin_or_creator(current_user, agent):
+        raise HTTPException(status_code=403, detail="Not authorized to view this session")
+
+    window_size = max(getattr(agent, "context_window_size", 100) or 100, 1)
+
+    total_result = await db.execute(
+        select(func.count(ChatMessage.id)).where(ChatMessage.conversation_id == str(session_id))
+    )
+    session_messages_total = int(total_result.scalar() or 0)
+
+    window_result = await db.execute(
+        select(ChatMessage.content)
+        .where(ChatMessage.conversation_id == str(session_id))
+        .order_by(ChatMessage.created_at.desc())
+        .limit(window_size)
+    )
+    window_contents = window_result.scalars().all()
+
+    total_chars = sum(len(content or "") for content in window_contents)
+    # Reuse existing char-based estimator for consistency across code paths.
+    from app.services.token_tracker import estimate_tokens_from_chars
+    estimated_tokens_current_window = estimate_tokens_from_chars(total_chars) if total_chars > 0 else 0
+
+    budget_tokens = DEFAULT_CONTEXT_BUDGET_TOKENS
+    usage_ratio = round(
+        (estimated_tokens_current_window / budget_tokens) if budget_tokens > 0 else 0.0,
+        4,
+    )
+
+    return ContextBudgetOut(
+        window_size_messages=window_size,
+        session_messages_total=session_messages_total,
+        estimated_tokens_current_window=estimated_tokens_current_window,
+        budget_tokens=budget_tokens,
+        usage_ratio=usage_ratio,
+    )
 
 
 @router.get("/{agent_id}/sessions/{session_id}/messages")

--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -18,7 +18,7 @@ from app.models.agent import Agent
 from app.models.user import User
 
 router = APIRouter(prefix="/api/agents", tags=["chat-sessions"])
-DEFAULT_CONTEXT_BUDGET_TOKENS = 12000
+DEFAULT_CONTEXT_BUDGET_TOKENS = 128000
 
 
 def _is_admin_or_creator(user: User, agent: Agent) -> bool:

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -399,7 +399,18 @@
       "collapseSessions": "Collapse sessions",
       "showSessions": "Show chat sessions",
       "toolCallChain": "Tools Used",
-      "analysing": "Analysing"
+      "analysing": "Analysing",
+      "contextBudget": {
+        "aria": "View context window info",
+        "title": "Context Window Info",
+        "windowSize": "Window messages",
+        "sessionMessages": "Session total messages",
+        "estimatedTokens": "Estimated window tokens",
+        "budgetTokens": "Budget tokens",
+        "usageRatio": "Usage ratio",
+        "loading": "Loading...",
+        "unavailable": "No session data yet"
+      }
     },
     "activityLog": {
       "title": "Activity Log",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -406,7 +406,18 @@
       "collapseSessions": "折叠会话列表",
       "showSessions": "显示聊天会话",
       "toolCallChain": "使用工具",
-      "analysing": "分析中"
+      "analysing": "分析中",
+      "contextBudget": {
+        "aria": "查看上下文窗口信息",
+        "title": "上下文窗口信息",
+        "windowSize": "窗口消息条数",
+        "sessionMessages": "会话总消息条数",
+        "estimatedTokens": "窗口估算 Token",
+        "budgetTokens": "预算 Token",
+        "usageRatio": "使用率",
+        "loading": "加载中...",
+        "unavailable": "暂无会话数据"
+      }
     },
     "activityLog": {
       "title": "工作日志",

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -12,7 +12,7 @@ import PromptModal from '../components/PromptModal';
 import OpenClawSettings from './OpenClawSettings';
 import AgentBayLivePanel, { LivePreviewState } from '../components/AgentBayLivePanel';
 import AgentCredentials from '../components/AgentCredentials';
-import { activityApi, agentApi, channelApi, enterpriseApi, fileApi, scheduleApi, skillApi, taskApi, triggerApi, uploadFileWithProgress } from '../services/api';
+import { activityApi, agentApi, channelApi, chatSessionApi, enterpriseApi, fileApi, scheduleApi, skillApi, taskApi, triggerApi, uploadFileWithProgress } from '../services/api';
 import { useAppStore } from '../stores';
 import { useAuthStore } from '../stores';
 import { copyToClipboard } from '../utils/clipboard';
@@ -1430,6 +1430,7 @@ function AgentDetailInner() {
     const [historyMsgs, setHistoryMsgs] = useState<any[]>([]);
     const [sessionsLoading, setSessionsLoading] = useState(false);
     const [allSessionsLoading, setAllSessionsLoading] = useState(false);
+    const [showContextBudgetPopover, setShowContextBudgetPopover] = useState(false);
     const [agentExpired, setAgentExpired] = useState(false);
     // Websocket chat state (for 'me' conversation)
     const token = useAuthStore((s) => s.token);
@@ -1449,6 +1450,17 @@ function AgentDetailInner() {
     const currentAgentIdRef = useRef<string | undefined>(id);
     const sessionMsgAbortRef = useRef<AbortController | null>(null);
     const sessionLoadSeqRef = useRef(0);
+
+    const {
+        data: sessionContextBudget,
+        isFetching: sessionContextBudgetFetching,
+        refetch: refetchSessionContextBudget,
+    } = useQuery({
+        queryKey: ['agent-detail-chat-context-budget', id, activeSession?.id],
+        queryFn: () => chatSessionApi.contextBudget(id!, String(activeSession?.id)),
+        enabled: !!id && activeTab === 'chat' && !!activeSession?.id,
+        refetchInterval: activeTab === 'chat' && activeSession?.id ? 15000 : false,
+    });
 
     const buildSessionRuntimeKey = (agentId: string, sessionId: string) => `${agentId}:${sessionId}`;
 
@@ -1781,6 +1793,21 @@ function AgentDetailInner() {
     const chatInputRef = useRef<HTMLTextAreaElement>(null);
     const chatInputAreaRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const usageRatioRaw = sessionContextBudget?.usage_ratio ?? 0;
+    const usageRatio = Number.isFinite(usageRatioRaw) ? Math.max(usageRatioRaw, 0) : 0;
+    const usageRatioClamped = Math.min(usageRatio, 1);
+    const usagePercent = Math.round(usageRatio * 1000) / 10;
+    const contextRingColor = usageRatio >= 1
+        ? 'var(--error)'
+        : usageRatio >= 0.8
+            ? 'var(--warning)'
+            : usageRatio >= 0.6
+                ? 'var(--info)'
+                : 'var(--text-secondary)';
+    const contextRingRadius = 8;
+    const contextRingCircumference = 2 * Math.PI * contextRingRadius;
+    const contextRingOffset = contextRingCircumference * (1 - usageRatioClamped);
+    const formatBudgetCount = (value: number | undefined) => (typeof value === 'number' ? value.toLocaleString() : '—');
 
     // Settings form local state
     const [settingsForm, setSettingsForm] = useState({
@@ -2067,6 +2094,7 @@ function AgentDetailInner() {
                     return [...prev, parseChatMsg({ role: d.role, content: d.content, timestamp: new Date().toISOString() })];
                 });
                 fetchMySessions(true, agentId);
+                refetchSessionContextBudget();
             } else if (d.type === 'error' || d.type === 'quota_exceeded') {
                 const msg = d.content || d.detail || d.message || 'Request denied';
                 setChatMessages(prev => {
@@ -4683,6 +4711,129 @@ function AgentDetailInner() {
                                                         <IconSend size={16} stroke={1.75} />
                                                     </button>
                                                 )}
+                                                <div
+                                                    style={{ position: 'relative' }}
+                                                    onMouseEnter={() => setShowContextBudgetPopover(true)}
+                                                    onMouseLeave={() => setShowContextBudgetPopover(false)}
+                                                >
+                                                    <button
+                                                        type="button"
+                                                        aria-label={t('agent.chat.contextBudget.aria')}
+                                                        style={{
+                                                            width: '32px',
+                                                            height: '32px',
+                                                            borderRadius: '0',
+                                                            border: 'none',
+                                                            background: 'transparent',
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            justifyContent: 'center',
+                                                            padding: 0,
+                                                            cursor: 'default',
+                                                            boxShadow: 'none',
+                                                            opacity: activeSession?.id ? 1 : 0.5,
+                                                        }}
+                                                    >
+                                                        <svg width="28" height="28" viewBox="0 0 20 20" role="presentation">
+                                                            <defs>
+                                                                <linearGradient id="contextBudgetRingGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                                                                    <stop offset="0%" stopColor={contextRingColor} stopOpacity="0.95" />
+                                                                    <stop offset="100%" stopColor={contextRingColor} stopOpacity="0.55" />
+                                                                </linearGradient>
+                                                                <filter id="contextBudgetRingGlow" x="-50%" y="-50%" width="200%" height="200%">
+                                                                    <feDropShadow dx="0" dy="0" stdDeviation="1.4" floodColor={contextRingColor} floodOpacity="0.45" />
+                                                                </filter>
+                                                            </defs>
+                                                            <circle
+                                                                cx="10"
+                                                                cy="10"
+                                                                r={contextRingRadius}
+                                                                fill="none"
+                                                                stroke="rgba(127,127,127,0.22)"
+                                                                strokeWidth="2.3"
+                                                            />
+                                                            <circle
+                                                                cx="10"
+                                                                cy="10"
+                                                                r={contextRingRadius}
+                                                                fill="none"
+                                                                stroke="url(#contextBudgetRingGradient)"
+                                                                strokeWidth="2.6"
+                                                                strokeLinecap="round"
+                                                                strokeDasharray={`${contextRingCircumference} ${contextRingCircumference}`}
+                                                                strokeDashoffset={contextRingOffset}
+                                                                transform="rotate(-90 10 10)"
+                                                                filter="url(#contextBudgetRingGlow)"
+                                                                style={{ transition: 'stroke-dashoffset 180ms ease' }}
+                                                            />
+                                                            <circle cx="10" cy="10" r="4.9" fill="#ffffff" />
+                                                            <text
+                                                                x="10"
+                                                                y="10.95"
+                                                                textAnchor="middle"
+                                                                dominantBaseline="middle"
+                                                                style={{
+                                                                    fill: '#2f3440',
+                                                                    fontSize: '3.95px',
+                                                                    fontWeight: 700,
+                                                                    fontFamily: '"Avenir Next", "SF Pro Display", "Inter", sans-serif',
+                                                                    letterSpacing: '-0.08px',
+                                                                }}
+                                                            >
+                                                                <tspan>{Math.max(0, Math.round(usagePercent))}</tspan>
+                                                                <tspan style={{ fontSize: '2.6px', fontWeight: 700 }}>%</tspan>
+                                                            </text>
+                                                        </svg>
+                                                    </button>
+                                                    {showContextBudgetPopover && (
+                                                        <div style={{
+                                                            position: 'absolute',
+                                                            bottom: 'calc(100% + 10px)',
+                                                            right: 0,
+                                                            minWidth: '292px',
+                                                            border: '1px solid color-mix(in srgb, var(--border-default) 78%, transparent)',
+                                                            borderRadius: '14px',
+                                                            padding: '12px 12px 11px',
+                                                            background: `
+                                                            radial-gradient(120% 140% at 0% 0%, rgba(255,255,255,0.05), transparent 48%),
+                                                            linear-gradient(180deg, var(--bg-elevated), color-mix(in srgb, var(--bg-elevated) 88%, var(--bg-secondary) 12%))
+                                                        `,
+                                                            boxShadow: 'none',
+                                                            zIndex: 30,
+                                                            backdropFilter: 'blur(6px)',
+                                                        }}>
+                                                            <div style={{ fontSize: '12px', fontWeight: 700, marginBottom: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                                                <span>{t('agent.chat.contextBudget.title')}</span>
+                                                                <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
+                                                            </div>
+                                                            <div style={{ height: '5px', borderRadius: '999px', background: 'rgba(127,127,127,0.18)', overflow: 'hidden', marginBottom: '10px' }}>
+                                                                <div style={{ height: '100%', width: `${Math.min(usageRatio, 1.2) * 100}%`, borderRadius: '999px', background: `linear-gradient(90deg, ${contextRingColor}, color-mix(in srgb, ${contextRingColor} 60%, white 40%))` }} />
+                                                            </div>
+                                                            {!activeSession?.id ? (
+                                                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                                                    {t('agent.chat.contextBudget.unavailable')}
+                                                                </div>
+                                                            ) : sessionContextBudgetFetching && !sessionContextBudget ? (
+                                                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                                                    {t('agent.chat.contextBudget.loading')}
+                                                                </div>
+                                                            ) : (
+                                                                <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', rowGap: '6px', columnGap: '10px', fontSize: '12px' }}>
+                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.windowSize')}</span>
+                                                                    <span>{formatBudgetCount(sessionContextBudget?.window_size_messages)}</span>
+                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.sessionMessages')}</span>
+                                                                    <span>{formatBudgetCount(sessionContextBudget?.session_messages_total)}</span>
+                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.estimatedTokens')}</span>
+                                                                    <span>{formatBudgetCount(sessionContextBudget?.estimated_tokens_current_window)}</span>
+                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.budgetTokens')}</span>
+                                                                    <span>{formatBudgetCount(sessionContextBudget?.budget_tokens)}</span>
+                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.usageRatio')}</span>
+                                                                    <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    )}
+                                                </div>
                                             </div>
                                         </div>
                                         </div>

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef, useCallback, Component, Er
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { createPortal } from 'react-dom';
 
 import ConfirmModal from '../components/ConfirmModal';
 import type { FileBrowserApi } from '../components/FileBrowser';
@@ -1431,6 +1432,10 @@ function AgentDetailInner() {
     const [sessionsLoading, setSessionsLoading] = useState(false);
     const [allSessionsLoading, setAllSessionsLoading] = useState(false);
     const [showContextBudgetPopover, setShowContextBudgetPopover] = useState(false);
+    const contextBudgetTriggerRef = useRef<HTMLButtonElement>(null);
+    const contextBudgetPopoverRef = useRef<HTMLDivElement>(null);
+    const [contextBudgetPopoverPos, setContextBudgetPopoverPos] = useState({ top: 0, left: 0 });
+    const contextBudgetCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [agentExpired, setAgentExpired] = useState(false);
     // Websocket chat state (for 'me' conversation)
     const token = useAuthStore((s) => s.token);
@@ -1808,6 +1813,45 @@ function AgentDetailInner() {
     const contextRingCircumference = 2 * Math.PI * contextRingRadius;
     const contextRingOffset = contextRingCircumference * (1 - usageRatioClamped);
     const formatBudgetCount = (value: number | undefined) => (typeof value === 'number' ? value.toLocaleString() : '—');
+    const clearContextBudgetCloseTimer = useCallback(() => {
+        if (contextBudgetCloseTimerRef.current) {
+            clearTimeout(contextBudgetCloseTimerRef.current);
+            contextBudgetCloseTimerRef.current = null;
+        }
+    }, []);
+    const updateContextBudgetPopoverPosition = useCallback(() => {
+        const rect = contextBudgetTriggerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        setContextBudgetPopoverPos({
+            top: Math.max(8, rect.top - 10),
+            left: Math.min(window.innerWidth - 12, rect.right),
+        });
+    }, []);
+    const openContextBudgetPopover = useCallback(() => {
+        clearContextBudgetCloseTimer();
+        updateContextBudgetPopoverPosition();
+        setShowContextBudgetPopover(true);
+    }, [clearContextBudgetCloseTimer, updateContextBudgetPopoverPosition]);
+    const scheduleCloseContextBudgetPopover = useCallback(() => {
+        clearContextBudgetCloseTimer();
+        contextBudgetCloseTimerRef.current = setTimeout(() => {
+            setShowContextBudgetPopover(false);
+            contextBudgetCloseTimerRef.current = null;
+        }, 90);
+    }, [clearContextBudgetCloseTimer]);
+
+    useEffect(() => {
+        if (!showContextBudgetPopover) return;
+        const handleMove = () => updateContextBudgetPopoverPosition();
+        window.addEventListener('resize', handleMove);
+        window.addEventListener('scroll', handleMove, true);
+        return () => {
+            window.removeEventListener('resize', handleMove);
+            window.removeEventListener('scroll', handleMove, true);
+        };
+    }, [showContextBudgetPopover, updateContextBudgetPopoverPosition]);
+
+    useEffect(() => () => clearContextBudgetCloseTimer(), [clearContextBudgetCloseTimer]);
 
     // Settings form local state
     const [settingsForm, setSettingsForm] = useState({
@@ -4588,7 +4632,7 @@ function AgentDetailInner() {
                                             </div>
                                         ) : null}
                                         <div ref={chatInputAreaRef} className="chat-input-area" style={{ flexShrink: 0 }}>
-                                            <div className="chat-composer">
+                                            <div className="chat-composer" style={{ position: 'relative' }}>
                                             {(chatUploadDrafts.length > 0 || attachedFiles.length > 0) && (
                                                 <div className="chat-composer-attachments">
                                                     {chatUploadDrafts.map((draft) => (
@@ -4645,7 +4689,7 @@ function AgentDetailInner() {
                                                     ))}
                                                 </div>
                                             )}
-                                            <div className="chat-composer-input-block">
+                                            <div className="chat-composer-input-block" style={{ paddingRight: '40px' }}>
                                                 <textarea
                                                     ref={chatInputRef}
                                                     className="chat-input"
@@ -4711,130 +4755,112 @@ function AgentDetailInner() {
                                                         <IconSend size={16} stroke={1.75} />
                                                     </button>
                                                 )}
-                                                <div
-                                                    style={{ position: 'relative' }}
-                                                    onMouseEnter={() => setShowContextBudgetPopover(true)}
-                                                    onMouseLeave={() => setShowContextBudgetPopover(false)}
+                                            </div>
+                                            <div
+                                                style={{ position: 'absolute', top: '8px', right: '8px', zIndex: 5 }}
+                                                onMouseEnter={openContextBudgetPopover}
+                                                onMouseLeave={scheduleCloseContextBudgetPopover}
+                                            >
+                                                <button
+                                                    type="button"
+                                                    ref={contextBudgetTriggerRef}
+                                                    className="chat-composer-btn"
+                                                    aria-label={t('agent.chat.contextBudget.aria')}
+                                                    style={{
+                                                        cursor: activeSession?.id ? 'pointer' : 'default',
+                                                        opacity: activeSession?.id ? 1 : 0.55,
+                                                        border: '1px solid var(--border-subtle)',
+                                                        borderRadius: '6px',
+                                                    }}
                                                 >
-                                                    <button
-                                                        type="button"
-                                                        aria-label={t('agent.chat.contextBudget.aria')}
-                                                        style={{
-                                                            width: '32px',
-                                                            height: '32px',
-                                                            borderRadius: '0',
-                                                            border: 'none',
-                                                            background: 'transparent',
-                                                            display: 'flex',
-                                                            alignItems: 'center',
-                                                            justifyContent: 'center',
-                                                            padding: 0,
-                                                            cursor: 'default',
-                                                            boxShadow: 'none',
-                                                            opacity: activeSession?.id ? 1 : 0.5,
-                                                        }}
-                                                    >
-                                                        <svg width="28" height="28" viewBox="0 0 20 20" role="presentation">
-                                                            <defs>
-                                                                <linearGradient id="contextBudgetRingGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                                                                    <stop offset="0%" stopColor={contextRingColor} stopOpacity="0.95" />
-                                                                    <stop offset="100%" stopColor={contextRingColor} stopOpacity="0.55" />
-                                                                </linearGradient>
-                                                                <filter id="contextBudgetRingGlow" x="-50%" y="-50%" width="200%" height="200%">
-                                                                    <feDropShadow dx="0" dy="0" stdDeviation="1.4" floodColor={contextRingColor} floodOpacity="0.45" />
-                                                                </filter>
-                                                            </defs>
-                                                            <circle
-                                                                cx="10"
-                                                                cy="10"
-                                                                r={contextRingRadius}
-                                                                fill="none"
-                                                                stroke="rgba(127,127,127,0.22)"
-                                                                strokeWidth="2.3"
-                                                            />
-                                                            <circle
-                                                                cx="10"
-                                                                cy="10"
-                                                                r={contextRingRadius}
-                                                                fill="none"
-                                                                stroke="url(#contextBudgetRingGradient)"
-                                                                strokeWidth="2.6"
-                                                                strokeLinecap="round"
-                                                                strokeDasharray={`${contextRingCircumference} ${contextRingCircumference}`}
-                                                                strokeDashoffset={contextRingOffset}
-                                                                transform="rotate(-90 10 10)"
-                                                                filter="url(#contextBudgetRingGlow)"
-                                                                style={{ transition: 'stroke-dashoffset 180ms ease' }}
-                                                            />
-                                                            <circle cx="10" cy="10" r="4.9" fill="#ffffff" />
-                                                            <text
-                                                                x="10"
-                                                                y="10.95"
-                                                                textAnchor="middle"
-                                                                dominantBaseline="middle"
-                                                                style={{
-                                                                    fill: '#2f3440',
-                                                                    fontSize: '3.95px',
-                                                                    fontWeight: 700,
-                                                                    fontFamily: '"Avenir Next", "SF Pro Display", "Inter", sans-serif',
-                                                                    letterSpacing: '-0.08px',
-                                                                }}
-                                                            >
-                                                                <tspan>{Math.max(0, Math.round(usagePercent))}</tspan>
-                                                                <tspan style={{ fontSize: '2.6px', fontWeight: 700 }}>%</tspan>
-                                                            </text>
-                                                        </svg>
-                                                    </button>
-                                                    {showContextBudgetPopover && (
-                                                        <div style={{
-                                                            position: 'absolute',
-                                                            bottom: 'calc(100% + 10px)',
-                                                            right: 0,
-                                                            minWidth: '292px',
-                                                            border: '1px solid color-mix(in srgb, var(--border-default) 78%, transparent)',
-                                                            borderRadius: '14px',
-                                                            padding: '12px 12px 11px',
-                                                            background: `
-                                                            radial-gradient(120% 140% at 0% 0%, rgba(255,255,255,0.05), transparent 48%),
-                                                            linear-gradient(180deg, var(--bg-elevated), color-mix(in srgb, var(--bg-elevated) 88%, var(--bg-secondary) 12%))
-                                                        `,
-                                                            boxShadow: 'none',
-                                                            zIndex: 30,
-                                                            backdropFilter: 'blur(6px)',
-                                                        }}>
-                                                            <div style={{ fontSize: '12px', fontWeight: 700, marginBottom: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                                                                <span>{t('agent.chat.contextBudget.title')}</span>
-                                                                <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
-                                                            </div>
-                                                            <div style={{ height: '5px', borderRadius: '999px', background: 'rgba(127,127,127,0.18)', overflow: 'hidden', marginBottom: '10px' }}>
-                                                                <div style={{ height: '100%', width: `${Math.min(usageRatio, 1.2) * 100}%`, borderRadius: '999px', background: `linear-gradient(90deg, ${contextRingColor}, color-mix(in srgb, ${contextRingColor} 60%, white 40%))` }} />
-                                                            </div>
-                                                            {!activeSession?.id ? (
-                                                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
-                                                                    {t('agent.chat.contextBudget.unavailable')}
-                                                                </div>
-                                                            ) : sessionContextBudgetFetching && !sessionContextBudget ? (
-                                                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
-                                                                    {t('agent.chat.contextBudget.loading')}
-                                                                </div>
-                                                            ) : (
-                                                                <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', rowGap: '6px', columnGap: '10px', fontSize: '12px' }}>
-                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.windowSize')}</span>
-                                                                    <span>{formatBudgetCount(sessionContextBudget?.window_size_messages)}</span>
-                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.sessionMessages')}</span>
-                                                                    <span>{formatBudgetCount(sessionContextBudget?.session_messages_total)}</span>
-                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.estimatedTokens')}</span>
-                                                                    <span>{formatBudgetCount(sessionContextBudget?.estimated_tokens_current_window)}</span>
-                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.budgetTokens')}</span>
-                                                                    <span>{formatBudgetCount(sessionContextBudget?.budget_tokens)}</span>
-                                                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.usageRatio')}</span>
-                                                                    <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
-                                                                </div>
-                                                            )}
+                                                    <svg width="16" height="16" viewBox="0 0 20 20" role="presentation">
+                                                        <circle
+                                                            cx="10"
+                                                            cy="10"
+                                                            r={contextRingRadius}
+                                                            fill="none"
+                                                            stroke="currentColor"
+                                                            strokeOpacity="0.3"
+                                                            strokeWidth="2.2"
+                                                        />
+                                                        <circle
+                                                            cx="10"
+                                                            cy="10"
+                                                            r={contextRingRadius}
+                                                            fill="none"
+                                                            stroke="currentColor"
+                                                            strokeWidth="2.2"
+                                                            strokeLinecap="round"
+                                                            strokeDasharray={`${contextRingCircumference} ${contextRingCircumference}`}
+                                                            strokeDashoffset={contextRingOffset}
+                                                            transform="rotate(-90 10 10)"
+                                                            style={{ transition: 'stroke-dashoffset 180ms ease' }}
+                                                        />
+                                                    </svg>
+                                                </button>
+                                            </div>
+                                            {showContextBudgetPopover && typeof document !== 'undefined' && createPortal(
+                                                <div
+                                                    ref={contextBudgetPopoverRef}
+                                                    onMouseEnter={openContextBudgetPopover}
+                                                    onMouseLeave={scheduleCloseContextBudgetPopover}
+                                                    style={{
+                                                        position: 'fixed',
+                                                        top: contextBudgetPopoverPos.top,
+                                                        left: contextBudgetPopoverPos.left,
+                                                        transform: 'translate(-100%, -100%)',
+                                                        minWidth: '292px',
+                                                        border: '1px solid var(--border-default)',
+                                                        borderRadius: '12px',
+                                                        padding: '12px',
+                                                        background: 'var(--bg-elevated)',
+                                                        boxShadow: 'var(--shadow-md)',
+                                                        zIndex: 2000,
+                                                    }}
+                                                >
+                                                    <div style={{
+                                                        position: 'absolute',
+                                                        right: '12px',
+                                                        bottom: '-6px',
+                                                        width: '10px',
+                                                        height: '10px',
+                                                        borderRight: '1px solid var(--border-default)',
+                                                        borderBottom: '1px solid var(--border-default)',
+                                                        background: 'var(--bg-elevated)',
+                                                        transform: 'rotate(45deg)',
+                                                    }} />
+                                                    <div style={{ fontSize: '12px', fontWeight: 700, marginBottom: '8px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                                                        <span>{t('agent.chat.contextBudget.title')}</span>
+                                                        <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
+                                                    </div>
+                                                    <div style={{ height: '5px', borderRadius: '999px', background: 'rgba(127,127,127,0.18)', overflow: 'hidden', marginBottom: '10px' }}>
+                                                        <div style={{ height: '100%', width: `${Math.min(usageRatio, 1.2) * 100}%`, borderRadius: '999px', background: contextRingColor }} />
+                                                    </div>
+                                                    {!activeSession?.id ? (
+                                                        <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                                            {t('agent.chat.contextBudget.unavailable')}
+                                                        </div>
+                                                    ) : sessionContextBudgetFetching && !sessionContextBudget ? (
+                                                        <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                                            {t('agent.chat.contextBudget.loading')}
+                                                        </div>
+                                                    ) : (
+                                                        <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', rowGap: '6px', columnGap: '10px', fontSize: '12px' }}>
+                                                            <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.windowSize')}</span>
+                                                            <span>{formatBudgetCount(sessionContextBudget?.window_size_messages)}</span>
+                                                            <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.sessionMessages')}</span>
+                                                            <span>{formatBudgetCount(sessionContextBudget?.session_messages_total)}</span>
+                                                            <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.estimatedTokens')}</span>
+                                                            <span>{formatBudgetCount(sessionContextBudget?.estimated_tokens_current_window)}</span>
+                                                            <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.budgetTokens')}</span>
+                                                            <span>{formatBudgetCount(sessionContextBudget?.budget_tokens)}</span>
+                                                            <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.usageRatio')}</span>
+                                                            <span style={{ color: contextRingColor, fontWeight: 700 }}>{usagePercent.toFixed(1)}%</span>
                                                         </div>
                                                     )}
-                                                </div>
-                                            </div>
+                                                </div>,
+                                                document.body
+                                            )}
                                         </div>
                                         </div>
                                     </div>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import AgentBayLivePanel, { LivePreviewState } from '../components/AgentBayLivePanel';
-import { agentApi, enterpriseApi, uploadFileWithProgress } from '../services/api';
+import { agentApi, chatSessionApi, enterpriseApi, uploadFileWithProgress } from '../services/api';
 import { IconPaperclip, IconSend } from '@tabler/icons-react';
 import { formatFileSize } from '../utils/formatFileSize';
 import { useAuthStore } from '../stores';
@@ -279,6 +279,7 @@ export default function Chat() {
     const [liveState, setLiveState] = useState<LivePreviewState>({});
     const [livePanelVisible, setLivePanelVisible] = useState(false);
     const [wsSessionId, setWsSessionId] = useState<string>('');
+    const [showBudgetPopover, setShowBudgetPopover] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -298,6 +299,26 @@ export default function Chat() {
         queryKey: ['llm-models'],
         queryFn: () => enterpriseApi.llmModels(),
         enabled: !!agent?.primary_model_id,
+    });
+
+    const { data: mineSessions = [], refetch: refetchMineSessions } = useQuery({
+        queryKey: ['chat-sessions-mine', id],
+        queryFn: () => chatSessionApi.listMine(id!),
+        enabled: !!id && !!token,
+        refetchInterval: 15000,
+    });
+
+    const activeSessionId = mineSessions[0]?.id;
+
+    const {
+        data: contextBudget,
+        isFetching: contextBudgetFetching,
+        refetch: refetchContextBudget,
+    } = useQuery({
+        queryKey: ['chat-context-budget', id, activeSessionId],
+        queryFn: () => chatSessionApi.contextBudget(id!, activeSessionId!),
+        enabled: !!id && !!token && !!activeSessionId,
+        refetchInterval: 15000,
     });
 
     const supportsVision = !!agent?.primary_model_id && llmModels.some(
@@ -561,6 +582,8 @@ export default function Chat() {
                         }
                         return updated;
                     });
+                    refetchMineSessions();
+                    refetchContextBudget();
                 } else {
                     // Legacy format: {role, content}
                     setMessages(prev => [...prev, { role: data.role, content: data.content }]);
@@ -692,6 +715,21 @@ export default function Chat() {
     };
 
     const hasLiveData = !!(liveState.desktop || liveState.browser || liveState.code);
+    const usageRatioRaw = contextBudget?.usage_ratio ?? 0;
+    const usageRatio = Number.isFinite(usageRatioRaw) ? Math.max(usageRatioRaw, 0) : 0;
+    const usageRatioClamped = Math.min(usageRatio, 1);
+    const usagePercent = Math.round(usageRatio * 1000) / 10;
+    const ringColor = usageRatio >= 1
+        ? 'var(--error)'
+        : usageRatio >= 0.8
+            ? 'var(--warning)'
+            : usageRatio >= 0.6
+                ? 'var(--info)'
+                : 'var(--text-secondary)';
+    const ringRadius = 8;
+    const ringCircumference = 2 * Math.PI * ringRadius;
+    const ringOffset = ringCircumference * (1 - usageRatioClamped);
+    const formatCount = (value: number | undefined) => (typeof value === 'number' ? value.toLocaleString() : '—');
 
     // ── Drag-and-drop file upload ──
     const handleDroppedFiles = useCallback(async (files: File[]) => {
@@ -748,6 +786,91 @@ export default function Chat() {
                             <span style={{ color: 'var(--text-tertiary)' }}>{connected ? t('agent.chat.connected') : t('agent.chat.disconnected')}</span>
                         </div>
                     </div>
+                </div>
+                <div
+                    style={{ position: 'relative' }}
+                    onMouseEnter={() => setShowBudgetPopover(true)}
+                    onMouseLeave={() => setShowBudgetPopover(false)}
+                >
+                    <button
+                        type="button"
+                        aria-label={t('agent.chat.contextBudget.aria')}
+                        style={{
+                            width: '30px',
+                            height: '30px',
+                            borderRadius: '999px',
+                            border: '1px solid var(--border-default)',
+                            background: 'var(--bg-elevated)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            padding: 0,
+                            transition: 'all 120ms ease',
+                        }}
+                    >
+                        <svg width="20" height="20" viewBox="0 0 20 20" role="presentation">
+                            <circle
+                                cx="10"
+                                cy="10"
+                                r={ringRadius}
+                                fill="none"
+                                stroke="var(--border-default)"
+                                strokeWidth="3"
+                            />
+                            <circle
+                                cx="10"
+                                cy="10"
+                                r={ringRadius}
+                                fill="none"
+                                stroke={ringColor}
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeDasharray={`${ringCircumference} ${ringCircumference}`}
+                                strokeDashoffset={ringOffset}
+                                transform="rotate(-90 10 10)"
+                            />
+                        </svg>
+                    </button>
+                    {showBudgetPopover && (
+                        <div style={{
+                            position: 'absolute',
+                            top: 'calc(100% + 8px)',
+                            right: 0,
+                            minWidth: '260px',
+                            border: '1px solid var(--border-default)',
+                            borderRadius: '10px',
+                            padding: '10px 12px',
+                            background: 'var(--bg-elevated)',
+                            boxShadow: 'var(--shadow-md)',
+                            zIndex: 20,
+                        }}>
+                            <div style={{ fontSize: '12px', fontWeight: 600, marginBottom: '8px' }}>
+                                {t('agent.chat.contextBudget.title')}
+                            </div>
+                            {!activeSessionId ? (
+                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                    {t('agent.chat.contextBudget.unavailable')}
+                                </div>
+                            ) : contextBudgetFetching && !contextBudget ? (
+                                <div style={{ fontSize: '12px', color: 'var(--text-tertiary)' }}>
+                                    {t('agent.chat.contextBudget.loading')}
+                                </div>
+                            ) : (
+                                <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', rowGap: '6px', columnGap: '10px', fontSize: '12px' }}>
+                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.windowSize')}</span>
+                                    <span>{formatCount(contextBudget?.window_size_messages)}</span>
+                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.sessionMessages')}</span>
+                                    <span>{formatCount(contextBudget?.session_messages_total)}</span>
+                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.estimatedTokens')}</span>
+                                    <span>{formatCount(contextBudget?.estimated_tokens_current_window)}</span>
+                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.budgetTokens')}</span>
+                                    <span>{formatCount(contextBudget?.budget_tokens)}</span>
+                                    <span style={{ color: 'var(--text-tertiary)' }}>{t('agent.chat.contextBudget.usageRatio')}</span>
+                                    <span style={{ color: ringColor, fontWeight: 600 }}>{usagePercent.toFixed(1)}%</span>
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </div>
             </div>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -258,6 +258,28 @@ export const agentApi = {
         request<any[]>(`/agents/${id}/gateway-messages`),
 };
 
+export interface ChatSessionSummary {
+    id: string;
+    title: string;
+    last_message_at?: string | null;
+}
+
+export interface SessionContextBudget {
+    window_size_messages: number;
+    session_messages_total: number;
+    estimated_tokens_current_window: number;
+    budget_tokens: number;
+    usage_ratio: number;
+}
+
+export const chatSessionApi = {
+    listMine: (agentId: string) =>
+        request<ChatSessionSummary[]>(`/agents/${agentId}/sessions?scope=mine`),
+
+    contextBudget: (agentId: string, sessionId: string) =>
+        request<SessionContextBudget>(`/agents/${agentId}/sessions/${sessionId}/context-budget`),
+};
+
 // ─── Tasks ────────────────────────────────────────────
 export const taskApi = {
     list: (agentId: string, status?: string, type?: string) => {


### PR DESCRIPTION
## Summary

This PR introduces session-level context budget visibility in two parts:

- **Backend**: adds a lightweight session context budget API to estimate current context load.
- **Frontend**: adds a chat-side context budget indicator + hover details panel in Agent Detail chat.

Commits included:

- abf332214cc9089106cd75bf4e8d21cd585b1595
- 601d5a2b2646317505bbc51305b065daa8325822


## What Changed

### 1) Backend: Session Context Budget Endpoint

Added:

- `GET /api/agents/{agent_id}/sessions/{session_id}/context-budget`

Returns minimal budget fields:

- `window_size_messages`
- `session_messages_total`
- `estimated_tokens_current_window`
- `budget_tokens`
- `usage_ratio`

Implementation notes:

- Estimates tokens from window message content using existing char-based estimator.
- Uses a fixed default `budget_tokens` baseline for now.
- Read-only endpoint; does not change chat behavior.


### 2) Frontend: Context Budget Indicator in Chat UI

Added session budget visualization in Agent Detail chat:

- Circular budget progress indicator near send controls.
- Hover card showing detailed context budget fields.
- Progress ring and percentages bound to `usage_ratio`.
- i18n labels for EN/ZH.


## Notes / Scope

- This PR is **observability only** for context budget.


## ScreenShots

<img width="1010" height="71" alt="image" src="https://github.com/user-attachments/assets/0c922621-fe3d-4225-8629-3408d8a551c5" />

<img width="1005" height="758" alt="image" src="https://github.com/user-attachments/assets/050ef1d2-e1f4-463f-8c02-563ab5421066" />



## Follow-up 

To keep this PR focused and easier to review, I’ve kept it to the context‑budget endpoint and UI only, and would implement auto compaction logic separately if you think it’s a good fit for the project.

A follow‑up PR with auto compaction would:

- proactively reduce the risk of context overflow and hard failures when long‑running sessions grow large;

- avoid silent quality degradation from models receiving overly long, noisy histories;


## Checklist

- [x] Tested locally
- [x] No unrelated changes included
