### PR TITLE
fix(chat_sessions): 修复数字员工查看全部对话异常

### DIFF
--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -117,8 +117,11 @@ async def list_sessions(
                 display = session.group_name or session.title or "Group Chat"
             else:
                 # Human session — resolve username
+                # Note: User.username is an association_proxy, so we need to join through Identity
+                from app.models.user import Identity
                 user_r = await db.execute(
-                    select(func.coalesce(User.display_name, User.username))
+                    select(func.coalesce(User.display_name, Identity.username))
+                    .join(Identity, User.identity_id == Identity.id)
                     .where(User.id == session.user_id)
                 )
                 display = user_r.scalar_one_or_none() or "Unknown"


### PR DESCRIPTION
修复数字员工查看全部对话时出现异常，前端无法显示任何对话记录。

由于User.username是association_proxy，需要通过Identity表关联查询username。修改查询语句以正确获取用户显示名称。
