### PR TITLE
[codex] Fix Feishu interactive card streaming stalls and out-of-order patches

### DIFF
--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -1,6 +1,9 @@
 """Feishu OAuth and Channel API routes."""
 
+import asyncio
+import time
 import uuid
+from collections.abc import Awaitable, Callable
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from loguru import logger
@@ -17,6 +20,33 @@ from app.schemas.schemas import ChannelConfigCreate, ChannelConfigOut, TokenResp
 from app.services.feishu_service import feishu_service
 
 router = APIRouter(tags=["feishu"])
+
+_LLM_TIMEOUT_SECONDS = 180.0
+_TOOL_STATUS_KEEP_LINES = 8
+
+
+class _SerialPatchQueue:
+    """Serialize patch requests for one Feishu message to prevent out-of-order overwrite."""
+
+    def __init__(self):
+        self._tail: asyncio.Task | None = None
+
+    def enqueue(self, job_factory: Callable[[], Awaitable[None]]) -> None:
+        prev = self._tail
+
+        async def _runner():
+            if prev:
+                try:
+                    await prev
+                except Exception as e:
+                    logger.warning(f"[Feishu] Previous patch job failed before next job: {e}")
+            await job_factory()
+
+        self._tail = asyncio.create_task(_runner())
+
+    async def drain(self) -> None:
+        if self._tail:
+            await self._tail
 
 
 # ─── OAuth ──────────────────────────────────────────────
@@ -617,15 +647,13 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     await feishu_service.send_message(
                         config.app_id, config.app_secret,
                         _reply_to_id, "text",
-                        json.dumps({"text": "\n\n".join(_fallback_parts)}),
+                        _json.dumps({"text": "\n\n".join(_fallback_parts)}),
                         receive_id_type=_rid_type,
                     )
             _cfs_token = _cfs.set(_feishu_file_sender)
 
             # Set up streaming response via interactive card
-            import time
             import json as _json_card
-            import asyncio as _aio
 
             # Send initial loading card
             init_card = {
@@ -638,12 +666,12 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                 if chat_type == "group" and chat_id:
                     init_resp = await feishu_service.send_message(
                         config.app_id, config.app_secret, chat_id, "interactive",
-                        _json_card.dumps(init_card), receive_id_type="chat_id"
+                        _json_card.dumps(init_card), receive_id_type="chat_id", stage="stream_init_card"
                     )
                 else:
                     init_resp = await feishu_service.send_message(
                         config.app_id, config.app_secret, sender_open_id, "interactive",
-                        _json_card.dumps(init_card), receive_id_type="open_id"
+                        _json_card.dumps(init_card), receive_id_type="open_id", stage="stream_init_card"
                     )
                 msg_id_for_patch = init_resp.get("data", {}).get("message_id")
             except Exception as e:
@@ -654,10 +682,20 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
             _last_flush_time = time.time()
             _FLUSH_INTERVAL = 1.0  # Update Feishu once per second to avoid limits
             _agent_name = agent_obj.name if agent_obj else "AI 回复"
+            _tool_status_lines: list[str] = []
+            _patch_queue = _SerialPatchQueue()
+            _heartbeat_task: asyncio.Task | None = None
+            _llm_done = False
 
             def _build_card(answer_text: str, thinking_text: str = "", streaming: bool = False) -> dict:
                 """Build interactive card. Thinking shown in collapsible grey section."""
                 elements = []
+                if _tool_status_lines:
+                    elements.append({
+                        "tag": "markdown",
+                        "content": "\n".join(_tool_status_lines[-_TOOL_STATUS_KEEP_LINES:]),
+                    })
+                    elements.append({"tag": "hr"})
                 if thinking_text:
                     # Show thinking in a collapsible note block
                     think_preview = thinking_text[:200].replace("\n", " ")
@@ -677,71 +715,148 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     "elements": elements,
                 }
 
-            async def _ws_on_chunk(text: str):
+            async def _queue_patch_card(card: dict, stage: str) -> None:
+                if not msg_id_for_patch:
+                    return
+                payload = _json_card.dumps(card)
+
+                async def _job():
+                    try:
+                        await feishu_service.patch_message(
+                            config.app_id,
+                            config.app_secret,
+                            msg_id_for_patch,
+                            payload,
+                            stage=stage,
+                        )
+                    except Exception as e:
+                        logger.warning(f"[Feishu] Patch failed (stage={stage}, message_id={msg_id_for_patch}): {e}")
+
+                _patch_queue.enqueue(_job)
+
+            async def _flush_stream(reason: str, force: bool = False):
                 nonlocal _last_flush_time
+                if not msg_id_for_patch:
+                    return
+                now = time.time()
+                if not force and now - _last_flush_time < _FLUSH_INTERVAL:
+                    return
+                card = _build_card(
+                    "".join(_stream_buffer),
+                    "".join(_thinking_buffer),
+                    streaming=True,
+                )
+                await _queue_patch_card(card, stage=f"stream_{reason}")
+                _last_flush_time = now
+
+            async def _ws_on_chunk(text: str):
                 if not msg_id_for_patch:
                     return
                 _stream_buffer.append(text)
-                now = time.time()
-                if now - _last_flush_time >= _FLUSH_INTERVAL:
-                    card = _build_card(
-                        "".join(_stream_buffer),
-                        "".join(_thinking_buffer),
-                        streaming=True,
-                    )
-                    _aio.create_task(feishu_service.patch_message(
-                        config.app_id, config.app_secret, msg_id_for_patch, _json_card.dumps(card)
-                    ))
-                    _last_flush_time = now
+                await _flush_stream("chunk")
 
             async def _ws_on_thinking(text: str):
-                nonlocal _last_flush_time
                 if not msg_id_for_patch:
                     return
                 _thinking_buffer.append(text)
-                now = time.time()
-                if now - _last_flush_time >= _FLUSH_INTERVAL:
-                    card = _build_card(
-                        "".join(_stream_buffer),
-                        "".join(_thinking_buffer),
-                        streaming=True,
-                    )
-                    _aio.create_task(feishu_service.patch_message(
-                        config.app_id, config.app_secret, msg_id_for_patch, _json_card.dumps(card)
-                    ))
-                    _last_flush_time = now
+                await _flush_stream("thinking")
+
+            async def _ws_on_tool_call(evt: dict):
+                tool_name = evt.get("name") or "unknown_tool"
+                status = (evt.get("status") or "").lower()
+                if status == "running":
+                    line = f"⏳ 正在调用工具: `{tool_name}`"
+                elif status == "done":
+                    line = f"✅ 工具完成: `{tool_name}`"
+                else:
+                    line = f"ℹ️ 工具状态更新: `{tool_name}` ({status or 'unknown'})"
+                _tool_status_lines.append(line)
+                await _flush_stream("tool")
+
+            async def _heartbeat():
+                while not _llm_done:
+                    await asyncio.sleep(_FLUSH_INTERVAL)
+                    await _flush_stream("heartbeat")
+
+            if msg_id_for_patch:
+                _heartbeat_task = asyncio.create_task(_heartbeat())
 
             # Call LLM with history and streaming callback
-            reply_text = await _call_agent_llm(
-                db, agent_id, llm_user_text, history=history, user_id=platform_user_id,
-                on_chunk=_ws_on_chunk, on_thinking=_ws_on_thinking,
-            )
-            _cfs.reset(_cfs_token)
-            _cfso.reset(_cfso_token)
+            try:
+                reply_text = await _call_agent_llm(
+                    db,
+                    agent_id,
+                    llm_user_text,
+                    history=history,
+                    user_id=platform_user_id,
+                    on_chunk=_ws_on_chunk,
+                    on_thinking=_ws_on_thinking,
+                    on_tool_call=_ws_on_tool_call,
+                )
+            finally:
+                _llm_done = True
+                if _heartbeat_task:
+                    _heartbeat_task.cancel()
+                    try:
+                        await _heartbeat_task
+                    except Exception:
+                        pass
+                _cfs.reset(_cfs_token)
+                _cfso.reset(_cfso_token)
             logger.info(f"[Feishu] LLM reply: {reply_text[:100]}")
 
             # Send final card update or fallback text
             if msg_id_for_patch:
+                try:
+                    await _patch_queue.drain()
+                except Exception as e:
+                    logger.warning(f"[Feishu] Drain patch queue failed before final patch: {e}")
                 final_card = _build_card(
                     reply_text,
                     "".join(_thinking_buffer),
                     streaming=False,
                 )
-                await feishu_service.patch_message(
-                    config.app_id, config.app_secret, msg_id_for_patch, _json_card.dumps(final_card)
-                )
+                try:
+                    await feishu_service.patch_message(
+                        config.app_id,
+                        config.app_secret,
+                        msg_id_for_patch,
+                        _json_card.dumps(final_card),
+                        stage="stream_final",
+                    )
+                except Exception as e:
+                    logger.error(f"[Feishu] Final card patch failed: {e}")
+                    if chat_type == "group" and chat_id:
+                        await feishu_service.send_message(
+                            config.app_id,
+                            config.app_secret,
+                            chat_id,
+                            "text",
+                            _json.dumps({"text": reply_text}),
+                            receive_id_type="chat_id",
+                            stage="stream_final_fallback_text",
+                        )
+                    else:
+                        await feishu_service.send_message(
+                            config.app_id,
+                            config.app_secret,
+                            sender_open_id,
+                            "text",
+                            _json.dumps({"text": reply_text}),
+                            stage="stream_final_fallback_text",
+                        )
             else:
                 # Fallback to plain text if card creation failed
                 try:
                     if chat_type == "group" and chat_id:
                         await feishu_service.send_message(
                             config.app_id, config.app_secret, chat_id, "text",
-                            json.dumps({"text": reply_text}), receive_id_type="chat_id",
+                            _json.dumps({"text": reply_text}), receive_id_type="chat_id", stage="stream_no_card_fallback_text",
                         )
                     else:
                         await feishu_service.send_message(
                             config.app_id, config.app_secret, sender_open_id, "text",
-                            json.dumps({"text": reply_text}),
+                            _json.dumps({"text": reply_text}), stage="stream_no_card_fallback_text",
                         )
                 except Exception as e:
                     logger.error(f"[Feishu] Failed to send fallback message: {e}")
@@ -969,7 +1084,6 @@ async def _handle_feishu_file(db, agent_id, config, message, sender_open_id, cha
 
     # For images: call LLM so vision models can actually see the image
     if msg_type == "image":
-        import time as _time_img
         import json as _json_card_img
 
         # Send initial loading card
@@ -985,55 +1099,102 @@ async def _handle_feishu_file(db, agent_id, config, message, sender_open_id, cha
         try:
             _init_resp = await feishu_service.send_message(
                 config.app_id, config.app_secret, _reply_to, "interactive",
-                _json_card_img.dumps(_init_card), receive_id_type=_rid_type
+                _json_card_img.dumps(_init_card), receive_id_type=_rid_type, stage="image_stream_init_card"
             )
             _patch_msg_id = _init_resp.get("data", {}).get("message_id")
         except Exception as _e_init:
             logger.error(f"[Feishu] Failed to send init card for image: {_e_init}")
 
         _img_stream_buf = []
-        _img_last_flush = _time_img.time()
+        _img_last_flush = time.time()
+        _img_flush_interval = 1.0
+        _img_patch_queue = _SerialPatchQueue()
+        _img_heartbeat_task: asyncio.Task | None = None
+        _img_llm_done = False
+
+        async def _queue_image_patch(_card: dict, _stage: str):
+            if not _patch_msg_id:
+                return
+            _payload = _json_card_img.dumps(_card)
+
+            async def _job():
+                try:
+                    await feishu_service.patch_message(
+                        config.app_id,
+                        config.app_secret,
+                        _patch_msg_id,
+                        _payload,
+                        stage=_stage,
+                    )
+                except Exception as _e_patch:
+                    logger.warning(f"[Feishu] Image patch failed (stage={_stage}, message_id={_patch_msg_id}): {_e_patch}")
+
+            _img_patch_queue.enqueue(_job)
+
+        async def _flush_image_stream(reason: str, force: bool = False):
+            nonlocal _img_last_flush
+            now = time.time()
+            if not force and now - _img_last_flush < _img_flush_interval:
+                return
+            _card = {
+                "config": {"update_multi": True},
+                "header": {"template": "blue", "title": {"content": _agent_name, "tag": "plain_text"}},
+                "elements": [{"tag": "markdown", "content": "".join(_img_stream_buf) + "▌"}]
+            }
+            await _queue_image_patch(_card, _stage=f"image_stream_{reason}")
+            _img_last_flush = now
 
         async def _img_on_chunk(text):
-            nonlocal _img_last_flush
             _img_stream_buf.append(text)
-            now = _time_img.time()
-            if _patch_msg_id and now - _img_last_flush >= 1.0:
-                _card = {
-                    "config": {"update_multi": True},
-                    "header": {"template": "blue", "title": {"content": _agent_name, "tag": "plain_text"}},
-                    "elements": [{"tag": "markdown", "content": "".join(_img_stream_buf) + "▌"}]
-                }
-                import asyncio as _aio_img
-                _aio_img.create_task(feishu_service.patch_message(
-                    config.app_id, config.app_secret, _patch_msg_id, _json_card_img.dumps(_card)
-                ))
-                _img_last_flush = now
+            if _patch_msg_id:
+                await _flush_image_stream("chunk")
+
+        async def _img_heartbeat():
+            while not _img_llm_done:
+                await asyncio.sleep(_img_flush_interval)
+                if _patch_msg_id:
+                    await _flush_image_stream("heartbeat")
+
+        if _patch_msg_id:
+            _img_heartbeat_task = asyncio.create_task(_img_heartbeat())
 
         # Call LLM with image marker — vision models will parse it
         async with _async_session() as _db_img:
-            reply_text = await _call_agent_llm(
-                _db_img, agent_id, user_msg_content, history=_history,
-                user_id=platform_user_id, on_chunk=_img_on_chunk,
-            )
+            try:
+                reply_text = await _call_agent_llm(
+                    _db_img, agent_id, user_msg_content, history=_history,
+                    user_id=platform_user_id, on_chunk=_img_on_chunk,
+                )
+            finally:
+                _img_llm_done = True
+                if _img_heartbeat_task:
+                    _img_heartbeat_task.cancel()
+                    try:
+                        await _img_heartbeat_task
+                    except Exception:
+                        pass
 
         logger.info(f"[Feishu] Image LLM reply: {reply_text[:100]}")
 
         # Send final card or fallback text
         if _patch_msg_id:
+            try:
+                await _img_patch_queue.drain()
+            except Exception as _e_drain:
+                logger.warning(f"[Feishu] Image patch queue drain failed: {_e_drain}")
             _final_card = {
                 "config": {"update_multi": True},
                 "header": {"template": "blue", "title": {"content": _agent_name, "tag": "plain_text"}},
                 "elements": [{"tag": "markdown", "content": reply_text or "..."}]
             }
             await feishu_service.patch_message(
-                config.app_id, config.app_secret, _patch_msg_id, _json_card_img.dumps(_final_card)
+                config.app_id, config.app_secret, _patch_msg_id, _json_card_img.dumps(_final_card), stage="image_stream_final"
             )
         else:
             try:
                 await feishu_service.send_message(
                     config.app_id, config.app_secret, _reply_to, "text",
-                    json.dumps({"text": reply_text}), receive_id_type=_rid_type,
+                    json.dumps({"text": reply_text}), receive_id_type=_rid_type, stage="image_stream_fallback_text",
                 )
             except Exception as _e_fb:
                 logger.error(f"[Feishu] Failed to send image reply: {_e_fb}")
@@ -1095,7 +1256,16 @@ async def _download_post_images(agent_id, config, message_id, image_keys):
                 logger.error(f"[Feishu] Failed to download post image {ik}: {e}")
 
 
-async def _call_agent_llm(db: AsyncSession, agent_id: uuid.UUID, user_text: str, history: list[dict] | None = None, user_id=None, on_chunk=None, on_thinking=None) -> str:
+async def _call_agent_llm(
+    db: AsyncSession,
+    agent_id: uuid.UUID,
+    user_text: str,
+    history: list[dict] | None = None,
+    user_id=None,
+    on_chunk=None,
+    on_thinking=None,
+    on_tool_call=None,
+) -> str:
     """Call the agent's configured LLM model with conversation history.
     
     Reuses the same call_llm function as the WebSocket chat endpoint so that
@@ -1153,18 +1323,57 @@ async def _call_agent_llm(db: AsyncSession, agent_id: uuid.UUID, user_text: str,
     effective_user_id = user_id or agent_id
 
     try:
-        reply = await call_llm(
-            model,
-            messages,
-            agent.name,
-            agent.role_description or "",
-            agent_id=agent_id,
-            user_id=effective_user_id,
-            supports_vision=getattr(model, 'supports_vision', False),
-            on_chunk=on_chunk,
-            on_thinking=on_thinking,
+        reply = await asyncio.wait_for(
+            call_llm(
+                model,
+                messages,
+                agent.name,
+                agent.role_description or "",
+                agent_id=agent_id,
+                user_id=effective_user_id,
+                supports_vision=getattr(model, 'supports_vision', False),
+                on_chunk=on_chunk,
+                on_thinking=on_thinking,
+                on_tool_call=on_tool_call,
+            ),
+            timeout=_LLM_TIMEOUT_SECONDS,
         )
         return reply
+    except asyncio.TimeoutError:
+        logger.error(
+            f"[LLM] Call timed out after {_LLM_TIMEOUT_SECONDS}s "
+            f"(agent_id={agent_id}, model={getattr(model, 'model', 'unknown')})"
+        )
+        if fallback_model:
+            logger.info(f"[LLM] Retrying timed-out request with fallback model: {fallback_model.model}")
+            try:
+                reply = await asyncio.wait_for(
+                    call_llm(
+                        fallback_model,
+                        messages,
+                        agent.name,
+                        agent.role_description or "",
+                        agent_id=agent_id,
+                        user_id=effective_user_id,
+                        supports_vision=getattr(fallback_model, 'supports_vision', False),
+                        on_chunk=on_chunk,
+                        on_thinking=on_thinking,
+                        on_tool_call=on_tool_call,
+                    ),
+                    timeout=_LLM_TIMEOUT_SECONDS,
+                )
+                return reply
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"[LLM] Fallback call also timed out after {_LLM_TIMEOUT_SECONDS}s "
+                    f"(agent_id={agent_id}, model={getattr(fallback_model, 'model', 'unknown')})"
+                )
+                return f"⚠️ 模型响应超时（>{int(_LLM_TIMEOUT_SECONDS)}秒）。请稍后重试，或减少一次请求内容。"
+            except Exception as e2:
+                import traceback
+                traceback.print_exc()
+                return f"⚠️ 调用模型出错: Primary Timeout | Fallback: {str(e2)[:80]}"
+        return f"⚠️ 模型响应超时（>{int(_LLM_TIMEOUT_SECONDS)}秒）。请稍后重试，或减少一次请求内容。"
     except Exception as e:
         import traceback
         traceback.print_exc()
@@ -1174,18 +1383,28 @@ async def _call_agent_llm(db: AsyncSession, agent_id: uuid.UUID, user_text: str,
         if fallback_model:
             logger.info(f"[LLM] Retrying with fallback model: {fallback_model.model}")
             try:
-                reply = await call_llm(
-                    fallback_model,
-                    messages,
-                    agent.name,
-                    agent.role_description or "",
-                    agent_id=agent_id,
-                    user_id=effective_user_id,
-                    supports_vision=getattr(fallback_model, 'supports_vision', False),
-                    on_chunk=on_chunk,
-                    on_thinking=on_thinking,
+                reply = await asyncio.wait_for(
+                    call_llm(
+                        fallback_model,
+                        messages,
+                        agent.name,
+                        agent.role_description or "",
+                        agent_id=agent_id,
+                        user_id=effective_user_id,
+                        supports_vision=getattr(fallback_model, 'supports_vision', False),
+                        on_chunk=on_chunk,
+                        on_thinking=on_thinking,
+                        on_tool_call=on_tool_call,
+                    ),
+                    timeout=_LLM_TIMEOUT_SECONDS,
                 )
                 return reply
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"[LLM] Fallback call timed out after {_LLM_TIMEOUT_SECONDS}s "
+                    f"(agent_id={agent_id}, model={getattr(fallback_model, 'model', 'unknown')})"
+                )
+                return f"⚠️ 调用模型超时: Primary: {str(e)[:80]} | Fallback Timeout"
             except Exception as e2:
                 traceback.print_exc()
                 return f"⚠️ 调用模型出错: Primary: {str(e)[:80]} | Fallback: {str(e2)[:80]}"

--- a/backend/app/services/feishu_service.py
+++ b/backend/app/services/feishu_service.py
@@ -1,6 +1,7 @@
 """Feishu (Lark) OAuth and API integration service."""
 
 import httpx
+from loguru import logger
 from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +25,41 @@ class FeishuService:
         self.app_id = settings.FEISHU_APP_ID
         self.app_secret = settings.FEISHU_APP_SECRET
         self._app_access_token: str | None = None
+
+    @staticmethod
+    def _parse_api_response(
+        resp: httpx.Response,
+        *,
+        stage: str,
+        message_id: str | None = None,
+    ) -> dict:
+        """Parse Feishu API response and verify both HTTP status and business code."""
+        try:
+            data = resp.json()
+        except Exception as e:
+            logger.warning(
+                f"[Feishu] {stage} returned non-JSON response "
+                f"(http_status={resp.status_code}, message_id={message_id}): {e}"
+            )
+            raise RuntimeError(f"Feishu {stage} returned invalid JSON")
+
+        if resp.status_code >= 400:
+            logger.warning(
+                f"[Feishu] {stage} HTTP failure "
+                f"(http_status={resp.status_code}, message_id={message_id}, body={str(data)[:300]})"
+            )
+            raise RuntimeError(f"Feishu {stage} HTTP {resp.status_code}")
+
+        code = data.get("code")
+        msg = data.get("msg", "")
+        if code is not None and code != 0:
+            logger.warning(
+                f"[Feishu] {stage} business failure "
+                f"(message_id={message_id}, code={code}, msg={msg})"
+            )
+            raise RuntimeError(f"Feishu {stage} failed: code={code}, msg={msg}")
+
+        return data
 
     async def get_app_access_token(self) -> str:
         """Get or refresh the app-level access token. Deprecated: Use get_tenant_access_token instead."""
@@ -213,8 +249,16 @@ class FeishuService:
         return user, token
 
 
-    async def send_message(self, app_id: str, app_secret: str, receive_id: str,
-                           msg_type: str, content: str, receive_id_type: str = "open_id") -> dict:
+    async def send_message(
+        self,
+        app_id: str,
+        app_secret: str,
+        receive_id: str,
+        msg_type: str,
+        content: str,
+        receive_id_type: str = "open_id",
+        stage: str = "send_message",
+    ) -> dict:
         """Send a message via a specific Feishu bot (per-agent credentials).
 
         Args:
@@ -242,9 +286,17 @@ class FeishuService:
                 },
                 headers={"Authorization": f"Bearer {app_token}"},
             )
-            return resp.json()
+            data = self._parse_api_response(resp, stage=stage)
+            return data
 
-    async def patch_message(self, app_id: str, app_secret: str, message_id: str, content: str) -> dict:
+    async def patch_message(
+        self,
+        app_id: str,
+        app_secret: str,
+        message_id: str,
+        content: str,
+        stage: str = "patch_message",
+    ) -> dict:
         """Patch an existing message (e.g. updating an interactive card for streaming)."""
         async with httpx.AsyncClient() as client:
             token_resp = await client.post(FEISHU_APP_TOKEN_URL, json={
@@ -260,7 +312,8 @@ class FeishuService:
                 },
                 headers={"Authorization": f"Bearer {app_token}"},
             )
-            return resp.json()
+            data = self._parse_api_response(resp, stage=stage, message_id=message_id)
+            return data
 
     async def resolve_open_id(self, app_id: str, app_secret: str,
                                email: str | None = None, mobile: str | None = None) -> str | None:

--- a/backend/tests/test_feishu_service_api.py
+++ b/backend/tests/test_feishu_service_api.py
@@ -1,0 +1,69 @@
+import pytest
+
+from app.services import feishu_service as feishu_service_module
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, *, send_payload: dict | None = None, patch_payload: dict | None = None):
+        self._send_payload = send_payload or {"code": 0, "msg": "ok", "data": {"message_id": "m_1"}}
+        self._patch_payload = patch_payload or {"code": 0, "msg": "ok"}
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **_kwargs):
+        if "app_access_token/internal" in url:
+            return _FakeResponse(200, {"app_access_token": "token_x"})
+        return _FakeResponse(200, self._send_payload)
+
+    async def patch(self, _url, **_kwargs):
+        return _FakeResponse(200, self._patch_payload)
+
+
+@pytest.mark.asyncio
+async def test_send_message_raises_when_business_code_nonzero(monkeypatch):
+    monkeypatch.setattr(
+        feishu_service_module.httpx,
+        "AsyncClient",
+        lambda: _FakeAsyncClient(send_payload={"code": 99991663, "msg": "rate limited"}),
+    )
+
+    with pytest.raises(RuntimeError, match="code=99991663"):
+        await feishu_service_module.feishu_service.send_message(
+            "app_id",
+            "app_secret",
+            "ou_xxx",
+            "text",
+            "{\"text\":\"hello\"}",
+            stage="unit_test_send",
+        )
+
+
+@pytest.mark.asyncio
+async def test_patch_message_raises_when_business_code_nonzero(monkeypatch):
+    monkeypatch.setattr(
+        feishu_service_module.httpx,
+        "AsyncClient",
+        lambda: _FakeAsyncClient(patch_payload={"code": 10019, "msg": "invalid card content"}),
+    )
+
+    with pytest.raises(RuntimeError, match="code=10019"):
+        await feishu_service_module.feishu_service.patch_message(
+            "app_id",
+            "app_secret",
+            "om_xxx",
+            "{\"content\":\"test\"}",
+            stage="unit_test_patch",
+        )


### PR DESCRIPTION
## Summary
- serialize Feishu interactive-card PATCH updates for the same `message_id` to prevent out-of-order overwrites during streaming
- drain queued PATCH jobs before sending the final card update so late intermediate patches cannot overwrite final content
- add tool-progress rendering (`on_tool_call`) to the Feishu card so users can see progress during tool rounds even without text chunks
- add heartbeat refresh while streaming to keep card progress visible when no chunks arrive, while keeping the original `_FLUSH_INTERVAL` cadence
- add timeout fallback (`180s`) for Feishu channel LLM calls and pass `on_tool_call` through both primary and fallback model paths
- validate Feishu business status (`code/msg`) in `send_message` and `patch_message`, with stage-aware logs for observability

## Validation
- `cd backend && python -m compileall -q app/api/feishu.py app/services/feishu_service.py`
- `cd backend && uv run --extra dev pytest -q tests/test_feishu_service_api.py tests/test_tools_bulk_api.py`
- Result: `3 passed`

Fixes #263