### PR TITLE
fix(chat): tighten session access and polish admin chat ui

### DIFF
--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import check_agent_access
 from app.core.security import get_current_user
 from app.database import get_db
 from app.models.audit import ChatMessage
@@ -24,6 +25,11 @@ def _is_admin_or_creator(user: User, agent: Agent) -> bool:
         user.role in ("platform_admin", "org_admin")
         or str(agent.creator_id) == str(user.id)
     )
+
+
+def _can_view_all_agent_chat_sessions(user: User) -> bool:
+    """Only admin roles may list/view/delete other users' chat sessions."""
+    return user.role in ("platform_admin", "org_admin", "agent_admin")
 
 
 class SessionOut(BaseModel):
@@ -63,15 +69,16 @@ async def list_sessions(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """List chat sessions for an agent. 'all' requires admin or creator role."""
+    """List chat sessions for an agent. scope=all for org/platform admins and agent_admin."""
     # Verify agent exists
     agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
     agent = agent_result.scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=404, detail="Agent not found")
+    await check_agent_access(db, current_user, agent_id)
 
     if scope == "all":
-        if not _is_admin_or_creator(current_user, agent):
+        if not _can_view_all_agent_chat_sessions(current_user):
             raise HTTPException(status_code=403, detail="Not authorized to view all sessions")
 
         # Fetch all sessions (including agent-to-agent where this agent is peer)
@@ -198,10 +205,7 @@ async def create_session(
     db: AsyncSession = Depends(get_db),
 ):
     """Create a new chat session for the current user."""
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-    if not agent:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await check_agent_access(db, current_user, agent_id)
 
     now = datetime.now(tz.utc)
     new_id = uuid.uuid4()
@@ -210,6 +214,7 @@ async def create_session(
         agent_id=agent_id,
         user_id=current_user.id,
         title=body.title or f"Session {now.strftime('%m-%d %H:%M')}",
+        source_channel="web",
         created_at=now,
     )
     db.add(session)
@@ -219,10 +224,13 @@ async def create_session(
         id=str(session.id),
         agent_id=str(session.agent_id),
         user_id=str(session.user_id),
+        source_channel=session.source_channel,
         title=session.title,
         created_at=session.created_at.isoformat(),
         last_message_at=None,
         message_count=0,
+        participant_type="user",
+        is_group=False,
     )
 
 
@@ -234,7 +242,8 @@ async def rename_session(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Rename a session. Only owner, admin, or creator can rename."""
+    """Rename a session. Owner, or org/platform admin (others' sessions)."""
+    await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
         select(ChatSession).where(ChatSession.id == session_id, ChatSession.agent_id == agent_id)
     )
@@ -242,10 +251,7 @@ async def rename_session(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-
-    if str(session.user_id) != str(current_user.id) and not _is_admin_or_creator(current_user, agent):
+    if str(session.user_id) != str(current_user.id) and not _can_view_all_agent_chat_sessions(current_user):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     session.title = body.title
@@ -260,7 +266,8 @@ async def delete_session(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete a chat session and its messages. Owner, admin, or creator only."""
+    """Delete a chat session and its messages. Owner, or org/platform admin (others' sessions)."""
+    await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
         select(ChatSession).where(ChatSession.id == session_id, ChatSession.agent_id == agent_id)
     )
@@ -268,10 +275,7 @@ async def delete_session(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-
-    if str(session.user_id) != str(current_user.id) and not _is_admin_or_creator(current_user, agent):
+    if str(session.user_id) != str(current_user.id) and not _can_view_all_agent_chat_sessions(current_user):
         raise HTTPException(status_code=403, detail="Not authorized")
 
     # Delete associated messages first
@@ -290,6 +294,7 @@ async def get_session_messages(
     db: AsyncSession = Depends(get_db),
 ):
     """Get chat messages for a specific session."""
+    await check_agent_access(db, current_user, agent_id)
     # Allow looking up sessions where agent_id OR peer_agent_id matches
     result = await db.execute(
         select(ChatSession).where(
@@ -301,10 +306,8 @@ async def get_session_messages(
     if not session:
         raise HTTPException(status_code=404, detail="Session not found")
 
-    # Permission: owner, admin, or creator can view
-    agent_result = await db.execute(select(Agent).where(Agent.id == agent_id))
-    agent = agent_result.scalar_one_or_none()
-    if str(session.user_id) != str(current_user.id) and not _is_admin_or_creator(current_user, agent):
+    # Permission: session owner, or any user with manage access to the viewed agent.
+    if str(session.user_id) != str(current_user.id) and not _can_view_all_agent_chat_sessions(current_user):
         raise HTTPException(status_code=403, detail="Not authorized to view this session")
 
     # Query messages by conversation_id only (agent-to-agent uses session_agent_id)

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -516,16 +516,26 @@ async def websocket_chat(
             from datetime import datetime as _dt, timezone as _tz
             conv_id = session_id
             if conv_id:
-                # Validate the session belongs to this agent
-                _sr = await db.execute(
-                    _sel(ChatSession).where(
-                        ChatSession.id == uuid.UUID(conv_id),
-                        ChatSession.agent_id == agent_id,
+                # Validate the session belongs to this agent and to this user (no hijacking others' sessions).
+                try:
+                    _sid = uuid.UUID(conv_id)
+                except (ValueError, TypeError):
+                    conv_id = None
+                    _existing = None
+                else:
+                    _sr = await db.execute(
+                        _sel(ChatSession).where(
+                            ChatSession.id == _sid,
+                            ChatSession.agent_id == agent_id,
+                        )
                     )
-                )
-                _existing = _sr.scalar_one_or_none()
-                if not _existing:
-                    conv_id = None  # fall through to create
+                    _existing = _sr.scalar_one_or_none()
+                    if not _existing:
+                        conv_id = None
+                    elif _existing.source_channel != "agent" and str(_existing.user_id) != str(user_id):
+                        await websocket.send_json({"type": "error", "content": "Not authorized for this session"})
+                        await websocket.close(code=4003)
+                        return
             if not conv_id:
                 # Find most recent session for this user+agent
                 _sr = await db.execute(

--- a/backend/tests/test_chat_sessions_api.py
+++ b/backend/tests/test_chat_sessions_api.py
@@ -1,0 +1,177 @@
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import chat_sessions as chat_sessions_api
+
+
+class DummyResult:
+    def __init__(self, values=None, scalar_value=None):
+        self._values = list(values or [])
+        self._scalar_value = scalar_value
+
+    def scalar_one_or_none(self):
+        if self._values:
+            return self._values[0]
+        return self._scalar_value
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._values)
+
+    def scalar(self):
+        if self._scalar_value is not None:
+            return self._scalar_value
+        return self._values[0] if self._values else None
+
+
+class RecordingDB:
+    def __init__(self, responses=None):
+        self.responses = list(responses or [])
+        self.added = []
+        self.committed = False
+        self.refreshed = []
+
+    async def execute(self, _statement, _params=None):
+        if not self.responses:
+            raise AssertionError("unexpected execute() call")
+        return self.responses.pop(0)
+
+    def add(self, value):
+        self.added.append(value)
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, value):
+        self.refreshed.append(value)
+
+
+@pytest.mark.asyncio
+async def test_org_admin_can_list_all_sessions(monkeypatch):
+    viewer_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    owner_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    current_user = SimpleNamespace(id=viewer_id, role="org_admin")
+    agent = SimpleNamespace(id=agent_id, creator_id=uuid.uuid4())
+    session = SimpleNamespace(
+        id=uuid.uuid4(),
+        agent_id=agent_id,
+        user_id=owner_id,
+        source_channel="web",
+        title="Customer follow-up",
+        created_at=now,
+        last_message_at=now,
+        peer_agent_id=None,
+        is_group=False,
+        group_name=None,
+    )
+    db = RecordingDB(
+        responses=[
+            DummyResult([agent]),
+            DummyResult([session]),
+            DummyResult(scalar_value=3),
+            DummyResult(scalar_value="Alice"),
+        ]
+    )
+
+    async def fake_check_agent_access(_db, _user, _agent_id):
+        return agent, "use"
+
+    monkeypatch.setattr(chat_sessions_api, "check_agent_access", fake_check_agent_access)
+
+    sessions = await chat_sessions_api.list_sessions(
+        agent_id=agent_id,
+        scope="all",
+        current_user=current_user,
+        db=db,
+    )
+
+    assert len(sessions) == 1
+    assert sessions[0].id == str(session.id)
+    assert sessions[0].user_id == str(owner_id)
+    assert sessions[0].username == "Alice"
+
+
+@pytest.mark.asyncio
+async def test_org_admin_can_view_other_users_session_messages(monkeypatch):
+    viewer_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    owner_id = uuid.uuid4()
+    session_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    current_user = SimpleNamespace(id=viewer_id, role="org_admin")
+    session = SimpleNamespace(
+        id=session_id,
+        agent_id=agent_id,
+        peer_agent_id=None,
+        user_id=owner_id,
+        source_channel="web",
+    )
+    message = SimpleNamespace(
+        role="user",
+        content="hello",
+        created_at=now,
+        participant_id=None,
+    )
+    db = RecordingDB(
+        responses=[
+            DummyResult([session]),
+            DummyResult([message]),
+        ]
+    )
+
+    async def fake_check_agent_access(_db, _user, _agent_id):
+        return SimpleNamespace(id=agent_id), "use"
+
+    monkeypatch.setattr(chat_sessions_api, "check_agent_access", fake_check_agent_access)
+
+    messages = await chat_sessions_api.get_session_messages(
+        agent_id=agent_id,
+        session_id=session_id,
+        current_user=current_user,
+        db=db,
+    )
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": "hello",
+            "created_at": now.isoformat(),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_web_session_shape(monkeypatch):
+    user_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+
+    current_user = SimpleNamespace(id=user_id, role="member")
+    db = RecordingDB()
+
+    async def fake_check_agent_access(_db, _user, _agent_id):
+        return SimpleNamespace(id=agent_id), "use"
+
+    monkeypatch.setattr(chat_sessions_api, "check_agent_access", fake_check_agent_access)
+
+    session = await chat_sessions_api.create_session(
+        agent_id=agent_id,
+        current_user=current_user,
+        db=db,
+    )
+
+    assert session.agent_id == str(agent_id)
+    assert session.user_id == str(user_id)
+    assert session.source_channel == "web"
+    assert session.participant_type == "user"
+    assert session.is_group is False
+    assert db.committed is True
+    assert len(db.added) == 1

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -372,8 +372,15 @@
       "cancel": "Cancel"
     },
     "chat": {
+      "sessionListTitle": "Session list",
+      "collapseSidebar": "Collapse session list",
       "mySessions": "My Sessions",
       "allUsers": "All Users",
+      "viewOtherUsersSessions": "View other users' sessions",
+      "otherUsersTab": "Other users",
+      "selectUserToView": "Select user",
+      "selectUserFirstHint": "Choose a user above to view their sessions with this agent (read-only).",
+      "noOtherUsersSessions": "No other users have sessions with this agent yet.",
       "newSession": "New Session",
       "noSessionsYet": "No sessions yet.",
       "clickToStart": "Click \"New Session\" to start.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -379,8 +379,15 @@
       "cancel": "取消"
     },
     "chat": {
+      "sessionListTitle": "会话列表",
+      "collapseSidebar": "收起会话列表",
       "mySessions": "我的会话",
       "allUsers": "所有用户",
+      "viewOtherUsersSessions": "查看其他用户会话",
+      "otherUsersTab": "其他用户",
+      "selectUserToView": "选择用户",
+      "selectUserFirstHint": "请先选择用户，查看其与该数字员工的会话（只读）。",
+      "noOtherUsersSessions": "暂无其他用户与该数字员工的会话。",
       "newSession": "新建会话",
       "noSessionsYet": "还没有会话。",
       "clickToStart": "点击\"新建会话\"开始。",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1044,6 +1044,25 @@ select:focus {
   border-bottom-color: var(--accent-primary);
 }
 
+/* Session sidebar admin tabs — same underline pattern as .tabs/.tab, compact for narrow column */
+.tabs.session-sidebar-session-tabs {
+  gap: var(--space-5);
+  margin-bottom: var(--space-2);
+  margin-top: 0;
+  padding: 2px 12px 0;
+  position: relative;
+  background: transparent;
+  z-index: auto;
+  top: auto;
+}
+
+.tabs.session-sidebar-session-tabs .tab {
+  flex: 0 1 auto;
+  padding: var(--space-2) var(--space-1) 10px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 /* Page header */
 .page-header {
   display: flex;
@@ -1892,7 +1911,7 @@ select:focus {
   flex-direction: column;
   min-height: 80px;
   border: 1px solid var(--border-default);
-  border-radius: 12px;
+  border-radius: 8px;
   background: var(--bg-primary);
   overflow: hidden;
   transition: border-color 150ms ease, box-shadow 150ms ease;
@@ -2117,7 +2136,7 @@ select:focus {
   min-height: 40px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 0 14px;
   font-size: 14px;
   color: var(--text-primary);

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, Component, ErrorInfo } from 'react';
+import React, { useState, useEffect, useMemo, useRef, Component, ErrorInfo } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -354,7 +354,7 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                                             </span>
                                         </label>
                                     ) : (
-                                        <span style={{ fontSize: '11px', color: tool.enabled ? '#22c55e' : 'var(--text-tertiary)', fontWeight: 500 }}>
+                                        <span style={{ fontSize: '11px', color: tool.enabled ? 'var(--accent-primary)' : 'var(--text-tertiary)', fontWeight: 500 }}>
                                             {tool.enabled ? t('common.enabled', 'On') : t('common.disabled', 'Off')}
                                         </span>
                                     )}
@@ -473,7 +473,7 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                                                             />
                                                             <span style={{
                                                                 position: 'absolute', inset: 0,
-                                                                background: (configData[field.key] ?? field.default) ? '#22c55e' : 'var(--bg-tertiary)',
+                                                                background: (configData[field.key] ?? field.default) ? 'var(--accent-primary)' : 'var(--bg-tertiary)',
                                                                 borderRadius: '11px', transition: 'background 0.2s', opacity: isReadOnly ? 0.6 : 1,
                                                             }}>
                                                                 <span style={{
@@ -1124,6 +1124,11 @@ function AgentDetailInner() {
     const token = useAuthStore((s) => s.token);
     const currentUser = useAuthStore((s) => s.user);
     const isAdmin = currentUser?.role === 'platform_admin' || currentUser?.role === 'org_admin';
+    /** Chat sidebar: who may list all sessions & read others' threads (matches backend scope=all). */
+    const canViewAllAgentChatSessions =
+        currentUser?.role === 'platform_admin' ||
+        currentUser?.role === 'org_admin' ||
+        currentUser?.role === 'agent_admin';
     type SessionRuntimeKey = string;
     const wsMapRef = useRef<Record<SessionRuntimeKey, WebSocket>>({});
     const reconnectTimerRef = useRef<Record<SessionRuntimeKey, ReturnType<typeof setTimeout> | null>>({});
@@ -1133,7 +1138,6 @@ function AgentDetailInner() {
     const currentAgentIdRef = useRef<string | undefined>(id);
     const sessionMsgAbortRef = useRef<AbortController | null>(null);
     const sessionLoadSeqRef = useRef(0);
-    const chatInputAreaRef = useRef<HTMLDivElement>(null);
 
     const buildSessionRuntimeKey = (agentId: string, sessionId: string) => `${agentId}:${sessionId}`;
 
@@ -1159,16 +1163,99 @@ function AgentDetailInner() {
         sessionUiStateRef.current[key] = { ...prev, ...next };
     };
 
-    const isWritableSession = (sess: any) => {
+    /** Normalize IDs — API/JSON may use number vs string; loose equality was breaking "own session" detection. */
+    const sessionUserIdStr = (s: any) => (s?.user_id == null ? '' : String(s.user_id));
+    const viewerUserIdStr = () => (currentUser?.id == null ? '' : String(currentUser.id));
+
+    /** Ensure session shape from POST/list so P2P "mine" is never mistaken for read-only or agent thread. */
+    const normalizeChatSession = (sess: any) => {
+        if (!sess || typeof sess !== 'object') return sess;
+        const vu = viewerUserIdStr();
+        const rawUid =
+            sess.user_id != null && String(sess.user_id).trim() !== '' ? String(sess.user_id) : vu;
+        return {
+            ...sess,
+            id: String(sess.id),
+            agent_id: sess.agent_id != null ? String(sess.agent_id) : sess.agent_id,
+            user_id: rawUid,
+            source_channel:
+                typeof sess.source_channel === 'string' && sess.source_channel.trim()
+                    ? sess.source_channel
+                    : 'web',
+            participant_type:
+                typeof sess.participant_type === 'string' && sess.participant_type.trim()
+                    ? sess.participant_type
+                    : 'user',
+            is_group: Boolean(sess.is_group),
+        };
+    };
+
+    const isWritableSession = (sess: any, scopeOverride: 'mine' | 'all' = chatScope) => {
         if (!sess) return false;
-        const isAgentSession = sess.source_channel === 'agent' || sess.participant_type === 'agent';
-        if (isAgentSession) return false;
-        if (sess.user_id && currentUser && sess.user_id !== String(currentUser.id)) return false;
+        const sc = String(sess.source_channel || 'web').toLowerCase();
+        const pt = String(sess.participant_type || 'user').toLowerCase();
+        if (sc === 'agent' || pt === 'agent') return false;
+        if (sess.is_group) return false;
+        if (canViewAllAgentChatSessions && scopeOverride === 'all') return false;
+        const su = sessionUserIdStr(sess);
+        const vu = viewerUserIdStr();
+        if (su && vu && su !== vu) return false;
         return true;
     };
 
-    const isViewingOtherUsersSessions = isAdmin && chatScope === 'all';
+    const isViewingOtherUsersSessions = canViewAllAgentChatSessions && chatScope === 'all';
 
+    /** Sessions in scope=all that are not the current viewer's own P2P rows (for admin「其他用户」tab). */
+    const otherUsersSessions = useMemo(() => {
+        const vu = viewerUserIdStr();
+        return allSessions.filter((s: any) => {
+            const su = sessionUserIdStr(s);
+            if (vu && su === vu) return false;
+            return true;
+        });
+    }, [allSessions, currentUser?.id]);
+
+    const otherUserPickerOptions = useMemo(() => {
+        const m = new Map<string, string>();
+        for (const s of otherUsersSessions) {
+            const uid = sessionUserIdStr(s);
+            if (!uid) continue;
+            if (!m.has(uid)) m.set(uid, String(s.username || s.user_id || uid));
+        }
+        return [...m.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+    }, [otherUsersSessions]);
+
+    const othersListForPicker = useMemo(() => {
+        if (!allUserFilter) return otherUsersSessions;
+        return otherUsersSessions.filter((s: any) => sessionUserIdStr(s) === allUserFilter);
+    }, [otherUsersSessions, allUserFilter]);
+
+    useEffect(() => {
+        if (!canViewAllAgentChatSessions && chatScope === 'all') setChatScope('mine');
+    }, [canViewAllAgentChatSessions, chatScope]);
+
+    const clearChatSelection = () => {
+        activeSessionIdRef.current = null;
+        setActiveSession(null);
+        setChatMessages([]);
+        setHistoryMsgs([]);
+        setWsConnected(false);
+        setIsStreaming(false);
+        setIsWaiting(false);
+    };
+
+    const onAdminTabMine = () => {
+        setChatScope('mine');
+        setAllUserFilter('');
+        if (activeSession && sessionUserIdStr(activeSession) !== viewerUserIdStr()) clearChatSelection();
+    };
+
+    const onAdminTabOthers = () => {
+        setChatScope('all');
+        setAllUserFilter('');
+        fetchAllSessions();
+        if (activeSession && sessionUserIdStr(activeSession) === viewerUserIdStr()) clearChatSelection();
+    };
     const syncActiveSocketState = (sess: any | null = activeSession, agentId: string | undefined = id) => {
         if (!sess || !agentId) {
             wsRef.current = null;
@@ -1188,7 +1275,7 @@ function AgentDetailInner() {
             const tkn = localStorage.getItem('token');
             const res = await fetch(`/api/agents/${agentId}/sessions?scope=mine`, { headers: { Authorization: `Bearer ${tkn}` } });
             if (res.ok) {
-                const data = await res.json();
+                const data = (await res.json()).map((row: any) => normalizeChatSession(row));
                 if (currentAgentIdRef.current === agentId) setSessions(data);
                 if (!silent && currentAgentIdRef.current === agentId) setSessionsLoading(false);
                 return data;
@@ -1199,22 +1286,32 @@ function AgentDetailInner() {
     };
 
     const fetchAllSessions = async () => {
-        if (!id) return;
+        if (!id || !canViewAllAgentChatSessions) return;
         setAllSessionsLoading(true);
         try {
             const tkn = localStorage.getItem('token');
             const res = await fetch(`/api/agents/${id}/sessions?scope=all`, { headers: { Authorization: `Bearer ${tkn}` } });
+            if (!currentAgentIdRef.current || currentAgentIdRef.current !== id) return;
             if (res.ok) {
-                const all = await res.json();
-                if (currentAgentIdRef.current === id) {
-                    setAllSessions(all.filter((s: any) => s.source_channel !== 'trigger'));
+                const all = (await res.json())
+                    .filter((s: any) => String(s.source_channel || 'direct').toLowerCase() !== 'trigger')
+                    .map((row: any) => normalizeChatSession(row));
+                setAllSessions(all);
+            } else {
+                setAllSessions([]);
+                if (res.status === 403) {
+                    console.warn('[chat] scope=all sessions forbidden (need org/platform/agent admin)');
                 }
             }
-        } catch { }
-        setAllSessionsLoading(false);
+        } catch {
+            if (currentAgentIdRef.current === id) setAllSessions([]);
+        } finally {
+            setAllSessionsLoading(false);
+        }
     };
 
-    const selectSession = async (sess: any) => {
+    const selectSession = async (rawSess: any, scopeOverride: 'mine' | 'all' = chatScope) => {
+        const sess = normalizeChatSession(rawSess);
         const targetAgentId = id;
         if (!targetAgentId) return;
         const runtimeKey = buildSessionRuntimeKey(targetAgentId, String(sess.id));
@@ -1244,31 +1341,15 @@ function AgentDetailInner() {
             if (controller.signal.aborted || loadSeq !== sessionLoadSeqRef.current) return;
             if (currentAgentIdRef.current !== targetAgentId) return;
             if (activeSessionIdRef.current !== sess.id) return;
-            const isAgentSession = sess.source_channel === 'agent' || sess.participant_type === 'agent';
-            const rawParsed = msgs.map((m: any) => parseChatMsg({
+            const preParsed = msgs.map((m: any) => parseChatMsg({
                 role: m.role, content: m.content || '',
                 ...(m.toolName && { toolName: m.toolName, toolArgs: m.toolArgs, toolStatus: m.toolStatus, toolResult: m.toolResult }),
                 ...(m.thinking && { thinking: m.thinking }),
                 ...(m.created_at && { timestamp: m.created_at }),
                 ...(m.id && { id: m.id }),
             }));
-            // Group consecutive tool_call messages into _isToolGroup
-            const preParsed: any[] = [];
-            for (const m of rawParsed) {
-                if ((m as any).role === 'tool_call') {
-                    const tc = { name: (m as any).toolName || '', args: (m as any).toolArgs || {}, result: (m as any).toolResult || '' };
-                    const last = preParsed[preParsed.length - 1];
-                    if (last && (last as any)._isToolGroup) {
-                        last.toolCalls = [...(last.toolCalls || []), tc];
-                    } else {
-                        preParsed.push({ role: 'assistant', content: '', toolCalls: [tc], _isToolGroup: true });
-                    }
-                } else {
-                    preParsed.push(m);
-                }
-            }
 
-            if (!isAgentSession && sess.user_id === String(currentUser?.id)) {
+            if (isWritableSession(sess, scopeOverride)) {
                 setChatMessages(preParsed);
             } else {
                 setHistoryMsgs(preParsed);
@@ -1288,11 +1369,12 @@ function AgentDetailInner() {
                 body: JSON.stringify({}),
             });
             if (res.ok) {
-                const newSess = await res.json();
-                setSessions(prev => [newSess, ...prev]);
+                const newSess = normalizeChatSession(await res.json());
+                setChatScope('mine');
+                setSessions((prev) => [newSess, ...prev]);
                 setIsStreaming(false);
                 setIsWaiting(false);
-                await selectSession(newSess);
+                await selectSession(newSess, 'mine');
             } else {
                 const err = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
                 console.error('Failed to create session:', err);
@@ -1321,7 +1403,7 @@ function AgentDetailInner() {
                 setIsWaiting(false);
             }
             await fetchMySessions(false, id);
-            await fetchAllSessions();
+            if (canViewAllAgentChatSessions) await fetchAllSessions();
         } catch (e: any) {
             alert(e.message || 'Delete failed');
         }
@@ -1360,7 +1442,7 @@ function AgentDetailInner() {
         } catch (e) { alert('Failed: ' + e); }
         setExpirySaving(false);
     };
-    interface ChatMsg { role: 'user' | 'assistant' | 'tool_call'; content: string; fileName?: string; toolName?: string; toolArgs?: any; toolStatus?: 'running' | 'done'; toolResult?: string; thinking?: string; imageUrl?: string; timestamp?: string; _isToolGroup?: boolean; toolCalls?: { name: string; args: any; result?: string }[]; }
+    interface ChatMsg { role: 'user' | 'assistant' | 'tool_call'; content: string; fileName?: string; toolName?: string; toolArgs?: any; toolStatus?: 'running' | 'done'; toolResult?: string; thinking?: string; imageUrl?: string; timestamp?: string; }
     const [chatMessages, setChatMessages] = useState<ChatMsg[]>([]);
     const [liveState, setLiveState] = useState<LivePreviewState>({});
     const [livePanelVisible, setLivePanelVisible] = useState(false);
@@ -1377,6 +1459,7 @@ function AgentDetailInner() {
     const chatEndRef = useRef<HTMLDivElement>(null);
     const chatContainerRef = useRef<HTMLDivElement>(null);
     const chatInputRef = useRef<HTMLTextAreaElement>(null);
+    const chatInputAreaRef = useRef<HTMLDivElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     // Settings form local state
@@ -1485,18 +1568,48 @@ function AgentDetailInner() {
         setWsConnected(false);
         wsRef.current = null;
         setChatScope('mine');
+        setAllUserFilter('');
+        setSessions([]);
+        setAllSessions([]);
         setAgentExpired(false);
         settingsInitRef.current = false;
     }, [id]);
+
+    // Switching login account or token must not leave another user's sessions/messages in memory.
+    useEffect(() => {
+        setSessions([]);
+        setAllSessions([]);
+        setAllUserFilter('');
+        setChatScope('mine');
+        sessionMsgAbortRef.current?.abort();
+        activeSessionIdRef.current = null;
+        setActiveSession(null);
+        setChatMessages([]);
+        setHistoryMsgs([]);
+        setWsConnected(false);
+        setIsStreaming(false);
+        setIsWaiting(false);
+        setSessionsLoading(false);
+        setAllSessionsLoading(false);
+        Object.keys(reconnectDisabledRef.current).forEach((k) => {
+            reconnectDisabledRef.current[k] = true;
+        });
+        Object.keys(wsMapRef.current).forEach((k) => {
+            const ws = wsMapRef.current[k];
+            if (ws && ws.readyState !== WebSocket.CLOSED) ws.close();
+        });
+        wsMapRef.current = {};
+        wsRef.current = null;
+    }, [currentUser?.id, token]);
 
     useEffect(() => {
         if (!id || !token || activeTab !== 'chat') return;
         fetchMySessions(false, id).then((data: any) => {
             if (currentAgentIdRef.current !== id) return;
             setSessionsLoading(false);
-            if (data && data.length > 0) selectSession(data[0]);
+            if (data && data.length > 0) selectSession(data[0], 'mine');
         });
-    }, [id, token, activeTab]);
+    }, [id, token, activeTab, currentUser?.id]);
 
     const ensureSessionSocket = (sess: any, agentId: string, authToken: string) => {
         const sessionId = String(sess.id);
@@ -1611,51 +1724,15 @@ function AgentDetailInner() {
                     setSessionListCollapsed(true);
                     useAppStore.setState({ sidebarCollapsed: true });
                 }
-                if (d.status === 'running') {
-                    setChatMessages(prev => {
-                        let msgs = [...prev];
-                        while (msgs.length > 0) {
-                            const last = msgs[msgs.length - 1];
-                            if (last.role === 'assistant' && !(last as any)._isToolGroup && !(last as any)._streaming && !(last.content && last.content.trim()) && !last.thinking) {
-                                msgs.pop();
-                            } else break;
-                        }
-                        const tc = { name: d.name, args: d.args || {} };
-                        // Find recent tool group to merge into, but stop at user messages (new turn boundary)
-                        for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
-                            if (msgs[i].role === 'user') break; // New conversation turn — don't merge across
-                            if ((msgs[i] as any)._isToolGroup) {
-                                msgs[i] = { ...msgs[i], toolCalls: [...(msgs[i].toolCalls || []), tc] } as any;
-                                return msgs;
-                            }
-                        }
-                        return [...msgs, { role: 'assistant', content: '', toolCalls: [tc], _isToolGroup: true } as any];
-                    });
-                } else {
-                    setChatMessages(prev => {
-                        let msgs = [...prev];
-                        while (msgs.length > 0) {
-                            const last = msgs[msgs.length - 1];
-                            if (last.role === 'assistant' && !(last as any)._isToolGroup && !(last as any)._streaming && !(last.content && last.content.trim()) && !last.thinking) {
-                                msgs.pop();
-                            } else break;
-                        }
-                        const newCall = { name: d.name, args: d.args, result: d.result || '' };
-                        // Find recent tool group, but stop at user messages (new turn boundary)
-                        for (let i = msgs.length - 1; i >= Math.max(0, msgs.length - 5); i--) {
-                            if (msgs[i].role === 'user') break; // New conversation turn — don't merge across
-                            if ((msgs[i] as any)._isToolGroup) {
-                                const existing = (msgs[i].toolCalls || []).map((tc: any) =>
-                                    tc.name === d.name && !tc.result ? newCall : tc
-                                );
-                                const hasIt = existing.some((tc: any) => tc.name === d.name && tc.result);
-                                msgs[i] = { ...msgs[i], toolCalls: hasIt ? existing : [...existing, newCall] } as any;
-                                return msgs;
-                            }
-                        }
-                        return [...msgs, { role: 'assistant', content: '', toolCalls: [newCall], _isToolGroup: true } as any];
-                    });
-                }
+                setChatMessages(prev => {
+                    const toolMsg: ChatMsg = { role: 'tool_call', content: '', toolName: d.name, toolArgs: d.args, toolStatus: d.status, toolResult: d.result };
+                    if (d.status === 'done') {
+                        const lastIdx = prev.length - 1;
+                        const last = prev[lastIdx];
+                        if (last && last.role === 'tool_call' && last.toolName === d.name && last.toolStatus === 'running') return [...prev.slice(0, lastIdx), toolMsg];
+                    }
+                    return [...prev, toolMsg];
+                });
             } else if (d.type === 'chunk') {
                 setChatMessages(prev => {
                     const last = prev[prev.length - 1];
@@ -1703,7 +1780,7 @@ function AgentDetailInner() {
         }
         ensureSessionSocket(activeSession, id, token);
         syncActiveSocketState(activeSession, id);
-    }, [id, token, activeTab, activeSession?.id]);
+    }, [id, token, activeTab, activeSession?.id, chatScope, canViewAllAgentChatSessions]);
 
     useEffect(() => {
         return () => {
@@ -1749,10 +1826,23 @@ function AgentDetailInner() {
         return () => clearTimeout(timer);
     }, [historyMsgs, activeSession?.id]);
     // Memoized component for each chat message to avoid re-renders while typing
-    const ChatMessageItem = React.useMemo(() => React.memo(({ msg, i, isLeft, t }: { msg: any, i: number, isLeft: boolean, t: any }) => {
+    const ChatMessageItem = React.useMemo(() => React.memo(({
+        msg, i, isLeft, t, senderLabel, avatarText, forceSenderLabel = false,
+    }: {
+        msg: any;
+        i: number;
+        isLeft: boolean;
+        t: any;
+        senderLabel?: string;
+        avatarText?: string;
+        forceSenderLabel?: boolean;
+    }) => {
         const fe = msg.fileName?.split('.').pop()?.toLowerCase() ?? '';
         const fi = fe === 'pdf' ? '📄' : (fe === 'csv' || fe === 'xlsx' || fe === 'xls') ? '📊' : (fe === 'docx' || fe === 'doc') ? '📝' : '📎';
         const isImage = msg.imageUrl && ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp'].includes(fe);
+        const resolvedSenderLabel = msg.sender_name || senderLabel;
+        const resolvedAvatarText = avatarText || (resolvedSenderLabel ? resolvedSenderLabel[0] : (isLeft ? 'A' : 'U'));
+        const showSenderLabel = !!resolvedSenderLabel && (forceSenderLabel || !!msg.sender_name);
 
         const timestampHtml = msg.timestamp ? (() => {
             const d = new Date(msg.timestamp);
@@ -1773,9 +1863,9 @@ function AgentDetailInner() {
 
         return (
             <div key={i} style={{ display: 'flex', flexDirection: isLeft ? 'row' : 'row-reverse', gap: '8px', marginBottom: '8px' }}>
-                <div style={{ width: '28px', height: '28px', borderRadius: '50%', background: isLeft ? 'var(--bg-elevated)' : 'rgba(16,185,129,0.15)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '11px', flexShrink: 0, color: 'var(--text-secondary)', fontWeight: 600 }}>{isLeft ? (msg.sender_name ? msg.sender_name[0] : 'A') : 'U'}</div>
+                <div style={{ width: '28px', height: '28px', borderRadius: '50%', background: isLeft ? 'var(--bg-elevated)' : 'rgba(16,185,129,0.15)', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '11px', flexShrink: 0, color: 'var(--text-secondary)', fontWeight: 600 }}>{resolvedAvatarText}</div>
                 <div style={{ maxWidth: '75%', padding: '8px 12px', borderRadius: '12px', background: isLeft ? 'var(--bg-secondary)' : 'rgba(16,185,129,0.1)', fontSize: '13px', lineHeight: '1.5', wordBreak: 'break-word' }}>
-                    {isLeft && msg.sender_name && <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginBottom: '2px', fontWeight: 600 }}>🤖 {msg.sender_name}</div>}
+                    {showSenderLabel && <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginBottom: '2px', fontWeight: 600 }}>{resolvedSenderLabel}</div>}
                     {isImage ? (
                         <div style={{ marginBottom: '4px' }}>
                             <img src={msg.imageUrl} alt={msg.fileName} style={{ maxWidth: '200px', maxHeight: '150px', borderRadius: '8px', border: '1px solid var(--border-subtle)' }} loading="lazy" />
@@ -1843,7 +1933,7 @@ function AgentDetailInner() {
         const observer = new ResizeObserver(() => updateScrollButtonOffset());
         observer.observe(chatInputAreaRef.current);
         return () => observer.disconnect();
-    }, [activeSession?.id, activeTab]);
+    }, [activeSession?.id, activeTab, chatUploadDrafts.length, attachedFiles.length]);
 
     const sendChatMsg = () => {
         if (!id || !activeSession?.id) return;
@@ -1901,6 +1991,7 @@ function AgentDetailInner() {
         }));
 
         setChatInput('');
+        // Reset textarea height after clearing content
         if (chatInputRef.current) {
             chatInputRef.current.style.height = 'auto';
         }
@@ -3080,76 +3171,7 @@ function AgentDetailInner() {
                                                                     <div style={{ padding: '12px 0', fontSize: '12px', color: 'var(--text-tertiary)' }}>Loading...</div>
                                                                 ) : (
                                                                     <div style={{ display: 'flex', flexDirection: 'column', gap: '6px', marginTop: '8px' }}>
-                                                                        {msgs.filter((msg: any) => !(msg.role === 'assistant' && !msg._isToolGroup && !(msg.content && msg.content.trim()))).map((msg: any, mi: number) => {
-                                                                            if (msg._isToolGroup && msg.toolCalls?.length > 0) {
-                                                                                return (
-                                                                                    <details key={mi} style={{ borderRadius: '6px', background: 'var(--bg-secondary)', overflow: 'hidden' }}>
-                                                                                        <summary style={{
-                                                                                            padding: '5px 10px', fontSize: '11px', cursor: 'pointer',
-                                                                                            display: 'flex', alignItems: 'center', gap: '8px',
-                                                                                            listStyle: 'none', WebkitAppearance: 'none',
-                                                                                        } as any}>
-                                                                                            <span style={{ fontSize: '8px', color: 'var(--text-tertiary)', flexShrink: 0 }}>&#9654;</span>
-                                                                                            <span style={{
-                                                                                                fontWeight: 600, fontSize: '10px', color: 'var(--text-tertiary)',
-                                                                                                padding: '1px 6px', borderRadius: '3px',
-                                                                                                background: 'var(--bg-tertiary, rgba(0,0,0,0.06))',
-                                                                                                flexShrink: 0,
-                                                                                            }}>{msg.toolCalls.length} tool{msg.toolCalls.length > 1 ? 's' : ''}</span>
-                                                                                            <span style={{ display: 'flex', gap: '4px', overflow: 'hidden', flexWrap: 'nowrap' }}>
-                                                                                                {msg.toolCalls.slice(0, 4).map((tc: any, ti: number) => (
-                                                                                                    <span key={ti} style={{
-                                                                                                        fontFamily: 'monospace', fontSize: '10px', color: 'var(--text-primary)',
-                                                                                                        padding: '1px 5px', borderRadius: '3px',
-                                                                                                        background: 'var(--bg-tertiary, rgba(0,0,0,0.06))',
-                                                                                                        flexShrink: 0,
-                                                                                                    }}>{tc.name}</span>
-                                                                                                ))}
-                                                                                                {msg.toolCalls.length > 4 && <span style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>+{msg.toolCalls.length - 4}</span>}
-                                                                                            </span>
-                                                                                        </summary>
-                                                                                        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', padding: '6px 10px', borderTop: '1px solid var(--border-subtle)' }}>
-                                                                                            {msg.toolCalls.map((tc: any, ti: number) => {
-                                                                                                const argsStr = typeof tc.args === 'string' ? tc.args : JSON.stringify(tc.args || {}, null, 2);
-                                                                                                const resultStr = typeof tc.result === 'string' ? tc.result : JSON.stringify(tc.result || '', null, 2);
-                                                                                                return (
-                                                                                                    <details key={ti} style={{ borderRadius: '4px', background: 'var(--bg-primary, var(--bg-secondary))', overflow: 'hidden' }}>
-                                                                                                        <summary style={{
-                                                                                                            padding: '4px 8px', fontSize: '10px', cursor: 'pointer',
-                                                                                                            display: 'flex', alignItems: 'center', gap: '6px',
-                                                                                                            listStyle: 'none', WebkitAppearance: 'none',
-                                                                                                        } as any}>
-                                                                                                            <span style={{ fontSize: '7px', color: 'var(--text-tertiary)', flexShrink: 0 }}>&#9654;</span>
-                                                                                                            <span style={{
-                                                                                                                fontWeight: 600, fontFamily: 'monospace', fontSize: '10px',
-                                                                                                                color: 'var(--text-primary)', flexShrink: 0,
-                                                                                                            }}>{tc.name}</span>
-                                                                                                            <span style={{
-                                                                                                                color: 'var(--text-tertiary)', fontFamily: 'monospace', fontSize: '10px',
-                                                                                                                overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-                                                                                                            }}>{argsStr.replace(/\n/g, ' ').substring(0, 60)}{argsStr.length > 60 ? '...' : ''}</span>
-                                                                                                        </summary>
-                                                                                                        <div style={{
-                                                                                                            padding: '6px 8px', borderTop: '1px solid var(--border-subtle)',
-                                                                                                            fontFamily: 'monospace', fontSize: '10px', lineHeight: 1.5,
-                                                                                                            whiteSpace: 'pre-wrap', maxHeight: '200px', overflow: 'auto',
-                                                                                                            color: 'var(--text-secondary)',
-                                                                                                        }}>
-                                                                                                            {argsStr}
-                                                                                                            {resultStr && (
-                                                                                                                <>
-                                                                                                                    <div style={{ borderTop: '1px dashed var(--border-subtle)', margin: '6px 0', opacity: 0.5 }} />
-                                                                                                                    <span style={{ color: 'var(--text-tertiary)' }}>→ </span>{resultStr.substring(0, 500)}
-                                                                                                                </>
-                                                                                                            )}
-                                                                                                        </div>
-                                                                                                    </details>
-                                                                                                );
-                                                                                            })}
-                                                                                        </div>
-                                                                                    </details>
-                                                                                );
-                                                                            }
+                                                                        {msgs.map((msg: any, mi: number) => {
                                                                             if (msg.role === 'tool_call') {
                                                                                 const tName = msg.toolName || (() => { try { return JSON.parse(msg.content || '{}').name; } catch { return ''; } })() || 'tool';
                                                                                 const tArgs = msg.toolArgs || (() => { try { return JSON.parse(msg.content || '{}').args; } catch { return {}; } })();
@@ -3409,12 +3431,12 @@ function AgentDetailInner() {
                                                 style={{ display: 'flex', alignItems: 'center', gap: '6px', whiteSpace: 'nowrap' }}
                                                 onClick={() => setShowImportSkillModal(true)}
                                             >
-                                                {t('agent.skills.importFromPresets', 'Import from Presets')}
+                                                Import from Presets
                                             </button>
                                         </div>
                                     </div>
                                     <div style={{ marginTop: '8px', padding: '10px 14px', background: 'var(--bg-secondary)', borderRadius: '8px', fontSize: '12px', color: 'var(--text-secondary)', lineHeight: 1.6 }}>
-                                        <strong>{t('agent.skills.skillFormat', 'Skill Format:')}</strong><br />
+                                        <strong>Skill Format:</strong><br />
                                         • <code>skills/my-skill/SKILL.md</code> — {t('agent.skills.folderFormat', 'Each skill is a folder with a SKILL.md file and optional auxiliary files (scripts/, examples/)')}
                                     </div>
                                 </div>
@@ -3502,11 +3524,11 @@ function AgentDetailInner() {
                                     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={() => setShowAgentUrlImport(false)}>
                                         <div onClick={e => e.stopPropagation()} style={{ background: 'var(--bg-primary)', borderRadius: '12px', padding: '24px', maxWidth: '500px', width: '90%', boxShadow: '0 20px 60px rgba(0,0,0,0.3)' }}>
                                             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
-                                                <h3>{t('agent.skills.importFromGithub', 'Import from GitHub URL')}</h3>
+                                                <h3>Import from GitHub URL</h3>
                                                 <button onClick={() => setShowAgentUrlImport(false)} style={{ background: 'none', border: 'none', fontSize: '18px', cursor: 'pointer', color: 'var(--text-secondary)', padding: '4px 8px' }}>x</button>
                                             </div>
                                             <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: '0 0 12px' }}>
-                                                {t('agent.skills.githubUrlDesc', 'Paste a GitHub URL pointing to a skill directory (must contain SKILL.md).')}
+                                                Paste a GitHub URL pointing to a skill directory (must contain SKILL.md).
                                             </p>
                                             <input
                                                 className="input"
@@ -3534,7 +3556,7 @@ function AgentDetailInner() {
                                                         }
                                                     }}
                                                 >
-                                                    {agentUrlImporting ? t('agent.skills.importing', 'Importing...') : t('agent.skills.importBtn', 'Import')}
+                                                    {agentUrlImporting ? 'Importing...' : 'Import'}
                                                 </button>
                                             </div>
                                         </div>
@@ -3546,7 +3568,7 @@ function AgentDetailInner() {
                                     <div style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, background: 'rgba(0,0,0,0.5)', zIndex: 1000, display: 'flex', alignItems: 'center', justifyContent: 'center' }} onClick={() => setShowImportSkillModal(false)}>
                                         <div onClick={e => e.stopPropagation()} style={{ background: 'var(--bg-primary)', borderRadius: '12px', padding: '24px', maxWidth: '600px', width: '90%', maxHeight: '70vh', display: 'flex', flexDirection: 'column', boxShadow: '0 20px 60px rgba(0,0,0,0.3)' }}>
                                             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
-                                                <h3>{t('agent.skills.importPreset', 'Import from Presets')}</h3>
+                                                <h3>📦 {t('agent.skills.importPreset', 'Import from Presets')}</h3>
                                                 <button onClick={() => setShowImportSkillModal(false)} style={{ background: 'none', border: 'none', fontSize: '18px', cursor: 'pointer', color: 'var(--text-secondary)', padding: '4px 8px' }}>✕</button>
                                             </div>
                                             <p style={{ fontSize: '13px', color: 'var(--text-secondary)', margin: '0 0 16px' }}>
@@ -3601,7 +3623,7 @@ function AgentDetailInner() {
                                                                     }
                                                                 }}
                                                             >
-                                                                {importingSkillId === skill.id ? t('agent.skills.importing', 'Importing...') : t('agent.skills.importBtn', 'Import')}
+                                                                {importingSkillId === skill.id ? '⏳ ...' : '⬇️ Import'}
                                                             </button>
                                                         </div>
                                                     ))
@@ -3639,144 +3661,230 @@ function AgentDetailInner() {
 
                 {
                     activeTab === 'chat' && (
-                        <div style={{ display: 'flex', gap: '0', flex: 1, minHeight: 0, height: 'calc(100vh - 206px)' }}>
+                        <div
+                            style={{
+                                display: 'flex',
+                                gap: 0,
+                                flex: 1,
+                                minHeight: 0,
+                                height: 'calc(100vh - 206px)',
+                                border: '1px solid color-mix(in srgb, var(--border-subtle) 55%, var(--bg-primary))',
+                                borderRadius: '12px',
+                                overflow: 'hidden',
+                            }}
+                        >
                             {/* ── Left: session sidebar ── */}
-                            <div className={`session-sidebar ${sessionListCollapsed ? 'collapsed' : ''}`} style={{ width: sessionListCollapsed ? '0px' : '220px', transition: 'width 0.2s ease', flexShrink: 0, borderRight: sessionListCollapsed ? 'none' : '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-                                {/* Tab row */}
-                                <div style={{ display: 'flex', alignItems: 'center', padding: '10px 12px 0', gap: '4px', borderBottom: '1px solid var(--border-subtle)', position: 'relative' }}>
-                                    {!sessionListCollapsed && (
-                                        <button onClick={() => setSessionListCollapsed(true)} className="session-sidebar-collapseBtn" style={{ position: 'absolute', top: '6px', right: '4px', zIndex: 10, background: 'none', border: 'none', color: 'var(--text-tertiary)', cursor: 'pointer', padding: '4px', borderRadius: '4px' }} title={t('agent.chat.collapseSessions', 'Collapse sessions')} onMouseEnter={e => e.currentTarget.style.background='var(--bg-secondary)'} onMouseLeave={e => e.currentTarget.style.background='none'}>
-                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-                                        </button>
-                                    )}
-                                    <button onClick={() => setChatScope('mine')}
-                                        style={{ flex: 1, padding: '5px 0', background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', fontWeight: chatScope === 'mine' ? 600 : 400, color: chatScope === 'mine' ? 'var(--text-primary)' : 'var(--text-tertiary)', borderBottom: chatScope === 'mine' ? '2px solid var(--accent-primary)' : '2px solid transparent', paddingBottom: '8px' }}>
-                                        {t('agent.chat.mySessions')}
-                                    </button>
-                                    {isAdmin && (
-                                        <button onClick={() => { setChatScope('all'); fetchAllSessions(); }}
-                                            style={{ flex: 1, padding: '5px 0', background: 'none', border: 'none', cursor: 'pointer', fontSize: '12px', fontWeight: chatScope === 'all' ? 600 : 400, color: chatScope === 'all' ? 'var(--text-primary)' : 'var(--text-tertiary)', borderBottom: chatScope === 'all' ? '2px solid var(--accent-primary)' : '2px solid transparent', paddingBottom: '8px' }}>
-                                            {t('agent.chat.allUsers')}
-                                        </button>
+                            <div className={`session-sidebar ${sessionListCollapsed ? 'collapsed' : ''}`} style={{ width: sessionListCollapsed ? '0px' : '220px', transition: 'width 0.2s ease', flexShrink: 0, minHeight: 0, borderRight: sessionListCollapsed ? 'none' : '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                                {/* ── Header: title + collapse, then new session ── */}
+                                <div style={{ flexShrink: 0 }}>
+                                    <div
+                                        style={{
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                            justifyContent: 'space-between',
+                                            gap: '8px',
+                                            padding: '10px 12px 8px',
+                                            minHeight: '40px',
+                                            boxSizing: 'border-box',
+                                        }}
+                                    >
+                                        <span
+                                            style={{
+                                                fontSize: '14px',
+                                                fontWeight: 600,
+                                                color: 'var(--text-primary)',
+                                                lineHeight: '1.25',
+                                                flex: 1,
+                                                minWidth: 0,
+                                            }}
+                                        >
+                                            {t('agent.chat.sessionListTitle')}
+                                        </span>
+                                        {!sessionListCollapsed && (
+                                            <button
+                                                type="button"
+                                                onClick={() => setSessionListCollapsed(true)}
+                                                className="session-sidebar-collapseBtn"
+                                                style={{
+                                                    display: 'inline-flex',
+                                                    alignItems: 'center',
+                                                    justifyContent: 'center',
+                                                    background: 'none',
+                                                    border: 'none',
+                                                    color: 'var(--text-tertiary)',
+                                                    cursor: 'pointer',
+                                                    padding: '4px',
+                                                    borderRadius: '4px',
+                                                    flexShrink: 0,
+                                                    lineHeight: 0,
+                                                }}
+                                                title={t('agent.chat.collapseSidebar')}
+                                                onMouseEnter={(e) => {
+                                                    e.currentTarget.style.background = 'var(--bg-secondary)';
+                                                }}
+                                                onMouseLeave={(e) => {
+                                                    e.currentTarget.style.background = 'none';
+                                                }}
+                                            >
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                                    <path d="M15 18l-6-6 6-6" />
+                                                </svg>
+                                            </button>
+                                        )}
+                                    </div>
+                                    {!canViewAllAgentChatSessions && (
+                                        <div style={{ padding: '0 12px 10px' }}>
+                                            <button
+                                                type="button"
+                                                onClick={createNewSession}
+                                                style={{
+                                                    width: '100%',
+                                                    height: '28px',
+                                                    padding: '0 10px',
+                                                    background: 'none',
+                                                    border: '1px solid var(--border-subtle)',
+                                                    borderRadius: '6px',
+                                                    cursor: 'pointer',
+                                                    fontSize: '12px',
+                                                    color: 'var(--text-secondary)',
+                                                    textAlign: 'left',
+                                                    display: 'flex',
+                                                    alignItems: 'center',
+                                                    gap: '6px',
+                                                    transition: 'all 0.15s ease',
+                                                    boxSizing: 'border-box',
+                                                }}
+                                                onMouseEnter={(e) => {
+                                                    e.currentTarget.style.background = 'var(--bg-secondary)';
+                                                    e.currentTarget.style.color = 'var(--text-primary)';
+                                                    e.currentTarget.style.borderColor = 'var(--accent-primary)';
+                                                }}
+                                                onMouseLeave={(e) => {
+                                                    e.currentTarget.style.background = 'none';
+                                                    e.currentTarget.style.color = 'var(--text-secondary)';
+                                                    e.currentTarget.style.borderColor = 'var(--border-subtle)';
+                                                }}
+                                            >
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                                    <line x1="12" y1="5" x2="12" y2="19" />
+                                                    <line x1="5" y1="12" x2="19" y2="12" />
+                                                </svg>
+                                                {t('agent.chat.newSession')}
+                                            </button>
+                                        </div>
                                     )}
                                 </div>
 
-                                {/* Actions row */}
-                                {chatScope === 'mine' && (
-                                    <div style={{ padding: '8px 12px', borderBottom: '1px solid var(--border-subtle)' }}>
-                                        <button onClick={createNewSession}
-                                            style={{ width: '100%', padding: '5px 8px', background: 'none', border: '1px solid var(--border-subtle)', borderRadius: '6px', cursor: 'pointer', fontSize: '12px', color: 'var(--text-secondary)', textAlign: 'center', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '6px' }}
-                                            onMouseEnter={e => { e.currentTarget.style.background = 'var(--bg-secondary)'; e.currentTarget.style.color = 'var(--text-primary)'; }}
-                                            onMouseLeave={e => { e.currentTarget.style.background = 'none'; e.currentTarget.style.color = 'var(--text-secondary)'; }}>
-                                            + {t('agent.chat.newSession')}
-                                        </button>
+                                {canViewAllAgentChatSessions && (
+                                    <div className="tabs session-sidebar-session-tabs" role="tablist">
+                                        <div
+                                            role="tab"
+                                            tabIndex={0}
+                                            aria-selected={chatScope === 'mine'}
+                                            className={`tab ${chatScope === 'mine' ? 'active' : ''}`}
+                                            onClick={onAdminTabMine}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' || e.key === ' ') {
+                                                    e.preventDefault();
+                                                    onAdminTabMine();
+                                                }
+                                            }}
+                                        >
+                                            {t('agent.chat.mySessions')}
+                                        </div>
+                                        <div
+                                            role="tab"
+                                            tabIndex={0}
+                                            aria-selected={chatScope === 'all'}
+                                            className={`tab ${chatScope === 'all' ? 'active' : ''}`}
+                                            onClick={onAdminTabOthers}
+                                            onKeyDown={(e) => {
+                                                if (e.key === 'Enter' || e.key === ' ') {
+                                                    e.preventDefault();
+                                                    onAdminTabOthers();
+                                                }
+                                            }}
+                                        >
+                                            {t('agent.chat.otherUsersTab')}
+                                        </div>
                                     </div>
                                 )}
 
-                                {/* Session list */}
-                                <div style={{ flex: 1, overflowY: 'auto', padding: '4px 0' }}>
-                                    {chatScope === 'mine' ? (
-                                        sessionsLoading ? (
-                                            <div style={{ padding: '20px 12px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('common.loading')}</div>
-                                        ) : sessions.length === 0 ? (
-                                            <div style={{ padding: '20px 12px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('agent.chat.noSessionsYet')}<br />{t('agent.chat.clickToStart')}</div>
-                                        ) : sessions.map((s: any) => {
-                                            const isActive = activeSession?.id === s.id;
-                                            const channelLabel: Record<string, string> = {
-                                                feishu: t('common.channels.feishu'),
-                                                discord: t('common.channels.discord'),
-                                                slack: t('common.channels.slack'),
-                                                dingtalk: t('common.channels.dingtalk'),
-                                                wecom: t('common.channels.wecom'),
-                                            };
-                                            const chLabel = channelLabel[s.source_channel];
-                                            return (
-                                                <div key={s.id} onClick={() => selectSession(s)}
-                                                    className="session-item"
-                                                    style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px', position: 'relative' }}
-                                                    onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0.5'; }}
-                                                    onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0'; }}>
-                                                    <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
-                                                        <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.title}</div>
-                                                        {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
-                                                    </div>
-                                                    <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
-                                                        {s.last_message_at
-                                                            ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-                                                            : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
-                                                        {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
-                                                    </div>
-                                                    <button className="del-btn" onClick={(e) => { e.stopPropagation(); deleteSession(s.id); }}
-                                                        style={{ position: 'absolute', top: '4px', right: '4px', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', opacity: 0, fontSize: '14px', color: 'var(--text-tertiary)', lineHeight: 1, transition: 'opacity 0.15s' }}
-                                                        onMouseEnter={e => { e.currentTarget.style.opacity = '1'; e.currentTarget.style.color = 'var(--status-error)'; }}
-                                                        onMouseLeave={e => { e.currentTarget.style.opacity = '0.5'; e.currentTarget.style.color = 'var(--text-tertiary)'; }}
-                                                        title={t('chat.deleteSession', 'Delete session')}>×</button>
-                                                </div>
-                                            );
-                                        })
-                                    ) : (
-                                        /* All Users tab — user filter dropdown + flat list */
+                                <div style={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+                                    {(!canViewAllAgentChatSessions || chatScope === 'mine') ? (
                                         <>
-                                            {/* User filter dropdown */}
-                                            <div style={{ padding: '8px 10px', borderBottom: '1px solid var(--border-subtle)' }}>
-                                                <select
-                                                    value={allUserFilter}
-                                                    onChange={e => setAllUserFilter(e.target.value)}
-                                                    style={{ width: '100%', padding: '4px 6px', fontSize: '11px', background: 'var(--bg-secondary)', border: '1px solid var(--border-subtle)', borderRadius: '5px', color: 'var(--text-primary)', cursor: 'pointer' }}
-                                                >
-                                                    <option value="">{t('agent.chat.allUsers', 'All Users')}</option>
-                                                    {Array.from(new Set(allSessions.map((s: any) => s.username || s.user_id))).filter(Boolean).map((u: any) => (
-                                                        <option key={u} value={u}>{u}</option>
-                                                    ))}
-                                                </select>
-                                            </div>
-                                            {/* Loading skeleton */}
-                                            {allSessionsLoading ? (
-                                                <div style={{ padding: '8px 12px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                                                    {[...Array(6)].map((_, i) => (
-                                                        <div key={i} style={{ padding: '6px 0', animation: 'pulse 1.5s ease-in-out infinite', animationDelay: `${i * 0.1}s` }}>
-                                                            <div style={{ height: '12px', width: `${70 + (i % 3) * 10}%`, background: 'var(--bg-tertiary)', borderRadius: '4px', marginBottom: '6px' }} />
-                                                            <div style={{ height: '10px', width: `${40 + (i % 4) * 8}%`, background: 'var(--bg-tertiary)', borderRadius: '3px', opacity: 0.6 }} />
-                                                        </div>
-                                                    ))}
+                                            {canViewAllAgentChatSessions && (
+                                                <div style={{ padding: '0 12px 8px', flexShrink: 0 }}>
+                                                    <button
+                                                        type="button"
+                                                        onClick={createNewSession}
+                                                        style={{
+                                                            width: '100%',
+                                                            height: '28px',
+                                                            padding: '0 10px',
+                                                            background: 'none',
+                                                            border: '1px solid var(--border-subtle)',
+                                                            borderRadius: '6px',
+                                                            cursor: 'pointer',
+                                                            fontSize: '12px',
+                                                            color: 'var(--text-secondary)',
+                                                            textAlign: 'center',
+                                                            display: 'flex',
+                                                            alignItems: 'center',
+                                                            justifyContent: 'center',
+                                                            gap: '6px',
+                                                            transition: 'all 0.15s ease',
+                                                            boxSizing: 'border-box',
+                                                        }}
+                                                        onMouseEnter={(e) => {
+                                                            e.currentTarget.style.background = 'var(--bg-secondary)';
+                                                            e.currentTarget.style.color = 'var(--text-primary)';
+                                                            e.currentTarget.style.borderColor = 'var(--accent-primary)';
+                                                        }}
+                                                        onMouseLeave={(e) => {
+                                                            e.currentTarget.style.background = 'none';
+                                                            e.currentTarget.style.color = 'var(--text-secondary)';
+                                                            e.currentTarget.style.borderColor = 'var(--border-subtle)';
+                                                        }}
+                                                    >
+                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                                            <line x1="12" y1="5" x2="12" y2="19" />
+                                                            <line x1="5" y1="12" x2="19" y2="12" />
+                                                        </svg>
+                                                        {t('agent.chat.newSession')}
+                                                    </button>
                                                 </div>
-                                            ) : allSessions.length === 0 ? (
-                                                <div style={{ padding: '20px 12px', fontSize: '12px', color: 'var(--text-tertiary)', textAlign: 'center' }}>{t('agent.chat.noSessionsYet')}</div>
-                                            ) : null}
-                                            {/* Filtered session list */}
-                                            {!allSessionsLoading && allSessions
-                                                .filter((s: any) => !allUserFilter || (s.username || s.user_id) === allUserFilter)
-                                                .map((s: any) => {
-                                                    const isActive = activeSession?.id === s.id;
+                                            )}
+                                            <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '4px 0' }}>
+                                                {sessionsLoading ? (
+                                                    <div style={{ padding: '20px 12px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('common.loading')}</div>
+                                                ) : sessions.length === 0 ? (
+                                                    <div style={{ padding: '20px 12px', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('agent.chat.noSessionsYet')}<br />{t('agent.chat.clickToStart')}</div>
+                                                ) : sessions.map((s: any) => {
+                                                    const isActive = activeSession?.id === s.id && (chatScope === 'mine' || !canViewAllAgentChatSessions);
+                                                    const channelLabel: Record<string, string> = {
+                                                        feishu: t('common.channels.feishu'),
+                                                        discord: t('common.channels.discord'),
+                                                        slack: t('common.channels.slack'),
+                                                        dingtalk: t('common.channels.dingtalk'),
+                                                        wecom: t('common.channels.wecom'),
+                                                    };
+                                                    const chLabel = channelLabel[s.source_channel];
                                                     return (
-                                                        <div key={s.id} onClick={() => selectSession(s)}
+                                                        <div key={s.id} onClick={() => { setChatScope('mine'); selectSession(s, 'mine'); }}
                                                             className="session-item"
-                                                            style={{ padding: '6px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', position: 'relative' }}
+                                                            style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px', position: 'relative' }}
                                                             onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0.5'; }}
                                                             onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0'; }}>
-                                                            <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '1px' }}>
-                                                                <div style={{ fontSize: '12px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-primary)', flex: 1 }}>{s.title}</div>
-                                                                {({
-                                                                    feishu: t('common.channels.feishu'),
-                                                                    discord: t('common.channels.discord'),
-                                                                    slack: t('common.channels.slack'),
-                                                                    dingtalk: t('common.channels.dingtalk'),
-                                                                    wecom: t('common.channels.wecom'),
-                                                                } as Record<string, string>)[s.source_channel] && (
-                                                                        <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>
-                                                                            {({
-                                                                                feishu: t('common.channels.feishu'),
-                                                                                discord: t('common.channels.discord'),
-                                                                                slack: t('common.channels.slack'),
-                                                                                dingtalk: t('common.channels.dingtalk'),
-                                                                                wecom: t('common.channels.wecom'),
-                                                                            } as Record<string, string>)[s.source_channel]}
-                                                                        </span>
-                                                                    )}
+                                                            <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
+                                                                <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.title}</div>
+                                                                {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
                                                             </div>
-                                                            <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', gap: '4px' }}>
-                                                                <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.username || ''}</span>
-                                                                <span style={{ flexShrink: 0 }}>{s.last_message_at ? new Date(s.last_message_at).toLocaleString('zh-CN', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}{s.message_count > 0 ? ` · ${s.message_count}` : ''}</span>
+                                                            <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                                                {s.last_message_at
+                                                                    ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+                                                                    : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
+                                                                {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
                                                             </div>
                                                             <button className="del-btn" onClick={(e) => { e.stopPropagation(); deleteSession(s.id); }}
                                                                 style={{ position: 'absolute', top: '4px', right: '4px', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', opacity: 0, fontSize: '14px', color: 'var(--text-tertiary)', lineHeight: 1, transition: 'opacity 0.15s' }}
@@ -3786,6 +3894,64 @@ function AgentDetailInner() {
                                                         </div>
                                                     );
                                                 })}
+                                            </div>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <div style={{ padding: '0 12px 8px', flexShrink: 0 }}>
+                                                <select
+                                                    value={allUserFilter}
+                                                    onChange={(e) => setAllUserFilter(e.target.value)}
+                                                    style={{ width: '100%', height: '28px', padding: '0 8px', fontSize: '12px', background: 'var(--bg-secondary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', color: 'var(--text-primary)', cursor: 'pointer' }}
+                                                >
+                                                    <option value="">{t('agent.chat.allUsers')}</option>
+                                                    {otherUserPickerOptions.map(([uid, label]) => (
+                                                        <option key={uid} value={uid}>{label}</option>
+                                                    ))}
+                                                </select>
+                                            </div>
+                                            <div style={{ flex: 1, minHeight: 0, overflowY: 'auto', padding: '4px 0' }}>
+                                                {allSessionsLoading ? (
+                                                    <div style={{ padding: '8px 12px', display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                                        {[...Array(3)].map((_, i) => (
+                                                            <div key={i} style={{ padding: '6px 0', animation: 'pulse 1.5s ease-in-out infinite', animationDelay: `${i * 0.1}s` }}>
+                                                                <div style={{ height: '12px', width: `${70 + (i % 3) * 10}%`, background: 'var(--bg-tertiary)', borderRadius: '4px', marginBottom: '6px' }} />
+                                                                <div style={{ height: '10px', width: `${40 + (i % 4) * 8}%`, background: 'var(--bg-tertiary)', borderRadius: '3px', opacity: 0.6 }} />
+                                                            </div>
+                                                        ))}
+                                                    </div>
+                                                ) : othersListForPicker.length === 0 ? (
+                                                    <div style={{ padding: '16px 12px', fontSize: '12px', color: 'var(--text-tertiary)', textAlign: 'center' }}>{t('agent.chat.noSessionsYet')}</div>
+                                                ) : (
+                                                    othersListForPicker.map((s: any) => {
+                                                        const isActive = activeSession?.id === s.id && chatScope === 'all';
+                                                        const channelLabel: Record<string, string> = {
+                                                            feishu: t('common.channels.feishu'),
+                                                            discord: t('common.channels.discord'),
+                                                            slack: t('common.channels.slack'),
+                                                            dingtalk: t('common.channels.dingtalk'),
+                                                            wecom: t('common.channels.wecom'),
+                                                        };
+                                                        const chLabel = channelLabel[s.source_channel];
+                                                        return (
+                                                            <div key={s.id} onClick={() => selectSession(s, 'all')}
+                                                                className="session-item"
+                                                                style={{ padding: '6px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', position: 'relative' }}
+                                                                onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; }}
+                                                                onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}>
+                                                                <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '1px' }}>
+                                                                    <div style={{ fontSize: '11px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--text-primary)', flex: 1 }}>{s.title}</div>
+                                                                    {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
+                                                                </div>
+                                                                <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', gap: '4px' }}>
+                                                                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.username || ''}</span>
+                                                                    <span style={{ flexShrink: 0 }}>{s.last_message_at ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : ''}{s.message_count > 0 ? ` · ${s.message_count}` : ''}</span>
+                                                                </div>
+                                                            </div>
+                                                        );
+                                                    })
+                                                )}
+                                            </div>
                                         </>
                                     )}
                                 </div>
@@ -3795,7 +3961,7 @@ function AgentDetailInner() {
                             <div className={`agent-chat-area ${ !!(liveState.desktop || liveState.browser || liveState.code) ? 'has-live-panel' : ''}`} style={{ flex: 1, display: 'flex', flexDirection: 'row', position: 'relative', minWidth: 0, overflow: 'hidden' }}>
                                 <div style={{ flex: 1, display: 'flex', flexDirection: 'column', position: 'relative', minWidth: 0, overflow: 'hidden' }}>
                                     {sessionListCollapsed && (
-                                        <button onClick={() => setSessionListCollapsed(false)} style={{ position: 'absolute', top: '12px', left: '12px', zIndex: 10, width: '28px', height: '28px', borderRadius: '6px', background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-secondary)', cursor: 'pointer', boxShadow: '0 2px 4px rgba(0,0,0,0.05)' }} title={t('agent.chat.showSessions', 'Show chat sessions')} onMouseEnter={e => e.currentTarget.style.background='var(--bg-secondary)'} onMouseLeave={e => e.currentTarget.style.background='var(--bg-elevated)'}>
+                                        <button onClick={() => setSessionListCollapsed(false)} style={{ position: 'absolute', top: '12px', left: '12px', zIndex: 10, width: '28px', height: '28px', borderRadius: '6px', background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-secondary)', cursor: 'pointer' }} title="Show chat sessions" onMouseEnter={e => e.currentTarget.style.background='var(--bg-secondary)'} onMouseLeave={e => e.currentTarget.style.background='var(--bg-elevated)'}>
                                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
                                         </button>
                                     )}
@@ -3806,33 +3972,31 @@ function AgentDetailInner() {
                                             <button className="btn btn-secondary" onClick={createNewSession} style={{ fontSize: '12px' }}>{t('agent.chat.startNewSession')}</button>
                                         )}
                                     </div>
-                                ) : (activeSession.user_id && currentUser && activeSession.user_id !== String(currentUser.id)) || activeSession.source_channel === 'agent' || activeSession.participant_type === 'agent' ? (
+                                ) : !isWritableSession(activeSession) ? (
                                     /* ── Read-only history view (other user's session or agent-to-agent) ── */
                                     <>
                                         <div
                                             style={{
                                                 position: 'absolute',
                                                 top: '12px',
-                                                left: sessionListCollapsed ? '48px' : '16px',
-                                                zIndex: 8,
+                                                left: sessionListCollapsed ? '52px' : '16px',
+                                                zIndex: 10,
                                                 fontSize: '11px',
                                                 color: 'var(--text-tertiary)',
                                                 padding: '4px 8px',
-                                                background: 'color-mix(in srgb, var(--bg-secondary) 92%, transparent)',
-                                                border: '1px solid var(--border-subtle)',
+                                                background: 'var(--bg-secondary)',
                                                 borderRadius: '4px',
-                                                boxShadow: 'var(--shadow-sm)',
-                                                backdropFilter: 'blur(6px)',
                                                 pointerEvents: 'none',
                                             }}
                                         >
                                             {activeSession.source_channel === 'agent' ? `🤖 Agent Conversation · ${activeSession.username || 'Agents'}` : `Read-only · ${activeSession.username || 'User'}`}
                                         </div>
-                                        <div ref={historyContainerRef} onScroll={handleHistoryScroll} style={{ flex: 1, overflowY: 'auto', padding: '52px 16px 12px' }}>
+                                        <div ref={historyContainerRef} onScroll={handleHistoryScroll} style={{ flex: 1, overflowY: 'auto', padding: '48px 16px 12px' }}>
                                             {(() => {
                                                 // For A2A sessions, determine which participant is "this agent" (left side)
                                                 // Use agent.name matching against sender_name from messages
                                                 const isA2A = activeSession.source_channel === 'agent' || activeSession.participant_type === 'agent';
+                                                const isHumanReadonly = !isA2A && !activeSession.is_group;
                                                 const thisAgentName = (agent as any)?.name;
                                                 // Find this agent's participant_id from loaded messages
                                                 const thisAgentPid = isA2A && thisAgentName
@@ -3891,7 +4055,16 @@ function AgentDetailInner() {
                                                         return null;
                                                     }
                                                     return (
-                                                        <ChatMessageItem key={i} msg={m} i={i} isLeft={isLeft} t={t} />
+                                                        <ChatMessageItem
+                                                            key={i}
+                                                            msg={m}
+                                                            i={i}
+                                                            isLeft={isLeft}
+                                                            t={t}
+                                                            senderLabel={isHumanReadonly ? (isLeft ? ((agent as any)?.name || 'Agent') : (activeSession.username || 'User')) : undefined}
+                                                            avatarText={isHumanReadonly ? (isLeft ? (((agent as any)?.name || 'Agent')[0]) : ((activeSession.username || 'User')[0])) : undefined}
+                                                            forceSenderLabel={isHumanReadonly}
+                                                        />
                                                     );
                                                 });
                                             })()}
@@ -3912,86 +4085,6 @@ function AgentDetailInner() {
                                                 </div>
                                             )}
                                             {chatMessages.map((msg, i) => {
-                                                {/* Tool call chain — grouped consecutive tool calls */}
-                                                if ((msg as any)._isToolGroup && msg.toolCalls && msg.toolCalls.length > 0) {
-                                                    return (
-                                                        <div key={i} style={{ paddingLeft: '36px', marginBottom: '6px' }}>
-                                                            <details style={{
-                                                                borderRadius: '8px',
-                                                                background: 'rgba(99,102,241,0.06)',
-                                                                border: '1px solid rgba(99,102,241,0.18)',
-                                                                fontSize: '12px',
-                                                                overflow: 'hidden',
-                                                            }}>
-                                                                <summary style={{
-                                                                    padding: '7px 10px', cursor: 'pointer',
-                                                                    display: 'flex', alignItems: 'center', gap: '6px',
-                                                                    color: 'var(--accent-text, #818cf8)',
-                                                                    userSelect: 'none', listStyle: 'none',
-                                                                }}>
-                                                                    <span style={{ fontSize: '13px' }}>🔧</span>
-                                                                    <span style={{ flex: 1, fontWeight: 500 }}>{t('agent.chat.toolCallChain')}</span>
-                                                                    <span style={{
-                                                                        background: 'rgba(99,102,241,0.18)', color: '#818cf8',
-                                                                        borderRadius: '10px', padding: '1px 7px',
-                                                                        fontSize: '10px', fontWeight: 600,
-                                                                    }}>{msg.toolCalls.length}</span>
-                                                                </summary>
-                                                                {/* Collapsed: tool name pills */}
-                                                                <div style={{ padding: '0 10px 7px 10px', display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
-                                                                    {msg.toolCalls.map((tc: any, j: number) => (
-                                                                        <span key={j} style={{
-                                                                            background: 'rgba(99,102,241,0.10)',
-                                                                            border: '1px solid rgba(99,102,241,0.15)',
-                                                                            borderRadius: '4px', padding: '1px 6px',
-                                                                            fontSize: '10px', color: '#a5b4fc',
-                                                                            fontFamily: 'var(--font-mono)',
-                                                                        }}>{tc.name}</span>
-                                                                    ))}
-                                                                </div>
-                                                                {/* Expanded: each tool's details */}
-                                                                <div style={{ borderTop: '1px solid rgba(99,102,241,0.15)' }}>
-                                                                    {msg.toolCalls.map((tc: any, j: number) => (
-                                                                        <details key={j} style={{
-                                                                            borderBottom: j < msg.toolCalls!.length - 1 ? '1px solid rgba(99,102,241,0.10)' : 'none',
-                                                                        }}>
-                                                                            <summary style={{
-                                                                                padding: '6px 10px', cursor: 'pointer',
-                                                                                display: 'flex', alignItems: 'center', gap: '5px',
-                                                                                userSelect: 'none', listStyle: 'none', fontSize: '11px',
-                                                                            }}>
-                                                                                <span style={{ width: '4px', height: '4px', borderRadius: '50%', background: tc.result ? '#818cf8' : '#f59e0b', flexShrink: 0 }} />
-                                                                                <span style={{ fontFamily: 'var(--font-mono)', color: '#818cf8', fontWeight: 600 }}>{tc.name}</span>
-                                                                                {!tc.result && <span style={{ color: 'var(--text-tertiary)', fontSize: '10px', marginLeft: 'auto' }}>{t('common.loading')}</span>}
-                                                                            </summary>
-                                                                            <div style={{ padding: '0 10px 6px 10px' }}>
-                                                                                {tc.args && Object.keys(tc.args).length > 0 && (
-                                                                                    <div style={{
-                                                                                        fontFamily: 'var(--font-mono)', fontSize: '10px',
-                                                                                        color: 'var(--text-tertiary)', whiteSpace: 'pre-wrap',
-                                                                                        wordBreak: 'break-all', maxHeight: '80px', overflowY: 'auto',
-                                                                                        background: 'rgba(0,0,0,0.12)', borderRadius: '4px',
-                                                                                        padding: '4px 6px', marginBottom: tc.result ? '4px' : 0,
-                                                                                    }}>{JSON.stringify(tc.args, null, 2)}</div>
-                                                                                )}
-                                                                                {tc.result && (
-                                                                                    <div style={{
-                                                                                        fontSize: '10px', color: 'var(--text-secondary)',
-                                                                                        whiteSpace: 'pre-wrap', wordBreak: 'break-all',
-                                                                                        maxHeight: '120px', overflowY: 'auto',
-                                                                                        background: 'rgba(0,0,0,0.08)', borderRadius: '4px',
-                                                                                        padding: '4px 6px',
-                                                                                    }}>{tc.result.length > 500 ? tc.result.slice(0, 500) + '…' : tc.result}</div>
-                                                                                )}
-                                                                            </div>
-                                                                        </details>
-                                                                    ))}
-                                                                </div>
-                                                            </details>
-                                                        </div>
-                                                    );
-                                                }
-                                                {/* Legacy individual tool_call (fallback) */}
                                                 if (msg.role === 'tool_call') {
                                                     return (
                                                         <div key={i} style={{ display: 'flex', gap: '8px', marginBottom: '6px', paddingLeft: '36px', minWidth: 0 }}>
@@ -4008,7 +4101,7 @@ function AgentDetailInner() {
                                                     );
                                                 }
                                                 {/* Assistant message with no text content: show inline thinking or skip */ }
-                                                if (msg.role === 'assistant' && !(msg as any)._isToolGroup && !msg.content?.trim()) {
+                                                if (msg.role === 'assistant' && !msg.content?.trim()) {
                                                     if (msg.thinking) {
                                                         return (
                                                             <div key={i} style={{ paddingLeft: '36px', marginBottom: '6px' }}>
@@ -4036,7 +4129,15 @@ function AgentDetailInner() {
                                                     return null;
                                                 }
                                                 return (
-                                                    <ChatMessageItem key={i} msg={msg} i={i} isLeft={msg.role === 'assistant'} t={t} />
+                                                    <ChatMessageItem
+                                                        key={i}
+                                                        msg={msg}
+                                                        i={i}
+                                                        isLeft={msg.role === 'assistant'}
+                                                        t={t}
+                                                        senderLabel={msg.role === 'assistant' ? ((agent as any)?.name || 'Agent') : (currentUser?.display_name || undefined)}
+                                                        avatarText={msg.role === 'assistant' ? (((agent as any)?.name || 'Agent')[0]) : (currentUser?.display_name?.[0] || undefined)}
+                                                    />
                                                 );
                                             })}
                                             {isWaiting && (
@@ -4062,7 +4163,7 @@ function AgentDetailInner() {
                                                 <span>u23f8</span>
                                                 <span>This Agent has <strong>expired</strong> and is off duty. Contact your admin to extend its service.</span>
                                             </div>
-                                        ) : !wsConnected && (!activeSession?.user_id || !currentUser || activeSession.user_id === String(currentUser?.id)) ? (
+                                        ) : !wsConnected && !!currentUser && sessionUserIdStr(activeSession) === viewerUserIdStr() ? (
                                             <div style={{ padding: '3px 16px', display: 'flex', alignItems: 'center', gap: '6px', fontSize: '11px', color: 'var(--text-tertiary)' }}>
                                                 <span style={{ display: 'inline-block', width: '5px', height: '5px', borderRadius: '50%', background: 'var(--accent-primary)', opacity: 0.8, animation: 'pulse 1.2s ease-in-out infinite' }} />
                                                 Connecting...
@@ -4133,6 +4234,7 @@ function AgentDetailInner() {
                                                     value={chatInput}
                                                     onChange={e => {
                                                         setChatInput(e.target.value);
+                                                        // Auto-grow: reset height then expand to scrollHeight
                                                         const el = e.target;
                                                         el.style.height = 'auto';
                                                         el.style.height = el.scrollHeight + 'px';
@@ -4145,7 +4247,7 @@ function AgentDetailInner() {
                                                         }
                                                     }}
                                                     onPaste={handlePaste}
-                                                    placeholder={!wsConnected && (!activeSession?.user_id || !currentUser || activeSession.user_id === String(currentUser?.id)) ? 'Connecting...' : t('chat.placeholder')}
+                                                    placeholder={!wsConnected && !!currentUser && sessionUserIdStr(activeSession) === viewerUserIdStr() ? 'Connecting...' : t('chat.placeholder')}
                                                     disabled={!wsConnected}
                                                     rows={1}
                                                 />

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -2219,7 +2219,7 @@ export default function EnterpriseSettings() {
                                                     title={m.enabled ? t('enterprise.llm.clickToDisable', 'Click to disable') : t('enterprise.llm.clickToEnable', 'Click to enable')}
                                                     style={{
                                                         position: 'relative', width: '36px', height: '20px', borderRadius: '10px', border: 'none', cursor: 'pointer', transition: 'background 0.2s',
-                                                        background: m.enabled ? 'var(--success, #00b478)' : 'var(--bg-tertiary, #444)',
+                                                        background: m.enabled ? 'var(--accent-primary)' : 'var(--bg-tertiary, #444)',
                                                         padding: 0, flexShrink: 0,
                                                     }}
                                                 >


### PR DESCRIPTION
## Summary
- tighten chat session authorization in the session APIs and websocket flow so users cannot access other users' web sessions
- refine the admin agent chat UI, including the session sidebar tabs, related i18n copy, and small composer styling adjustments
- add regression coverage for chat session access behavior and session management flows

## Verification
- npm run build
- pytest tests/test_chat_sessions_api.py