### PR TITLE
feat(feishu): CardKit streaming cards and SSE hang fixes (#287)

### DIFF
--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -670,46 +670,71 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     )
             _cfs_token = _cfs.set(_feishu_file_sender)
 
-            # Set up streaming response via interactive card
+            # Set up streaming response via CardKit (primary) or IM patch (fallback)
             import json as _json_card
 
-            # Send initial loading card
+            cardkit_card_id: str | None = None
+            cardkit_sequence: int = 0
+            msg_id_for_patch: str | None = None
+
+            _reply_target = chat_id if chat_type == "group" and chat_id else sender_open_id
+            _rid_type = "chat_id" if chat_type == "group" and chat_id else "open_id"
+
             init_card = {
-                "config": {"update_multi": True},
-                "header": {"template": "blue", "title": {"content": "思考中...", "tag": "plain_text"}},
-                "elements": [{"tag": "markdown", "content": "..."}]
+                "schema": "2.0",
+                "config": {
+                    "streaming_mode": True,
+                    "locales": ["zh_cn", "en_us"],
+                    "summary": {"content": "思考中..."},
+                },
+                "body": {
+                    "elements": [
+                        {"tag": "markdown", "content": "", "text_align": "left", "text_size": "normal_v2", "element_id": "streaming_content"},
+                        {"tag": "markdown", "content": " ", "icon": {"tag": "custom_icon", "img_key": "img_v3_02vb_496bec09-4b43-4773-ad6b-0cdd103cd2bg", "size": "16px 16px"}, "element_id": "loading_icon"},
+                    ]
+                },
             }
-            msg_id_for_patch = None
+
             try:
-                if chat_type == "group" and chat_id:
-                    init_resp = await feishu_service.send_message(
-                        config.app_id, config.app_secret, chat_id, "interactive",
-                        _json_card.dumps(init_card), receive_id_type="chat_id", stage="stream_init_card"
-                    )
-                else:
-                    init_resp = await feishu_service.send_message(
-                        config.app_id, config.app_secret, sender_open_id, "interactive",
-                        _json_card.dumps(init_card), receive_id_type="open_id", stage="stream_init_card"
-                    )
-                msg_id_for_patch = init_resp.get("data", {}).get("message_id")
+                cardkit_card_id = await feishu_service.create_card_entity(
+                    config.app_id, config.app_secret, init_card
+                )
+                cardkit_sequence = 1
+                await feishu_service.send_card_by_card_id(
+                    config.app_id, config.app_secret, _reply_target, cardkit_card_id,
+                    receive_id_type=_rid_type,
+                )
+                logger.info(f"[Feishu] CardKit card created and sent: card_id={cardkit_card_id}")
             except Exception as e:
-                logger.error(f"[Feishu] Failed to send init stream card: {e}")
+                logger.warning(f"[Feishu] CardKit flow failed, falling back to IM patch: {e}")
+                cardkit_card_id = None
+                init_card_fallback = {
+                    "config": {"update_multi": True},
+                    "header": {"template": "blue", "title": {"content": "思考中...", "tag": "plain_text"}},
+                    "elements": [{"tag": "markdown", "content": "..."}],
+                }
+                try:
+                    init_resp = await feishu_service.send_message(
+                        config.app_id, config.app_secret, _reply_target, "interactive",
+                        _json_card.dumps(init_card_fallback), receive_id_type=_rid_type, stage="stream_init_card",
+                    )
+                    msg_id_for_patch = init_resp.get("data", {}).get("message_id")
+                except Exception as e2:
+                    logger.error(f"[Feishu] Fallback init card also failed: {e2}")
 
             _stream_buffer = []
             _thinking_buffer = []
             _last_flush_time = time.time()
-            _FLUSH_INTERVAL = 1.0  # Update Feishu once per second to avoid limits
+            _FLUSH_INTERVAL_CARDKIT = 0.5
+            _FLUSH_INTERVAL_PATCH = 1.0
             _agent_name = agent_obj.name if agent_obj else "AI 回复"
-            # Tool status tracking:
-            # - _tool_status_running: dict of call_id -> display line for tools still in flight.
-            #   Cleared when the tool completes so the "running" icon never lingers.
-            # - _tool_status_done: ordered list of completed tool status lines (trimmed to N).
             _tool_status_running: dict[str, str] = {}
             _tool_status_done: list[str] = []
             _patch_queue = _SerialPatchQueue()
             _heartbeat_task: asyncio.Task | None = None
             _llm_done = False
-            _last_flushed_hash: int = 0  # Content hash to skip no-op heartbeat patches
+            _last_flushed_hash: int = 0
+            _last_flushed_text: str = ""
 
             def _build_card(
                 answer_text: str,
@@ -777,6 +802,29 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     "elements": elements,
                 }
 
+            def _build_final_cardkit_card(answer_text: str, thinking_text: str = "") -> dict:
+                elements = []
+                if thinking_text:
+                    elements.append({
+                        "tag": "collapsible_panel",
+                        "expanded": False,
+                        "header": {
+                            "title": {"tag": "markdown", "content": f"💭 Thinking... ({len(thinking_text)} chars)"},
+                            "vertical_align": "center",
+                            "icon": {"tag": "standard_icon", "token": "down-small-ccm_outlined", "size": "16px 16px"},
+                            "icon_position": "follow_text",
+                            "icon_expanded_angle": -180,
+                        },
+                        "border": {"color": "grey", "corner_radius": "5px"},
+                        "elements": [{"tag": "markdown", "content": thinking_text, "text_size": "notation"}],
+                    })
+                elements.append({"tag": "markdown", "content": answer_text or "..."})
+                return {
+                    "schema": "2.0",
+                    "config": {"wide_screen_mode": True, "update_multi": True},
+                    "body": {"elements": elements},
+                }
+
             async def _queue_patch_card(card: dict, stage: str) -> None:
                 if not msg_id_for_patch:
                     return
@@ -797,39 +845,55 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                 _patch_queue.enqueue(_job)
 
             async def _flush_stream(reason: str, force: bool = False):
-                nonlocal _last_flush_time, _last_flushed_hash
-                if not msg_id_for_patch:
+                nonlocal _last_flush_time, _last_flushed_hash, cardkit_sequence, _last_flushed_text
+                if not cardkit_card_id and not msg_id_for_patch:
                     return
                 now = time.time()
-                if not force and now - _last_flush_time < _FLUSH_INTERVAL:
+                flush_interval = _FLUSH_INTERVAL_CARDKIT if cardkit_card_id else _FLUSH_INTERVAL_PATCH
+                if not force and now - _last_flush_time < flush_interval:
                     return
-                card = _build_card(
-                    "".join(_stream_buffer),
-                    "".join(_thinking_buffer),
-                    streaming=True,
-                )
-                # Skip patch when content has not changed since the last flush
-                # (common during heartbeat ticks when LLM is waiting for tool results).
-                current_hash = hash(
-                    "".join(_stream_buffer)
-                    + "".join(_thinking_buffer)
-                    + str(_tool_status_done)
-                    + str(list(_tool_status_running.values()))
-                )
-                if reason == "heartbeat" and current_hash == _last_flushed_hash:
-                    return
-                _last_flushed_hash = current_hash
-                await _queue_patch_card(card, stage=f"stream_{reason}")
+
+                accumulated = "".join(_stream_buffer)
+
+                if cardkit_card_id:
+                    if accumulated != _last_flushed_text:
+                        cardkit_sequence += 1
+                        try:
+                            await feishu_service.stream_card_content(
+                                config.app_id, config.app_secret,
+                                cardkit_card_id, "streaming_content",
+                                accumulated, cardkit_sequence,
+                            )
+                            _last_flushed_text = accumulated
+                        except Exception as e:
+                            logger.warning(f"[Feishu] CardKit stream failed: {e}")
+                elif msg_id_for_patch:
+                    card = _build_card(
+                        accumulated,
+                        "".join(_thinking_buffer),
+                        streaming=True,
+                    )
+                    current_hash = hash(
+                        accumulated
+                        + "".join(_thinking_buffer)
+                        + str(_tool_status_done)
+                        + str(list(_tool_status_running.values()))
+                    )
+                    if reason == "heartbeat" and current_hash == _last_flushed_hash:
+                        return
+                    _last_flushed_hash = current_hash
+                    await _queue_patch_card(card, stage=f"stream_{reason}")
+
                 _last_flush_time = now
 
             async def _ws_on_chunk(text: str):
-                if not msg_id_for_patch:
+                if not cardkit_card_id and not msg_id_for_patch:
                     return
                 _stream_buffer.append(text)
                 await _flush_stream("chunk")
 
             async def _ws_on_thinking(text: str):
-                if not msg_id_for_patch:
+                if not cardkit_card_id and not msg_id_for_patch:
                     return
                 _thinking_buffer.append(text)
                 await _flush_stream("thinking")
@@ -860,10 +924,10 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
 
             async def _heartbeat():
                 while not _llm_done:
-                    await asyncio.sleep(_FLUSH_INTERVAL)
+                    await asyncio.sleep(_FLUSH_INTERVAL_CARDKIT if cardkit_card_id else _FLUSH_INTERVAL_PATCH)
                     await _flush_stream("heartbeat")
 
-            if msg_id_for_patch:
+            if cardkit_card_id or msg_id_for_patch:
                 _heartbeat_task = asyncio.create_task(_heartbeat())
 
             # Call LLM with history and streaming callback
@@ -891,7 +955,30 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
             logger.info(f"[Feishu] LLM reply: {reply_text[:100]}")
 
             # Send final card update or fallback text
-            if msg_id_for_patch:
+            if cardkit_card_id:
+                try:
+                    cardkit_sequence += 1
+                    await feishu_service.set_card_streaming_mode(
+                        config.app_id, config.app_secret,
+                        cardkit_card_id, 0, cardkit_sequence,
+                    )
+                    cardkit_sequence += 1
+                    final_card = _build_final_cardkit_card(reply_text, "".join(_thinking_buffer))
+                    await feishu_service.update_cardkit_card(
+                        config.app_id, config.app_secret,
+                        cardkit_card_id, final_card, cardkit_sequence,
+                    )
+                except Exception as e:
+                    logger.error(f"[Feishu] CardKit final update failed: {e}")
+                    try:
+                        await feishu_service.send_message(
+                            config.app_id, config.app_secret, _reply_target, "text",
+                            _json.dumps({"text": reply_text}), receive_id_type=_rid_type,
+                            stage="stream_final_fallback_text",
+                        )
+                    except Exception as e2:
+                        logger.error(f"[Feishu] CardKit fallback text also failed: {e2}")
+            elif msg_id_for_patch:
                 try:
                     await _patch_queue.drain()
                 except Exception as e:
@@ -911,38 +998,21 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     )
                 except Exception as e:
                     logger.error(f"[Feishu] Final card patch failed: {e}")
-                    if chat_type == "group" and chat_id:
+                    try:
                         await feishu_service.send_message(
-                            config.app_id,
-                            config.app_secret,
-                            chat_id,
-                            "text",
-                            _json.dumps({"text": reply_text}),
-                            receive_id_type="chat_id",
+                            config.app_id, config.app_secret, _reply_target, "text",
+                            _json.dumps({"text": reply_text}), receive_id_type=_rid_type,
                             stage="stream_final_fallback_text",
                         )
-                    else:
-                        await feishu_service.send_message(
-                            config.app_id,
-                            config.app_secret,
-                            sender_open_id,
-                            "text",
-                            _json.dumps({"text": reply_text}),
-                            stage="stream_final_fallback_text",
-                        )
+                    except Exception as e2:
+                        logger.error(f"[Feishu] Fallback text also failed: {e2}")
             else:
-                # Fallback to plain text if card creation failed
                 try:
-                    if chat_type == "group" and chat_id:
-                        await feishu_service.send_message(
-                            config.app_id, config.app_secret, chat_id, "text",
-                            _json.dumps({"text": reply_text}), receive_id_type="chat_id", stage="stream_no_card_fallback_text",
-                        )
-                    else:
-                        await feishu_service.send_message(
-                            config.app_id, config.app_secret, sender_open_id, "text",
-                            _json.dumps({"text": reply_text}), stage="stream_no_card_fallback_text",
-                        )
+                    await feishu_service.send_message(
+                        config.app_id, config.app_secret, _reply_target, "text",
+                        _json.dumps({"text": reply_text}), receive_id_type=_rid_type,
+                        stage="stream_no_card_fallback_text",
+                    )
                 except Exception as e:
                     logger.error(f"[Feishu] Failed to send fallback message: {e}")
 

--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -735,6 +735,7 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
             _llm_done = False
             _last_flushed_hash: int = 0
             _last_flushed_text: str = ""
+            _flush_lock = asyncio.Lock()
 
             def _build_card(
                 answer_text: str,
@@ -848,43 +849,38 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                 nonlocal _last_flush_time, _last_flushed_hash, cardkit_sequence, _last_flushed_text
                 if not cardkit_card_id and not msg_id_for_patch:
                     return
-                now = time.time()
-                flush_interval = _FLUSH_INTERVAL_CARDKIT if cardkit_card_id else _FLUSH_INTERVAL_PATCH
-                if not force and now - _last_flush_time < flush_interval:
-                    return
-
-                accumulated = "".join(_stream_buffer)
-
-                if cardkit_card_id:
-                    if accumulated != _last_flushed_text:
-                        cardkit_sequence += 1
-                        try:
-                            await feishu_service.stream_card_content(
-                                config.app_id, config.app_secret,
-                                cardkit_card_id, "streaming_content",
-                                accumulated, cardkit_sequence,
-                            )
-                            _last_flushed_text = accumulated
-                        except Exception as e:
-                            logger.warning(f"[Feishu] CardKit stream failed: {e}")
-                elif msg_id_for_patch:
-                    card = _build_card(
-                        accumulated,
-                        "".join(_thinking_buffer),
-                        streaming=True,
-                    )
-                    current_hash = hash(
-                        accumulated
-                        + "".join(_thinking_buffer)
-                        + str(_tool_status_done)
-                        + str(list(_tool_status_running.values()))
-                    )
-                    if reason == "heartbeat" and current_hash == _last_flushed_hash:
+                async with _flush_lock:
+                    logger.debug(f"[Feishu] flush({reason}): seq={cardkit_sequence}")
+                    now = time.time()
+                    flush_interval = _FLUSH_INTERVAL_CARDKIT if cardkit_card_id else _FLUSH_INTERVAL_PATCH
+                    if not force and now - _last_flush_time < flush_interval:
                         return
-                    _last_flushed_hash = current_hash
-                    await _queue_patch_card(card, stage=f"stream_{reason}")
-
-                _last_flush_time = now
+                    accumulated = "".join(_stream_buffer)
+                    if cardkit_card_id:
+                        if accumulated != _last_flushed_text:
+                            cardkit_sequence += 1
+                            try:
+                                await asyncio.wait_for(
+                                    feishu_service.stream_card_content(
+                                        config.app_id, config.app_secret,
+                                        cardkit_card_id, "streaming_content",
+                                        accumulated, cardkit_sequence,
+                                    ),
+                                    timeout=5.0,
+                                )
+                                _last_flushed_text = accumulated
+                            except asyncio.TimeoutError:
+                                logger.warning(f"[Feishu] CardKit stream timed out, seq={cardkit_sequence}")
+                            except Exception as e:
+                                logger.warning(f"[Feishu] CardKit stream failed: {e}")
+                    elif msg_id_for_patch:
+                        card = _build_card(accumulated, "".join(_thinking_buffer), streaming=True)
+                        current_hash = hash(accumulated + "".join(_thinking_buffer) + str(_tool_status_done) + str(list(_tool_status_running.values())))
+                        if reason == "heartbeat" and current_hash == _last_flushed_hash:
+                            return
+                        _last_flushed_hash = current_hash
+                        await _queue_patch_card(card, stage=f"stream_{reason}")
+                    _last_flush_time = now
 
             async def _ws_on_chunk(text: str):
                 if not cardkit_card_id and not msg_id_for_patch:
@@ -948,7 +944,7 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
                     _heartbeat_task.cancel()
                     try:
                         await _heartbeat_task
-                    except Exception:
+                    except (Exception, asyncio.CancelledError):
                         pass
                 _cfs.reset(_cfs_token)
                 _cfso.reset(_cfso_token)
@@ -958,15 +954,21 @@ async def process_feishu_event(agent_id: uuid.UUID, body: dict, db: AsyncSession
             if cardkit_card_id:
                 try:
                     cardkit_sequence += 1
-                    await feishu_service.set_card_streaming_mode(
-                        config.app_id, config.app_secret,
-                        cardkit_card_id, 0, cardkit_sequence,
+                    await asyncio.wait_for(
+                        feishu_service.set_card_streaming_mode(
+                            config.app_id, config.app_secret,
+                            cardkit_card_id, 0, cardkit_sequence,
+                        ),
+                        timeout=10.0,
                     )
                     cardkit_sequence += 1
                     final_card = _build_final_cardkit_card(reply_text, "".join(_thinking_buffer))
-                    await feishu_service.update_cardkit_card(
-                        config.app_id, config.app_secret,
-                        cardkit_card_id, final_card, cardkit_sequence,
+                    await asyncio.wait_for(
+                        feishu_service.update_cardkit_card(
+                            config.app_id, config.app_secret,
+                            cardkit_card_id, final_card, cardkit_sequence,
+                        ),
+                        timeout=10.0,
                     )
                 except Exception as e:
                     logger.error(f"[Feishu] CardKit final update failed: {e}")

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -291,6 +291,7 @@ async def call_llm(
             return f"[LLM call error] {type(e).__name__}: {str(e)[:200]}"
 
         # ── Track tokens for this round ──
+        logger.info(f"[LLM] stream() returned: {len(response.content or '')} chars, finish={response.finish_reason}, tools={len(response.tool_calls or [])}")
         real_tokens = extract_usage_tokens(response.usage)
         if real_tokens:
             _accumulated_tokens += real_tokens
@@ -301,9 +302,12 @@ async def call_llm(
 
         # If no tool calls, return the final content
         if not response.tool_calls:
+            logger.info("[LLM] No tool calls, recording tokens and closing client")
             if agent_id and _accumulated_tokens > 0:
                 await record_token_usage(agent_id, _accumulated_tokens)
+            logger.info("[LLM] Tokens recorded, closing client")
             await client.close()
+            logger.info(f"[LLM] Client closed, returning content: {len(response.content or '')} chars")
             return response.content or "[LLM returned empty content]"
 
         # Execute tool calls

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -291,23 +291,19 @@ async def call_llm(
             return f"[LLM call error] {type(e).__name__}: {str(e)[:200]}"
 
         # ── Track tokens for this round ──
-        logger.info(f"[LLM] stream() returned: {len(response.content or '')} chars, finish={response.finish_reason}, tools={len(response.tool_calls or [])}")
+        logger.debug(f"[LLM] stream() returned: {len(response.content or '')} chars, finish={response.finish_reason}, tools={len(response.tool_calls or [])}")
         real_tokens = extract_usage_tokens(response.usage)
         if real_tokens:
             _accumulated_tokens += real_tokens
         else:
-            # Fallback: estimate from message content length
             round_chars = sum(len(m.content or '') if isinstance(m.content, str) else 0 for m in api_messages) + len(response.content or '')
             _accumulated_tokens += estimate_tokens_from_chars(round_chars)
 
         # If no tool calls, return the final content
         if not response.tool_calls:
-            logger.info("[LLM] No tool calls, recording tokens and closing client")
             if agent_id and _accumulated_tokens > 0:
                 await record_token_usage(agent_id, _accumulated_tokens)
-            logger.info("[LLM] Tokens recorded, closing client")
             await client.close()
-            logger.info(f"[LLM] Client closed, returning content: {len(response.content or '')} chars")
             return response.content or "[LLM returned empty content]"
 
         # Execute tool calls

--- a/backend/app/services/feishu_service.py
+++ b/backend/app/services/feishu_service.py
@@ -1,7 +1,16 @@
 """Feishu (Lark) OAuth and API integration service."""
 
+import json
+
 import httpx
 from loguru import logger
+
+try:
+    import lark_oapi as lark
+    _HAS_LARK = True
+except ImportError:
+    lark = None  # type: ignore
+    _HAS_LARK = False
 from sqlalchemy import select, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,6 +34,7 @@ class FeishuService:
         self.app_id = settings.FEISHU_APP_ID
         self.app_secret = settings.FEISHU_APP_SECRET
         self._app_access_token: str | None = None
+        self._lark_clients: dict[str, lark.Client] = {}
 
     @staticmethod
     def _parse_api_response(
@@ -694,5 +704,206 @@ class FeishuService:
                 headers={"Authorization": f"Bearer {tenant_token}"}
             )
             return resp.json()
+
+    # --- CardKit Streaming API ---
+
+    def _get_lark_client(self, app_id: str, app_secret: str):
+        """Get or create a cached lark-oapi SDK client for the given app credentials."""
+        if not _HAS_LARK:
+            raise RuntimeError("lark-oapi package is not installed. Install with: pip install lark-oapi")
+        cache_key = f"{app_id}:{app_secret}"
+        client = self._lark_clients.get(cache_key)
+        if client is None:
+            client = lark.Client.builder().app_id(app_id).app_secret(app_secret).build()
+            self._lark_clients[cache_key] = client
+        return client
+
+    async def create_card_entity(
+        self,
+        app_id: str,
+        app_secret: str,
+        card_dict: dict,
+    ) -> str:
+        """Create a CardKit card entity and return its card_id."""
+        from lark_oapi.api.cardkit.v1.model import (
+            CreateCardRequest, CreateCardRequestBody,
+        )
+
+        client = self._get_lark_client(app_id, app_secret)
+        body = CreateCardRequestBody.builder() \
+            .type("card_json") \
+            .data(json.dumps(card_dict)) \
+            .build()
+        request = CreateCardRequest.builder().request_body(body).build()
+
+        try:
+            resp = await client.cardkit.v1.card.acreate(request)
+            logger.info(
+                f"[Feishu CardKit] create_card_entity response: "
+                f"code={resp.code}, msg={resp.msg}"
+            )
+            if not resp.success():
+                raise RuntimeError(
+                    f"Feishu CardKit create_card_entity failed: code={resp.code}, msg={resp.msg}"
+                )
+            return resp.data.card_id
+        except Exception as e:
+            if isinstance(e, RuntimeError):
+                raise
+            logger.error(f"[Feishu CardKit] create_card_entity error: {e}")
+            raise RuntimeError(f"Feishu CardKit create_card_entity error: {e}") from e
+
+    async def send_card_by_card_id(
+        self,
+        app_id: str,
+        app_secret: str,
+        receive_id: str,
+        card_id: str,
+        receive_id_type: str = "open_id",
+    ) -> None:
+        """Send an interactive message referencing an existing card_id."""
+        content = json.dumps({
+            "type": "card",
+            "data": {"card_id": card_id},
+        })
+        await self.send_message(
+            app_id=app_id,
+            app_secret=app_secret,
+            receive_id=receive_id,
+            msg_type="interactive",
+            content=content,
+            receive_id_type=receive_id_type,
+            stage="send_card_by_card_id",
+        )
+
+    async def stream_card_content(
+        self,
+        app_id: str,
+        app_secret: str,
+        card_id: str,
+        element_id: str,
+        content: str,
+        sequence: int,
+    ) -> None:
+        """Stream content to a specific card element via CardKit API."""
+        from lark_oapi.api.cardkit.v1.model import (
+            ContentCardElementRequest, ContentCardElementRequestBody,
+        )
+
+        client = self._get_lark_client(app_id, app_secret)
+        body = ContentCardElementRequestBody.builder() \
+            .content(content) \
+            .sequence(sequence) \
+            .build()
+        request = ContentCardElementRequest.builder() \
+            .card_id(card_id) \
+            .element_id(element_id) \
+            .request_body(body) \
+            .build()
+
+        try:
+            resp = await client.cardkit.v1.card_element.acontent(request)
+            logger.info(
+                f"[Feishu CardKit] stream_card_content response: "
+                f"code={resp.code}, msg={resp.msg}, card_id={card_id}, "
+                f"element_id={element_id}, sequence={sequence}"
+            )
+            if not resp.success():
+                raise RuntimeError(
+                    f"Feishu CardKit stream_card_content failed: "
+                    f"code={resp.code}, msg={resp.msg}"
+                )
+        except Exception as e:
+            if isinstance(e, RuntimeError):
+                raise
+            logger.error(f"[Feishu CardKit] stream_card_content error: {e}")
+            raise RuntimeError(f"Feishu CardKit stream_card_content error: {e}") from e
+
+    async def set_card_streaming_mode(
+        self,
+        app_id: str,
+        app_secret: str,
+        card_id: str,
+        streaming_mode: int,
+        sequence: int,
+    ) -> None:
+        """Toggle streaming mode on a card via CardKit settings API."""
+        from lark_oapi.api.cardkit.v1.model import (
+            SettingsCardRequest, SettingsCardRequestBody,
+        )
+
+        client = self._get_lark_client(app_id, app_secret)
+        body = SettingsCardRequestBody.builder() \
+            .settings(json.dumps({"streaming_mode": streaming_mode})) \
+            .sequence(sequence) \
+            .build()
+        request = SettingsCardRequest.builder() \
+            .card_id(card_id) \
+            .request_body(body) \
+            .build()
+
+        try:
+            resp = await client.cardkit.v1.card.asettings(request)
+            logger.info(
+                f"[Feishu CardKit] set_card_streaming_mode response: "
+                f"code={resp.code}, msg={resp.msg}, card_id={card_id}, "
+                f"streaming_mode={streaming_mode}, sequence={sequence}"
+            )
+            if not resp.success():
+                raise RuntimeError(
+                    f"Feishu CardKit set_card_streaming_mode failed: "
+                    f"code={resp.code}, msg={resp.msg}"
+                )
+        except Exception as e:
+            if isinstance(e, RuntimeError):
+                raise
+            logger.error(f"[Feishu CardKit] set_card_streaming_mode error: {e}")
+            raise RuntimeError(f"Feishu CardKit set_card_streaming_mode error: {e}") from e
+
+    async def update_cardkit_card(
+        self,
+        app_id: str,
+        app_secret: str,
+        card_id: str,
+        card_dict: dict,
+        sequence: int,
+    ) -> None:
+        """Full card update via CardKit API."""
+        from lark_oapi.api.cardkit.v1.model import (
+            UpdateCardRequest, UpdateCardRequestBody, Card,
+        )
+
+        client = self._get_lark_client(app_id, app_secret)
+        card = Card.builder() \
+            .type("card_json") \
+            .data(json.dumps(card_dict)) \
+            .build()
+        body = UpdateCardRequestBody.builder() \
+            .card(card) \
+            .sequence(sequence) \
+            .build()
+        request = UpdateCardRequest.builder() \
+            .card_id(card_id) \
+            .request_body(body) \
+            .build()
+
+        try:
+            resp = await client.cardkit.v1.card.aupdate(request)
+            logger.info(
+                f"[Feishu CardKit] update_cardkit_card response: "
+                f"code={resp.code}, msg={resp.msg}, card_id={card_id}, "
+                f"sequence={sequence}"
+            )
+            if not resp.success():
+                raise RuntimeError(
+                    f"Feishu CardKit update_cardkit_card failed: "
+                    f"code={resp.code}, msg={resp.msg}"
+                )
+        except Exception as e:
+            if isinstance(e, RuntimeError):
+                raise
+            logger.error(f"[Feishu CardKit] update_cardkit_card error: {e}")
+            raise RuntimeError(f"Feishu CardKit update_cardkit_card error: {e}") from e
+
 
 feishu_service = FeishuService()

--- a/backend/app/services/feishu_ws.py
+++ b/backend/app/services/feishu_ws.py
@@ -16,6 +16,33 @@ except ImportError:
     ws = None    # type: ignore
     _HAS_LARK = False
 
+if _HAS_LARK:
+    try:
+        import websockets as _websockets
+        _orig_connect = _websockets.connect
+
+        class _NoProxyConnect:
+            def __init__(self, *args, **kwargs):
+                kwargs.setdefault("proxy", None)
+                self._coro = _orig_connect(*args, **kwargs)
+                self._ws = None
+
+            def __await__(self):
+                return self._coro.__await__()
+
+            async def __aenter__(self):
+                self._ws = await self._coro
+                return self._ws
+
+            async def __aexit__(self, *exc):
+                if self._ws:
+                    await self._ws.close()
+
+        _websockets.connect = _NoProxyConnect
+        logger.info("[Feishu WS] Patched websockets.connect to bypass system proxy")
+    except Exception as _patch_err:
+        logger.warning(f"[Feishu WS] Failed to patch websockets: {_patch_err}")
+
 from app.database import async_session
 from app.models.channel_config import ChannelConfig
 from sqlalchemy import select

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -246,7 +246,7 @@ class OpenAICompatibleClient(LLMClient):
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True)
+            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True, proxy=None)
         return self._client
 
     def _get_headers(self) -> dict[str, str]:
@@ -575,7 +575,11 @@ class OpenAICompatibleClient(LLMClient):
     async def close(self) -> None:
         """Close the HTTP client."""
         if self._client and not self._client.is_closed:
-            await self._client.aclose()
+            try:
+                await asyncio.wait_for(self._client.aclose(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("[LLM] Client close timed out, forcing")
+                self._client = None
 
 
 # ============================================================================
@@ -602,7 +606,7 @@ class OpenAIResponsesClient(LLMClient):
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True)
+            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True, proxy=None)
         return self._client
 
     def _get_headers(self) -> dict[str, str]:
@@ -872,7 +876,11 @@ class OpenAIResponsesClient(LLMClient):
     async def close(self) -> None:
         """Close the HTTP client."""
         if self._client and not self._client.is_closed:
-            await self._client.aclose()
+            try:
+                await asyncio.wait_for(self._client.aclose(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("[LLM] Client close timed out, forcing")
+                self._client = None
 
 
 # ============================================================================
@@ -900,7 +908,7 @@ class GeminiClient(LLMClient):
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True)
+            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True, proxy=None)
         return self._client
 
     async def _get_openai_fallback_client(self) -> OpenAICompatibleClient:
@@ -1355,7 +1363,11 @@ class GeminiClient(LLMClient):
         if self._openai_fallback_client:
             await self._openai_fallback_client.close()
         if self._client and not self._client.is_closed:
-            await self._client.aclose()
+            try:
+                await asyncio.wait_for(self._client.aclose(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("[LLM] Client close timed out, forcing")
+                self._client = None
 
 
 # ============================================================================
@@ -1384,7 +1396,7 @@ class AnthropicClient(LLMClient):
     async def _get_client(self) -> httpx.AsyncClient:
         """Get or create HTTP client."""
         if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True)
+            self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True, proxy=None)
         return self._client
 
     def _get_headers(self) -> dict[str, str]:
@@ -1593,6 +1605,7 @@ class AnthropicClient(LLMClient):
                         
                     if line.startswith("event:"):
                         current_event = line[len("event:"):].strip()
+                        logger.debug(f"[Anthropic SSE] event: {current_event}")
                         continue
                         
                     if not line.startswith("data:"):
@@ -1600,6 +1613,7 @@ class AnthropicClient(LLMClient):
                         
                     data_str = line[len("data:"):].strip()
                     if data_str == "[DONE]":
+                        logger.info("[Anthropic SSE] received [DONE]")
                         break
                         
                     try:
@@ -1653,11 +1667,13 @@ class AnthropicClient(LLMClient):
                                 
                     elif current_event == "message_delta":
                         delta = data.get("delta", {})
+                        logger.info(f"[Anthropic SSE] message_delta: stop_reason={delta.get('stop_reason')}, usage={bool(data.get('usage'))}")
+                        if data.get("usage"):
+                            final_usage = data["usage"]
                         if delta.get("stop_reason"):
                             last_finish_reason = delta["stop_reason"]
-                        if data.get("usage"):
-                            # message_delta usage is cumulative
-                            final_usage = data["usage"]
+                            logger.info("[Anthropic SSE] breaking on stop_reason")
+                            break
                             
                     elif current_event == "error":
                         error_info = data.get("error", {})
@@ -1665,6 +1681,8 @@ class AnthropicClient(LLMClient):
 
                     elif current_event == "message_stop":
                         break
+
+            logger.info(f"[Anthropic SSE] stream loop ended, content={len(full_content)} chars, finish={last_finish_reason}, tools={len(tool_calls_data)}")
 
         except (httpx.TransportError, httpx.ConnectTimeout) as e:
             # TransportError covers NetworkError (ConnectError, ReadError) and
@@ -1676,6 +1694,8 @@ class AnthropicClient(LLMClient):
             last_finish_reason = "stop"
         elif last_finish_reason == "tool_use":
             last_finish_reason = "tool_calls"
+
+        logger.info(f"[Anthropic SSE] returning LLMResponse: {len(full_content)} chars, finish={last_finish_reason}")
 
         return LLMResponse(
             content=full_content,
@@ -1690,7 +1710,11 @@ class AnthropicClient(LLMClient):
     async def close(self) -> None:
         """Close the HTTP client."""
         if self._client and not self._client.is_closed:
-            await self._client.aclose()
+            try:
+                await asyncio.wait_for(self._client.aclose(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.warning("[LLM] Client close timed out, forcing")
+                self._client = None
 
 
 # ============================================================================

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -538,8 +538,9 @@ class OpenAICompatibleClient(LLMClient):
 
                         if chunk.finish_reason:
                             last_finish_reason = chunk.finish_reason
+                            break
 
-                break  # Success
+                break
 
             except (httpx.TransportError, httpx.ConnectTimeout) as e:
                 # TransportError covers all network-layer issues:
@@ -1299,8 +1300,10 @@ class GeminiClient(LLMClient):
                     if not line.startswith("data:"):
                         continue
                     data_str = line[len("data:"):].strip()
-                    if not data_str or data_str == "[DONE]":
+                    if not data_str:
                         continue
+                    if data_str == "[DONE]":
+                        break
 
                     try:
                         data = json.loads(data_str)
@@ -1319,6 +1322,8 @@ class GeminiClient(LLMClient):
                         continue
                     candidate = candidates[0]
                     final_finish_reason = candidate.get("finishReason") or final_finish_reason
+                    if final_finish_reason:
+                        break
                     content_obj = candidate.get("content", {}) or {}
                     for part in content_obj.get("parts", []) or []:
                         text = part.get("text")

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -1618,7 +1618,7 @@ class AnthropicClient(LLMClient):
                         
                     data_str = line[len("data:"):].strip()
                     if data_str == "[DONE]":
-                        logger.info("[Anthropic SSE] received [DONE]")
+                        logger.debug("[Anthropic SSE] received [DONE]")
                         break
                         
                     try:
@@ -1672,12 +1672,12 @@ class AnthropicClient(LLMClient):
                                 
                     elif current_event == "message_delta":
                         delta = data.get("delta", {})
-                        logger.info(f"[Anthropic SSE] message_delta: stop_reason={delta.get('stop_reason')}, usage={bool(data.get('usage'))}")
+                        logger.debug(f"[Anthropic SSE] message_delta: stop_reason={delta.get('stop_reason')}, usage={bool(data.get('usage'))}")
                         if data.get("usage"):
                             final_usage = data["usage"]
                         if delta.get("stop_reason"):
                             last_finish_reason = delta["stop_reason"]
-                            logger.info("[Anthropic SSE] breaking on stop_reason")
+                            logger.debug("[Anthropic SSE] breaking on stop_reason")
                             break
                             
                     elif current_event == "error":
@@ -1687,7 +1687,7 @@ class AnthropicClient(LLMClient):
                     elif current_event == "message_stop":
                         break
 
-            logger.info(f"[Anthropic SSE] stream loop ended, content={len(full_content)} chars, finish={last_finish_reason}, tools={len(tool_calls_data)}")
+            logger.debug(f"[Anthropic SSE] stream loop ended, content={len(full_content)} chars, finish={last_finish_reason}, tools={len(tool_calls_data)}")
 
         except (httpx.TransportError, httpx.ConnectTimeout) as e:
             # TransportError covers NetworkError (ConnectError, ReadError) and
@@ -1700,7 +1700,7 @@ class AnthropicClient(LLMClient):
         elif last_finish_reason == "tool_use":
             last_finish_reason = "tool_calls"
 
-        logger.info(f"[Anthropic SSE] returning LLMResponse: {len(full_content)} chars, finish={last_finish_reason}")
+        logger.debug(f"[Anthropic SSE] returning LLMResponse: {len(full_content)} chars, finish={last_finish_reason}")
 
         return LLMResponse(
             content=full_content,


### PR DESCRIPTION
## Summary

Implements CardKit streaming card API for smooth typewriter-style output in Feishu (Lark), and fixes multiple SSE stream hanging issues that caused the bot to become unresponsive.

Closes #287

## What's New

### CardKit Streaming Card Integration
- **`create_card_entity()`** — Create CardKit card entities for streaming
- **`send_card_by_card_id()`** — Send cards by card_id via IM API
- **`stream_card_content()`** — Element-level streaming content push (500ms refresh interval)
- **`set_card_streaming_mode()`** — Enable/disable streaming mode on cards
- **`update_cardkit_card()`** — Full card content update after streaming completes

### Dual-Path Design with Graceful Degradation
1. **CardKit path** (preferred): create → stream → close streaming → final update
2. **IM Patch path** (fallback): send interactive card → patch updates
3. **Plain text** (last resort): simple text message

### Streaming Flush Control
- `asyncio.Lock`-protected `_flush_stream()` — prevents sequence conflicts
- `_SerialPatchQueue` — serializes IM patch requests to prevent out-of-order overwrites
- Heartbeat refresh task — periodic card updates during tool execution

## Bug Fixes

### 1. Anthropic SSE Stream Hang (Root Cause)
`AnthropicClient.stream()` waited indefinitely for a `message_stop` event that Zhipu's Anthropic-compatible API never sends. After receiving `message_delta` with `stop_reason`, the `aiter_lines()` loop hung forever.

**Fix**: Break immediately on `stop_reason` in `message_delta`, before waiting for `message_stop`.

### 2. `CancelledError` Not Caught in Heartbeat Cleanup
In Python 3.9+, `asyncio.CancelledError` inherits from `BaseException`, not `Exception`. The `except Exception: pass` block in the heartbeat task cleanup did not catch it, causing the exception to propagate and skip the final card update entirely.

**Fix**: Changed to `except (Exception, asyncio.CancelledError)`.

### 3. httpx System Proxy Interference
`httpx.AsyncClient` auto-detects macOS system proxy settings, which can interfere with long-lived SSE connections to LLM APIs.

**Fix**: Added `proxy=None` to all `httpx.AsyncClient` constructors.

### 4. httpx `aclose()` Indefinite Blocking
When a streaming connection was terminated early (via `break`), `httpx.AsyncClient.aclose()` could hang indefinitely waiting for the server to finish sending.

**Fix**: Wrapped `aclose()` in `asyncio.wait_for(..., timeout=5.0)` for all client classes.

### 5. OpenAI/Gemini SSE Stream Termination
- **OpenAICompatibleClient**: Only broke on `[DONE]`, not on `finish_reason`. If a provider sends `finish_reason` without `[DONE]`, the stream hangs.
- **GeminiClient**: `[DONE]` was only `continue`d (not breaking), and `finishReason` was recorded but never acted on. The client relied solely on HTTP connection close.

**Fix**: Added `finish_reason` break protection to both clients, matching the Anthropic client's defensive pattern.

## Files Changed

| File | Changes |
|------|---------|
| `backend/app/api/feishu.py` | CardKit streaming integration, flush control, CancelledError fix |
| `backend/app/api/websocket.py` | Stream return logging |
| `backend/app/services/feishu_service.py` | 5 new CardKit API methods |
| `backend/app/services/feishu_ws.py` | WebSocket proxy bypass |
| `backend/app/services/llm_client.py` | SSE break protection (all 3 clients), proxy=None, aclose timeout |

## Testing

| Provider | Mode | Model | Result |
|----------|------|-------|--------|
| Zhipu | Anthropic-compatible | GLM | ✅ Streaming cards work end-to-end |
| Zhipu | OpenAI-compatible | GLM | ✅ Streaming cards work end-to-end |
| Google | Gemini native | Gemini 2.5 Flash | ✅ Streaming cards work end-to-end |