### PR TITLE
feat(llm): enhance retry strategy with primary/fallback model alternation

### DIFF
--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -1523,80 +1523,15 @@ async def _call_agent_llm(
                 on_chunk=on_chunk,
                 on_thinking=on_thinking,
                 on_tool_call=on_tool_call,
+                fallback_model=fallback_model,
             ),
             timeout=_timeout,
         )
         return reply
     except asyncio.TimeoutError:
-        logger.error(
-            f"[LLM] Call timed out after {_timeout}s "
-            f"(agent_id={agent_id}, model={getattr(model, 'model', 'unknown')})"
-        )
-        if fallback_model:
-            # Use the fallback model's own timeout budget.
-            _fb_timeout = _get_llm_timeout(fallback_model)
-            logger.info(f"[LLM] Retrying timed-out request with fallback model: {fallback_model.model} (timeout={_fb_timeout}s)")
-            try:
-                reply = await asyncio.wait_for(
-                    call_llm(
-                        fallback_model,
-                        messages,
-                        agent.name,
-                        agent.role_description or "",
-                        agent_id=agent_id,
-                        user_id=effective_user_id,
-                        supports_vision=getattr(fallback_model, 'supports_vision', False),
-                        on_chunk=on_chunk,
-                        on_thinking=on_thinking,
-                        on_tool_call=on_tool_call,
-                    ),
-                    timeout=_fb_timeout,
-                )
-                return reply
-            except asyncio.TimeoutError:
-                logger.error(
-                    f"[LLM] Fallback call also timed out after {_fb_timeout}s "
-                    f"(agent_id={agent_id}, model={getattr(fallback_model, 'model', 'unknown')})"
-                )
-                return f"⚠️ Model response timed out (>{int(_fb_timeout)}s). Please retry or shorten your request."
-            except Exception as e2:
-                import traceback
-                traceback.print_exc()
-                return f"⚠️ Model error: Primary Timeout | Fallback: {str(e2)[:80]}"
+        logger.error(f"[LLM] Call timed out after {_timeout}s (agent_id={agent_id})")
         return f"⚠️ Model response timed out (>{int(_timeout)}s). Please retry or shorten your request."
     except Exception as e:
         import traceback
         traceback.print_exc()
-        error_msg = str(e) or repr(e)
-        logger.error(f"[LLM] Primary model error: {error_msg}")
-        # Runtime fallback: primary model failed -> retry with fallback model
-        if fallback_model:
-            logger.info(f"[LLM] Retrying with fallback model: {fallback_model.model}")
-            try:
-                _fb_timeout = _get_llm_timeout(fallback_model)
-                reply = await asyncio.wait_for(
-                    call_llm(
-                        fallback_model,
-                        messages,
-                        agent.name,
-                        agent.role_description or "",
-                        agent_id=agent_id,
-                        user_id=effective_user_id,
-                        supports_vision=getattr(fallback_model, 'supports_vision', False),
-                        on_chunk=on_chunk,
-                        on_thinking=on_thinking,
-                        on_tool_call=on_tool_call,
-                    ),
-                    timeout=_fb_timeout,
-                )
-                return reply
-            except asyncio.TimeoutError:
-                logger.error(
-                    f"[LLM] Fallback call timed out after {_fb_timeout}s "
-                    f"(agent_id={agent_id}, model={getattr(fallback_model, 'model', 'unknown')})"
-                )
-                return f"⚠️ Model error: Primary: {str(e)[:80]} | Fallback Timeout"
-            except Exception as e2:
-                traceback.print_exc()
-                return f"⚠️ Model error: Primary: {str(e)[:80]} | Fallback: {str(e2)[:80]}"
-        return f"⚠️ 调用模型出错: {error_msg[:150]}"
+        return f"⚠️ 调用模型出错: {(str(e) or repr(e))[:150]}"

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -121,6 +121,8 @@ async def call_llm(
     on_tool_call=None,
     on_thinking=None,
     supports_vision=False,
+    fallback_model: LLMModel | None = None,
+    on_notify=None,
 ) -> str:
     """Call LLM via unified client with function-calling tool loop.
 
@@ -128,6 +130,8 @@ async def call_llm(
         on_chunk: Optional async callback(text: str) for streaming chunks to client.
         on_thinking: Optional async callback(text: str) for reasoning/thinking content.
         on_tool_call: Optional async callback(dict) for tool call status updates.
+        fallback_model: Optional fallback model for retry alternation (LLM_RETRY_MAX config).
+        on_notify: Optional async callback(str) to notify client about retry status.
     """
     from app.services.agent_tools import AGENT_TOOLS, execute_tool, get_agent_tools_for_llm
     from app.services.llm_utils import create_llm_client, get_max_tokens, LLMMessage, LLMError
@@ -222,18 +226,35 @@ async def call_llm(
                 )
 
     # Create the unified LLM client
-    try:
-        client = create_llm_client(
-            provider=model.provider,
-            api_key=model.api_key_encrypted,
-            model=model.model,
-            base_url=model.base_url,
-            timeout=float(getattr(model, 'request_timeout', None) or 120.0),
+    def _make_client(m: LLMModel):
+        return create_llm_client(
+            provider=m.provider,
+            api_key=m.api_key_encrypted,
+            model=m.model,
+            base_url=m.base_url,
+            timeout=float(getattr(m, 'request_timeout', None) or 120.0),
         )
+
+    try:
+        client = _make_client(model)
     except Exception as e:
         return f"[Error] Failed to create LLM client: {e}"
 
     max_tokens = get_max_tokens(model.provider, model.model, getattr(model, 'max_output_tokens', None))
+
+    # ── Retry config ──
+    from app.config import get_settings
+    _max_retries = max(get_settings().LLM_RETRY_MAX, 1)
+    _retry_models = [model]
+    if fallback_model:
+        _retry_models.append(fallback_model)
+
+    def _retry_delay(attempt: int) -> float:
+        """First 50% fixed 1s, rest exponential (max 30s)."""
+        half = _max_retries // 2
+        if attempt < half:
+            return 1.0
+        return min(2.0 ** (attempt - half + 1), 30.0)
 
     # ── Per-round token accumulator ──
     from app.services.token_tracker import record_token_usage, extract_usage_tokens, estimate_tokens_from_chars
@@ -261,34 +282,54 @@ async def call_llm(
                 content=f"🚨 仅剩 2 轮工具调用。请立即保存进度到 focus.md 并设置续接触发器。",
             ))
 
-        try:
-            # Use streaming API for real-time responses
-            response = await client.stream(
-                messages=api_messages,
-                tools=tools_for_llm if tools_for_llm else None,
-                temperature=model.temperature,
-                max_tokens=max_tokens,
-                on_chunk=on_chunk,
-                on_thinking=on_thinking,
-            )
-        except LLMError as e:
-            # Record accumulated tokens before returning error
-            logger.error(
-                f"[LLM] LLMError provider={getattr(model, 'provider', '?')} "
-                f"model={getattr(model, 'model', '?')} round={round_i + 1}: {e}"
-            )
+        # ── LLM call with retry + model alternation ──
+        response = None
+        _last_err = None
+        _prev_model_id = id(model)
+        for _attempt in range(_max_retries):
+            _cur_model = _retry_models[_attempt % len(_retry_models)]
+            _cur_label = getattr(_cur_model, 'model', '?')
+
+            if _attempt > 0:
+                _delay = _retry_delay(_attempt)
+                logger.info(f"[Retry] Round {round_i+1}, attempt {_attempt+1}/{_max_retries} → {_cur_label}, wait {_delay:.1f}s")
+                if on_notify:
+                    try:
+                        await on_notify(f"Retrying ({_attempt+1}/{_max_retries}) with {_cur_label}...")
+                    except Exception:
+                        pass
+                await asyncio.sleep(_delay)
+                # Recreate client only when model actually changes
+                if id(_cur_model) != _prev_model_id:
+                    try:
+                        client = _make_client(_cur_model)
+                        max_tokens = get_max_tokens(_cur_model.provider, _cur_model.model, getattr(_cur_model, 'max_output_tokens', None))
+                    except Exception:
+                        continue
+                    _prev_model_id = id(_cur_model)
+
+            try:
+                response = await client.stream(
+                    messages=api_messages,
+                    tools=tools_for_llm if tools_for_llm else None,
+                    temperature=_cur_model.temperature,
+                    max_tokens=max_tokens,
+                    on_chunk=on_chunk,
+                    on_thinking=on_thinking,
+                )
+                break  # success
+            except Exception as e:
+                _last_err = e
+                logger.warning(f"[Retry] Round {round_i+1} attempt {_attempt+1} failed: {type(e).__name__}: {str(e)[:150]}")
+                if _attempt >= _max_retries - 1:
+                    if agent_id and _accumulated_tokens > 0:
+                        await record_token_usage(agent_id, _accumulated_tokens)
+                    return f"[LLM Error] {e}"
+
+        if response is None:
             if agent_id and _accumulated_tokens > 0:
                 await record_token_usage(agent_id, _accumulated_tokens)
-            return f"[LLM Error] {e}"
-        except Exception as e:
-            logger.error(
-                f"[LLM] Unexpected error provider={getattr(model, 'provider', '?')} "
-                f"model={getattr(model, 'model', '?')} round={round_i + 1}: "
-                f"{type(e).__name__}: {str(e)[:300]}"
-            )
-            if agent_id and _accumulated_tokens > 0:
-                await record_token_usage(agent_id, _accumulated_tokens)
-            return f"[LLM call error] {type(e).__name__}: {str(e)[:200]}"
+            return f"[LLM Error] {_last_err}"
 
         # ── Track tokens for this round ──
         logger.debug(f"[LLM] stream() returned: {len(response.content or '')} chars, finish={response.finish_reason}, tools={len(response.tool_calls or [])}")
@@ -823,7 +864,7 @@ async def websocket_chat(
 
                     import asyncio as _aio
 
-                    # Run call_llm as a cancellable task
+                    # Run call_llm as a cancellable task (retry logic is built-in)
                     llm_task = _aio.create_task(call_llm(
                         llm_model,
                         conversation[-ctx_size:],
@@ -836,6 +877,8 @@ async def websocket_chat(
                         on_tool_call=tool_call_to_ws,
                         on_thinking=thinking_to_ws,
                         supports_vision=getattr(llm_model, 'supports_vision', False),
+                        fallback_model=fallback_llm_model,
+                        on_notify=lambda msg: websocket.send_json({"type": "info", "content": msg}),
                     ))
 
                     # Listen for abort while LLM is running
@@ -899,34 +942,10 @@ async def websocket_chat(
                 except WebSocketDisconnect:
                     raise
                 except Exception as e:
-                    logger.error(f"[WS] LLM error: {e}")
+                    logger.error(f"[WS] LLM error (after all retries): {e}")
                     import traceback
                     traceback.print_exc()
-                    # Runtime fallback: primary model failed -> retry with fallback model
-                    if fallback_llm_model:
-                        logger.info(f"[WS] Primary model failed, retrying with fallback: {fallback_llm_model.model}")
-                        try:
-                            await websocket.send_json({"type": "info", "content": f"Primary model error, switching to fallback model ({fallback_llm_model.model})..."})
-                            assistant_response = await call_llm(
-                                fallback_llm_model,
-                                conversation[-ctx_size:],
-                                agent_name,
-                                role_description,
-                                agent_id=agent_id,
-                                user_id=user_id,
-                                session_id=conv_id,
-                                on_chunk=stream_to_ws,
-                                on_tool_call=tool_call_to_ws,
-                                on_thinking=thinking_to_ws,
-                                supports_vision=getattr(fallback_llm_model, 'supports_vision', False),
-                            )
-                            logger.info(f"[WS] Fallback LLM response: {assistant_response[:80]}")
-                        except Exception as e2:
-                            logger.error(f"[WS] Fallback LLM also failed: {e2}")
-                            traceback.print_exc()
-                            assistant_response = f"[LLM call error] Primary: {str(e)[:100]} | Fallback: {str(e2)[:100]}"
-                    else:
-                        assistant_response = f"[LLM call error] {str(e)[:200]}"
+                    assistant_response = f"[LLM call error] {str(e)[:200]}"
             else:
                 assistant_response = f"⚠️ {agent_name} has no LLM model configured. Please select a model in the agent's Settings tab."
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
     # Jina AI (Reader + Search APIs)
     JINA_API_KEY: str = ""
 
+    # LLM Retry Strategy
+    LLM_RETRY_MAX: int = 10  # Max retry attempts (alternates primary/fallback), 0 to disable
+
 
     # Sandbox configuration
     SANDBOX_TYPE: SandboxType = SandboxType.SUBPROCESS

--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -486,16 +486,25 @@ class OpenAICompatibleClient(LLMClient):
         tag_buffer = ""
         json_buffer = ""  # Buffer for non-standard APIs with split JSON (inspired by PR #120)
 
-        max_retries = 3
         client = await self._get_client()
 
-        for attempt in range(max_retries):
+        _RETRYABLE_HTTP_STATUS = {400, 408, 429, 500, 502, 503, 504, 529}
+
+        for attempt in range(3):  # HTTP-level retry (3 attempts per model)
             try:
                 async with client.stream("POST", url, json=payload, headers=self._get_headers()) as resp:
                     if resp.status_code >= 400:
                         error_body = ""
                         async for chunk in resp.aiter_bytes():
                             error_body += chunk.decode(errors="replace")
+                        # Retryable server errors (rate-limit, overload, gateway)
+                        if resp.status_code in _RETRYABLE_HTTP_STATUS and attempt < 2:
+                            _OVERLOAD_MARKERS = ("overload", "rate", "limit", "too many", "capacity", "try again", "访问量过大")
+                            _lower = error_body[:500].lower()
+                            if resp.status_code != 400 or any(m in _lower for m in _OVERLOAD_MARKERS):
+                                logger.warning(f"Stream attempt {attempt + 1} got HTTP {resp.status_code}, retrying...")
+                                await asyncio.sleep(1)
+                                continue
                         raise LLMError(f"HTTP {resp.status_code}: {error_body[:500]}")
 
                     async for line in resp.aiter_lines():
@@ -543,15 +552,11 @@ class OpenAICompatibleClient(LLMClient):
                 break
 
             except (httpx.TransportError, httpx.ConnectTimeout) as e:
-                # TransportError covers all network-layer issues:
-                # - ConnectError, ReadError, WriteError (NetworkError subclasses)
-                # - RemoteProtocolError, LocalProtocolError (ProtocolError subclasses)
-                # The last case is common with local vLLM when the server closes
-                # the connection mid-stream (e.g. OOM, context limit exceeded).
-                if attempt < max_retries - 1:
-                    wait = (attempt + 1) * 1
-                    logger.warning(f"Stream attempt {attempt + 1} failed ({type(e).__name__}: {e}), retrying in {wait}s...")
-                    await asyncio.sleep(wait)
+                # TransportError: ConnectError, ReadError, WriteError, RemoteProtocolError, etc.
+                # Common with local vLLM when server closes connection mid-stream (OOM, etc.)
+                if attempt < 2:
+                    logger.warning(f"Stream attempt {attempt + 1} failed ({type(e).__name__}: {e}), retrying...")
+                    await asyncio.sleep(1)
                     full_content = ""
                     full_reasoning = ""
                     tool_calls_data = []
@@ -559,7 +564,7 @@ class OpenAICompatibleClient(LLMClient):
                     tag_buffer = ""
                     json_buffer = ""
                 else:
-                    raise LLMError(f"Connection failed after {max_retries} attempts: {type(e).__name__}: {e}")
+                    raise LLMError(f"Connection failed after 3 attempts: {type(e).__name__}: {e}")
 
         # Clean up any remaining think tags
         full_content = re.sub(r"<think>[\s\S]*?</think>\s*", "", full_content).strip()


### PR DESCRIPTION
## Summary

- Major LLM providers (Anthropic, OpenAI, DeepSeek, etc.) frequently return **429/400/529 rate-limit errors** during peak hours, causing agent conversations to fail mid-task
- After daily usage testing, a **10-attempt retry with backoff** strategy effectively covers the impact of transient rate-limiting
- Retry logic is embedded **inside the tool loop** in `call_llm`, preserving all executed tool progress (file writes, messages sent, etc.)

## Changes

### Retry inside tool loop (`websocket.py`)
- On each `client.stream()` failure (429/529/overload), retry in-place without losing tool progress
- Alternates between primary and fallback model on each attempt
- Backoff: first 50% fixed 1s, rest exponential (max 30s)
- Notifies client via `on_notify` callback when switching models

### HTTP-level retry (`llm_client.py`)
- Retries on 429, 529, 500-504, 408 unconditionally
- Retries on 400 **only** when body contains overload markers (`overloaded`, `访问量过大`, `rate limit`, etc.)
- 3 attempts per model, 1s interval

### Configurable (`config.py`)
- `LLM_RETRY_MAX` env var (default: 10, set to 0 to disable)

### Deduplication (`feishu.py`, `websocket.py`)
- Removed 89 lines of duplicated manual fallback logic (was copy-pasted across 3 locations)
- Both channels now pass `fallback_model=` to `call_llm` — single source of truth

## Test plan

- [x] Retry alternation: `primary → fallback → primary → ...` verified
- [x] Backoff sequence: `[1, 1, 1, 1, 1, 2, 4, 8, 16, 30]` verified
- [x] HTTP 429/529 → retry; HTTP 400 overload → retry; HTTP 400 normal → no retry; HTTP 401 → no retry
- [x] `gateway.py` / `trigger_daemon.py` backward compatible (no new params)
- [x] `LLM_RETRY_MAX=0` edge case: at least 1 attempt guaranteed
- [ ] Manual test: trigger 429 from a rate-limited provider and verify auto-recovery
- [ ] Manual test: verify tool progress preserved after mid-loop retry