### PR TITLE
Tool Call Chain: Group consecutive tool calls into a collapsible chain UI

### DIFF
--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1242,13 +1242,28 @@ function AgentDetailInner() {
             if (currentAgentIdRef.current !== targetAgentId) return;
             if (activeSessionIdRef.current !== sess.id) return;
             const isAgentSession = sess.source_channel === 'agent' || sess.participant_type === 'agent';
-            const preParsed = msgs.map((m: any) => parseChatMsg({
+            const rawParsed = msgs.map((m: any) => parseChatMsg({
                 role: m.role, content: m.content || '',
                 ...(m.toolName && { toolName: m.toolName, toolArgs: m.toolArgs, toolStatus: m.toolStatus, toolResult: m.toolResult }),
                 ...(m.thinking && { thinking: m.thinking }),
                 ...(m.created_at && { timestamp: m.created_at }),
                 ...(m.id && { id: m.id }),
             }));
+            // Group consecutive tool_call messages into _isToolGroup
+            const preParsed: any[] = [];
+            for (const m of rawParsed) {
+                if ((m as any).role === 'tool_call') {
+                    const tc = { name: (m as any).toolName || '', args: (m as any).toolArgs || {}, result: (m as any).toolResult || '' };
+                    const last = preParsed[preParsed.length - 1];
+                    if (last && (last as any)._isToolGroup) {
+                        last.toolCalls = [...(last.toolCalls || []), tc];
+                    } else {
+                        preParsed.push({ role: 'assistant', content: '', toolCalls: [tc], _isToolGroup: true });
+                    }
+                } else {
+                    preParsed.push(m);
+                }
+            }
 
             if (!isAgentSession && sess.user_id === String(currentUser?.id)) {
                 setChatMessages(preParsed);
@@ -1342,7 +1357,7 @@ function AgentDetailInner() {
         } catch (e) { alert('Failed: ' + e); }
         setExpirySaving(false);
     };
-    interface ChatMsg { role: 'user' | 'assistant' | 'tool_call'; content: string; fileName?: string; toolName?: string; toolArgs?: any; toolStatus?: 'running' | 'done'; toolResult?: string; thinking?: string; imageUrl?: string; timestamp?: string; }
+    interface ChatMsg { role: 'user' | 'assistant' | 'tool_call'; content: string; fileName?: string; toolName?: string; toolArgs?: any; toolStatus?: 'running' | 'done'; toolResult?: string; thinking?: string; imageUrl?: string; timestamp?: string; _isToolGroup?: boolean; toolCalls?: { name: string; args: any; result?: string }[]; }
     const [chatMessages, setChatMessages] = useState<ChatMsg[]>([]);
     const [liveState, setLiveState] = useState<LivePreviewState>({});
     const [livePanelVisible, setLivePanelVisible] = useState(false);
@@ -1593,15 +1608,51 @@ function AgentDetailInner() {
                     setSessionListCollapsed(true);
                     useAppStore.setState({ sidebarCollapsed: true });
                 }
-                setChatMessages(prev => {
-                    const toolMsg: ChatMsg = { role: 'tool_call', content: '', toolName: d.name, toolArgs: d.args, toolStatus: d.status, toolResult: d.result };
-                    if (d.status === 'done') {
-                        const lastIdx = prev.length - 1;
-                        const last = prev[lastIdx];
-                        if (last && last.role === 'tool_call' && last.toolName === d.name && last.toolStatus === 'running') return [...prev.slice(0, lastIdx), toolMsg];
-                    }
-                    return [...prev, toolMsg];
-                });
+                if (d.status === 'running') {
+                    setChatMessages(prev => {
+                        let msgs = [...prev];
+                        while (msgs.length > 0) {
+                            const last = msgs[msgs.length - 1];
+                            if (last.role === 'assistant' && !(last as any)._isToolGroup && !(last as any)._streaming && !(last.content && last.content.trim()) && !last.thinking) {
+                                msgs.pop();
+                            } else break;
+                        }
+                        const tc = { name: d.name, args: d.args || {} };
+                        // Find recent tool group to merge into, but stop at user messages (new turn boundary)
+                        for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
+                            if (msgs[i].role === 'user') break; // New conversation turn — don't merge across
+                            if ((msgs[i] as any)._isToolGroup) {
+                                msgs[i] = { ...msgs[i], toolCalls: [...(msgs[i].toolCalls || []), tc] } as any;
+                                return msgs;
+                            }
+                        }
+                        return [...msgs, { role: 'assistant', content: '', toolCalls: [tc], _isToolGroup: true } as any];
+                    });
+                } else {
+                    setChatMessages(prev => {
+                        let msgs = [...prev];
+                        while (msgs.length > 0) {
+                            const last = msgs[msgs.length - 1];
+                            if (last.role === 'assistant' && !(last as any)._isToolGroup && !(last as any)._streaming && !(last.content && last.content.trim()) && !last.thinking) {
+                                msgs.pop();
+                            } else break;
+                        }
+                        const newCall = { name: d.name, args: d.args, result: d.result || '' };
+                        // Find recent tool group, but stop at user messages (new turn boundary)
+                        for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
+                            if (msgs[i].role === 'user') break; // New conversation turn — don't merge across
+                            if ((msgs[i] as any)._isToolGroup) {
+                                const existing = (msgs[i].toolCalls || []).map((tc: any) =>
+                                    tc.name === d.name && !tc.result ? newCall : tc
+                                );
+                                const hasIt = existing.some((tc: any) => tc.name === d.name && tc.result);
+                                msgs[i] = { ...msgs[i], toolCalls: hasIt ? existing : [...existing, newCall] } as any;
+                                return msgs;
+                            }
+                        }
+                        return [...msgs, { role: 'assistant', content: '', toolCalls: [newCall], _isToolGroup: true } as any];
+                    });
+                }
             } else if (d.type === 'chunk') {
                 setChatMessages(prev => {
                     const last = prev[prev.length - 1];
@@ -3017,7 +3068,76 @@ function AgentDetailInner() {
                                                                     <div style={{ padding: '12px 0', fontSize: '12px', color: 'var(--text-tertiary)' }}>Loading...</div>
                                                                 ) : (
                                                                     <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '8px' }}>
-                                                                        {msgs.map((msg: any, mi: number) => {
+                                                                        {msgs.filter((msg: any) => !(msg.role === 'assistant' && !msg._isToolGroup && !(msg.content && msg.content.trim()))).map((msg: any, mi: number) => {
+                                                                            if (msg._isToolGroup && msg.toolCalls?.length > 0) {
+                                                                                return (
+                                                                                    <details key={mi} style={{ borderRadius: '6px', background: 'var(--bg-secondary)', overflow: 'hidden' }}>
+                                                                                        <summary style={{
+                                                                                            padding: '5px 10px', fontSize: '11px', cursor: 'pointer',
+                                                                                            display: 'flex', alignItems: 'center', gap: '8px',
+                                                                                            listStyle: 'none', WebkitAppearance: 'none',
+                                                                                        } as any}>
+                                                                                            <span style={{ fontSize: '8px', color: 'var(--text-tertiary)', flexShrink: 0 }}>&#9654;</span>
+                                                                                            <span style={{
+                                                                                                fontWeight: 600, fontSize: '10px', color: 'var(--text-tertiary)',
+                                                                                                padding: '1px 6px', borderRadius: '3px',
+                                                                                                background: 'var(--bg-tertiary, rgba(0,0,0,0.06))',
+                                                                                                flexShrink: 0,
+                                                                                            }}>{msg.toolCalls.length} tool{msg.toolCalls.length > 1 ? 's' : ''}</span>
+                                                                                            <span style={{ display: 'flex', gap: '4px', overflow: 'hidden', flexWrap: 'nowrap' }}>
+                                                                                                {msg.toolCalls.slice(0, 4).map((tc: any, ti: number) => (
+                                                                                                    <span key={ti} style={{
+                                                                                                        fontFamily: 'monospace', fontSize: '10px', color: 'var(--text-primary)',
+                                                                                                        padding: '1px 5px', borderRadius: '3px',
+                                                                                                        background: 'var(--bg-tertiary, rgba(0,0,0,0.06))',
+                                                                                                        flexShrink: 0,
+                                                                                                    }}>{tc.name}</span>
+                                                                                                ))}
+                                                                                                {msg.toolCalls.length > 4 && <span style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>+{msg.toolCalls.length - 4}</span>}
+                                                                                            </span>
+                                                                                        </summary>
+                                                                                        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', padding: '6px 10px', borderTop: '1px solid var(--border-subtle)' }}>
+                                                                                            {msg.toolCalls.map((tc: any, ti: number) => {
+                                                                                                const argsStr = typeof tc.args === 'string' ? tc.args : JSON.stringify(tc.args || {}, null, 2);
+                                                                                                const resultStr = typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result || '', null, 2);
+                                                                                                return (
+                                                                                                    <details key={ti} style={{ borderRadius: '4px', background: 'var(--bg-primary, var(--bg-secondary))', overflow: 'hidden' }}>
+                                                                                                        <summary style={{
+                                                                                                            padding: '4px 8px', fontSize: '10px', cursor: 'pointer',
+                                                                                                            display: 'flex', alignItems: 'center', gap: '6px',
+                                                                                                            listStyle: 'none', WebkitAppearance: 'none',
+                                                                                                        } as any}>
+                                                                                                            <span style={{ fontSize: '7px', color: 'var(--text-tertiary)', flexShrink: 0 }}>&#9654;</span>
+                                                                                                            <span style={{
+                                                                                                                fontWeight: 600, fontFamily: 'monospace', fontSize: '10px',
+                                                                                                                color: 'var(--text-primary)', flexShrink: 0,
+                                                                                                            }}>{tc.name}</span>
+                                                                                                            <span style={{
+                                                                                                                color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: '10px',
+                                                                                                                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                                                                                                            }}>{argsStr.replace(/\n/g, ' ').substring(0, 60)}{argsStr.length > 60 ? '...' : ''}</span>
+                                                                                                        </summary>
+                                                                                                        <div style={{
+                                                                                                            padding: '6px 8px', borderTop: '1px solid var(--border-subtle)',
+                                                                                                            fontFamily: 'monospace', fontSize: '10px', lineHeight: 1.5,
+                                                                                                            whiteSpace: 'pre-wrap', maxHeight: '200px', overflow: 'auto',
+                                                                                                            color: 'var(--text-secondary)',
+                                                                                                        }}>
+                                                                                                            {argsStr}
+                                                                                                            {resultStr && (
+                                                                                                                <>
+                                                                                                                    <div style={{ borderTop: '1px dashed var(--border-subtle)', margin: '6px 0', opacity: 0.5 }} />
+                                                                                                                    <span style={{ color: 'var(--text-tertiary)' }}>→ </span>{resultStr.substring(0, 500)}
+                                                                                                                </>
+                                                                                                            )}
+                                                                                                        </div>
+                                                                                                    </details>
+                                                                                                );
+                                                                                            })}
+                                                                                        </div>
+                                                                                    </details>
+                                                                                );
+                                                                            }
                                                                             if (msg.role === 'tool_call') {
                                                                                 const tName = msg.toolName || (() => { try { return JSON.parse(msg.content || '{}').name; } catch { return ''; } })() || 'tool';
                                                                                 const tArgs = msg.toolArgs || (() => { try { return JSON.parse(msg.content || '{}').args; } catch { return {}; } })();
@@ -3762,6 +3882,86 @@ function AgentDetailInner() {
                                                 </div>
                                             )}
                                             {chatMessages.map((msg, i) => {
+                                                {/* Tool call chain — grouped consecutive tool calls */}
+                                                if ((msg as any)._isToolGroup && msg.toolCalls && msg.toolCalls.length > 0) {
+                                                    return (
+                                                        <div key={i} style={{ paddingLeft: '36px', marginBottom: '6px' }}>
+                                                            <details style={{
+                                                                borderRadius: '8px',
+                                                                background: 'rgba(99,102,241,0.06)',
+                                                                border: '1px solid rgba(99,102,241,0.18)',
+                                                                fontSize: '12px',
+                                                                overflow: 'hidden',
+                                                            }}>
+                                                                <summary style={{
+                                                                    padding: '7px 10px', cursor: 'pointer',
+                                                                    display: 'flex', alignItems: 'center', gap: '6px',
+                                                                    color: 'var(--accent-text, #818cf8)',
+                                                                    userSelect: 'none', listStyle: 'none',
+                                                                }}>
+                                                                    <span style={{ fontSize: '13px' }}>🔧</span>
+                                                                    <span style={{ flex: 1, fontWeight: 500 }}>Tool Call Chain</span>
+                                                                    <span style={{
+                                                                        background: 'rgba(99,102,241,0.18)', color: '#818cf8',
+                                                                        borderRadius: '10px', padding: '1px 7px',
+                                                                        fontSize: '10px', fontWeight: 600,
+                                                                    }}>{msg.toolCalls.length}</span>
+                                                                </summary>
+                                                                {/* Collapsed: tool name pills */}
+                                                                <div style={{ padding: '0 10px 7px 10px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                                                                    {msg.toolCalls.map((tc: any, j: number) => (
+                                                                        <span key={j} style={{
+                                                                            background: 'rgba(99,102,241,0.10)',
+                                                                            border: '1px solid rgba(99,102,241,0.15)',
+                                                                            borderRadius: '4px', padding: '1px 6px',
+                                                                            fontSize: '10px', color: '#a5b4fc',
+                                                                            fontFamily: 'var(--font-mono)',
+                                                                        }}>{tc.name}</span>
+                                                                    ))}
+                                                                </div>
+                                                                {/* Expanded: each tool's details */}
+                                                                <div style={{ borderTop: '1px solid rgba(99,102,241,0.15)' }}>
+                                                                    {msg.toolCalls.map((tc: any, j: number) => (
+                                                                        <details key={j} style={{
+                                                                            borderBottom: j < msg.toolCalls!.length - 1 ? '1px solid rgba(99,102,241,0.10)' : 'none',
+                                                                        }}>
+                                                                            <summary style={{
+                                                                                padding: '6px 10px', cursor: 'pointer',
+                                                                                display: 'flex', alignItems: 'center', gap: '5px',
+                                                                                userSelect: 'none', listStyle: 'none', fontSize: '11px',
+                                                                            }}>
+                                                                                <span style={{ width: '4px', height: '4px', borderRadius: '50%', background: tc.result ? '#818cf8' : '#f59e0b', flexShrink: 0 }} />
+                                                                                <span style={{ fontFamily: 'var(--font-mono)', color: '#818cf8', fontWeight: 600 }}>{tc.name}</span>
+                                                                                {!tc.result && <span style={{ color: 'var(--text-tertiary)', fontSize: '10px', marginLeft: 'auto' }}>{t('common.loading')}</span>}
+                                                                            </summary>
+                                                                            <div style={{ padding: '0 10px 6px 10px' }}>
+                                                                                {tc.args && Object.keys(tc.args).length > 0 && (
+                                                                                    <div style={{
+                                                                                        fontFamily: 'var(--font-mono)', fontSize: '10px',
+                                                                                        color: 'var(--text-tertiary)', whiteSpace: 'pre-wrap',
+                                                                                        wordBreak: 'break-all', maxHeight: '80px', overflowY: 'auto',
+                                                                                        background: 'rgba(0,0,0,0.12)', borderRadius: '4px',
+                                                                                        padding: '4px 6px', marginBottom: tc.result ? '4px' : 0,
+                                                                                    }}>{JSON.stringify(tc.args, null, 2)}</div>
+                                                                                )}
+                                                                                {tc.result && (
+                                                                                    <div style={{
+                                                                                        fontSize: '10px', color: 'var(--text-secondary)',
+                                                                                        whiteSpace: 'pre-wrap', wordBreak: 'break-all',
+                                                                                        maxHeight: '120px', overflowY: 'auto',
+                                                                                        background: 'rgba(0,0,0,0.08)', borderRadius: '4px',
+                                                                                        padding: '4px 6px',
+                                                                                    }}>{tc.result.length > 500 ? tc.result.slice(0, 500) + '…' : tc.result}</div>
+                                                                                )}
+                                                                            </div>
+                                                                        </details>
+                                                                    ))}
+                                                                </div>
+                                                            </details>
+                                                        </div>
+                                                    );
+                                                }
+                                                {/* Legacy individual tool_call (fallback) */}
                                                 if (msg.role === 'tool_call') {
                                                     return (
                                                         <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '6px', paddingLeft: '36px', minWidth: 0 }}>
@@ -3778,7 +3978,7 @@ function AgentDetailInner() {
                                                     );
                                                 }
                                                 {/* Assistant message with no text content: show inline thinking or skip */ }
-                                                if (msg.role === 'assistant' && !msg.content?.trim()) {
+                                                if (msg.role === 'assistant' && !(msg as any)._isToolGroup && !msg.content?.trim()) {
                                                     if (msg.thinking) {
                                                         return (
                                                             <div key={i} style={{ paddingLeft: '36px', marginBottom: '6px' }}>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -52,6 +52,7 @@ interface Message {
     thinking?: string;
     imageUrl?: string;
     timestamp?: string;
+    _isToolGroup?: boolean;
 }
 
 function ChatToolChain({ toolCalls }: { toolCalls: ToolCall[] }) {
@@ -222,11 +223,40 @@ export default function Chat() {
         })
             .then(r => r.json())
             .then((history: any[]) => {
-                if (history.length > 0) setMessages(history.map(h => {
-                    const msg = parseMessage({ role: h.role, content: h.content, fileName: h.fileName, toolCalls: h.toolCalls, thinking: h.thinking, imageUrl: h.imageUrl });
-                    msg.timestamp = h.created_at || undefined;
-                    return msg;
-                }));
+                if (history.length > 0) {
+                    // Group consecutive tool_call entries into _isToolGroup messages
+                    const processed: Message[] = [];
+                    for (const h of history) {
+                        if (h.role === 'tool_call') {
+                            const tc: ToolCall = {
+                                name: h.toolName || h.tool_name || '',
+                                args: h.toolArgs || h.tool_args || {},
+                                result: h.toolResult || h.tool_result || '',
+                            };
+                            const last = processed[processed.length - 1];
+                            if (last && last._isToolGroup) {
+                                // Merge into existing tool group
+                                last.toolCalls = [...(last.toolCalls || []), tc];
+                            } else if (last && last.role === 'assistant' && !(last.content && last.content.trim())) {
+                                // Previous is empty assistant — convert to tool group
+                                last._isToolGroup = true;
+                                last.toolCalls = [...(last.toolCalls || []), tc];
+                            } else {
+                                // Start new tool group
+                                processed.push({
+                                    role: 'assistant', content: '', toolCalls: [tc],
+                                    timestamp: h.created_at || undefined,
+                                    _isToolGroup: true,
+                                });
+                            }
+                        } else {
+                            const msg = parseMessage({ role: h.role, content: h.content, fileName: h.fileName, toolCalls: h.toolCalls, thinking: h.thinking, imageUrl: h.imageUrl });
+                            msg.timestamp = h.created_at || undefined;
+                            processed.push(msg);
+                        }
+                    }
+                    setMessages(processed);
+                }
             })
             .catch(() => { /* ignore */ });
     }, [id, token]);
@@ -322,15 +352,72 @@ export default function Chat() {
                         return [...prev, { role: 'assistant', content: streamContent.current, timestamp: new Date().toISOString() }];
                     });
                 } else if (data.type === 'tool_call') {
-                    // Debug: log all tool_call events to verify frontend code is current
-                    console.log('[ToolCall]', data.name, data.status, 'keys:', Object.keys(data).join(','));
-                    if (data.status === 'done') {
-                        pendingToolCalls.current.push({ name: data.name, args: data.args, result: data.result });
+                    console.log('[ToolCall]', data.name, data.status);
+                    if (data.status === 'running') {
+                        // Tool execution started — show in-progress in tool group
+                        const tc: ToolCall = { name: data.name, args: data.args || {} };
+                        pendingToolCalls.current.push(tc);
+                        const now = new Date().toISOString();
+                        setMessages(prev => {
+                            let msgs = [...prev];
+                            // Remove trailing empty assistant messages (stream placeholders)
+                            while (msgs.length > 0) {
+                                const last = msgs[msgs.length - 1];
+                                if (last.role === 'assistant' && !last._isToolGroup && !(last.content && last.content.trim())) {
+                                    msgs.pop();
+                                } else break;
+                            }
+                            // Merge into existing tool group, but stop at user messages (new turn)
+                            for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
+                                if (msgs[i].role === 'user') break;
+                                if (msgs[i]._isToolGroup) {
+                                    msgs[i] = { ...msgs[i], toolCalls: [...(msgs[i].toolCalls || []), tc], timestamp: now };
+                                    return msgs;
+                                }
+                            }
+                            return [...msgs, { role: 'assistant', content: '', toolCalls: [tc], timestamp: now, _isToolGroup: true }];
+                        });
+                    } else if (data.status === 'done') {
+                        // Tool execution finished — update result
+                        streamContent.current = '';
+                        thinkingContent.current = '';
+                        const newCall: ToolCall = { name: data.name, args: data.args, result: data.result || '' };
+                        // Update pending: replace running entry or add new
+                        const idx = pendingToolCalls.current.findIndex(tc => tc.name === data.name && !tc.result);
+                        if (idx >= 0) {
+                            pendingToolCalls.current[idx] = newCall;
+                        } else {
+                            pendingToolCalls.current.push(newCall);
+                        }
+                        const now = new Date().toISOString();
+                        setMessages(prev => {
+                            let msgs = [...prev];
+                            // Remove trailing empty assistant messages
+                            while (msgs.length > 0) {
+                                const last = msgs[msgs.length - 1];
+                                if (last.role === 'assistant' && !last._isToolGroup && !(last.content && last.content.trim())) {
+                                    msgs.pop();
+                                } else break;
+                            }
+                            // Find recent tool group, but stop at user messages (new turn)
+                            for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
+                                if (msgs[i].role === 'user') break;
+                                if (msgs[i]._isToolGroup) {
+                                    // Update the matching tool call with result, or add new
+                                    const existing = (msgs[i].toolCalls || []).map(tc =>
+                                        tc.name === data.name && !tc.result ? newCall : tc
+                                    );
+                                    const hasIt = existing.some(tc => tc.name === data.name && tc.result);
+                                    msgs[i] = { ...msgs[i], toolCalls: hasIt ? existing : [...existing, newCall], timestamp: now };
+                                    return msgs;
+                                }
+                            }
+                            return [...msgs, { role: 'assistant', content: '', toolCalls: [newCall], timestamp: now, _isToolGroup: true }];
+                        });
 
                         // ── AgentBay live preview (embedded in tool_call) ──
                         if (data.live_preview) {
                             const lp = data.live_preview;
-                            console.log('[LivePreview] Got from tool_call:', lp.env, lp.screenshot_url?.substring(0, 60));
                             setLiveState(prev => {
                                 const next = { ...prev };
                                 if ((lp.env === 'desktop' || lp.env === 'browser') && lp.screenshot_url) {
@@ -524,7 +611,19 @@ export default function Chat() {
                             <div style={{ fontSize: '12px', marginTop: '8px', opacity: 0.7 }}>{t('agent.chat.fileSupport')}</div>
                         </div>
                     )}
-                    {messages.map((msg, i) => (
+                    {messages.filter(m => {
+                        // Skip empty assistant messages (stream placeholders)
+                        if (m.role === 'assistant' && !m._isToolGroup && !(m.content && m.content.trim()) && !m.toolCalls?.length && !m.thinking) return false;
+                        return true;
+                    }).map((msg, i) => (
+                        msg._isToolGroup ? (
+                            /* Tool call group — compact display without avatar bubble */
+                            <div key={i} style={{ marginLeft: '48px', marginBottom: '8px' }}>
+                                {msg.toolCalls && msg.toolCalls.length > 0 && (
+                                    <ChatToolChain toolCalls={msg.toolCalls} />
+                                )}
+                            </div>
+                        ) :
                         <div key={i} className={`chat-message ${msg.role}`}>
                             <div className="chat-avatar" style={{ color: 'var(--text-tertiary)' }}>
                                 {msg.role === 'user' ? Icons.user : Icons.bot}


### PR DESCRIPTION
## Summary

### 🔧 Tool Call Chain — Collapse consecutive tool calls into an expandable chain
When an agent makes multiple consecutive tool calls (e.g., searching the web, reading files, executing code), they are now grouped into a single collapsible "Tool Call Chain" card instead of rendering each tool call as a separate card.

### Why
- Reduced visual noise: 5-10 tool calls no longer dominate the chat, keeping focus on the agent's final response
- Better scanability: Collapsed state shows tool count badge + name pills at a glance; expand only when details are needed
- Consistent UX: Both real-time streaming and history loading produce the same grouped view
- No information loss: Every tool's arguments and result remain accessible via nested expand
- Turn-aware grouping: Tool calls from different conversation turns are grouped separately — a new user message starts a new tool chain

### Changes

#### Chat.tsx (standalone chat page)
- Added ChatToolChain component with indigo theme, count badge, name pills (collapsed) and per-tool args/result (expanded)
- WebSocket tool_call events (running/done) merge into _isToolGroup messages instead of individual entries
- History loading groups consecutive tool_call records into tool chains
- Empty assistant placeholder messages filtered from render
- AgentDetail.tsx (main agent page chat tab)


#### AgentDetail.tsx (main agent page chat tab)
- ChatMsg interface extended with _isToolGroup and toolCalls fields
- WebSocket handler merges running/done tool_call events into tool groups
- History post-processing collapses consecutive tool_call messages
- Rendering: _isToolGroup messages render as collapsible tool chain; legacy individual tool_call cards kept as fallback
- Reflection session messages also support tool chain grouping

#### Original Tool Call:
<img width="2010" height="1516" alt="image" src="https://github.com/user-attachments/assets/88a5d67f-1160-4150-9dae-083ea1934338" />

#### Using Toll Chain merge:
Tool Chain Unfold:
<img width="1504" height="1008" alt="chain_unfold2" src="https://github.com/user-attachments/assets/51d2d106-0033-4306-a3d6-de7665849bee" />

Tool Chain Fold:
<img width="2332" height="1307" alt="chain_fold" src="https://github.com/user-attachments/assets/4ce29f5d-0297-455e-ac97-db0172375f82" />

--- 


### 🔧 工具调用链 — 多工具连续调用折叠为可展开工具链
当智能体连续发起多次工具调用（如搜索网页、读取文件、执行代码）时，这些调用现在会被合并为一个可折叠的"工具调用链"卡片，而非每个工具调用单独显示一张卡片。

###  为什么
- 减少视觉噪音：5-10 次工具调用不再占满聊天区域，用户可以聚焦于智能体的最终回复
- 更好的可读性：折叠状态一眼可见工具数量和名称标签，需要时再展开查看详情
- 一致的体验：实时流式和历史加载均呈现相同的分组视图
- 无信息丢失：每个工具的参数和结果均可通过嵌套展开访问
- 按对话轮次分组：不同对话轮次的工具调用独立分组，用户发新消息后会创建新的工具链

### 改动项

#### Chat.tsx（独立聊天页）

- 新增 ChatToolChain 组件，indigo 主题色，折叠时显示计数徽章和工具名标签，展开时显示每个工具的参数和结果
- WebSocket tool_call 事件（running/done）合并到 _isToolGroup 消息，而非单独条目
- 历史加载时连续 tool_call 记录合并为工具链
- 过滤空的 assistant 占位消息

#### AgentDetail.tsx（智能体详情页聊天标签）

- ChatMsg 接口扩展 _isToolGroup 和 toolCalls 字段
- WebSocket 处理器将 running/done 工具调用事件合并到工具组
- 历史后处理折叠连续 tool_call 消息
- 渲染：_isToolGroup 消息显示为可折叠工具链；保留旧版单独 tool_call 卡片作为兼容回退
- 回顾会话消息同样支持工具链分组

#### Checklist
[x] Tested locally
[x] No unrelated changes included