### PR TITLE
fix: correct stale send_agent_message references and unify msg_type enum

### DIFF
--- a/backend/app/api/gateway.py
+++ b/backend/app/api/gateway.py
@@ -413,7 +413,7 @@ async def _send_to_agent_background(
                 "--- Agent-to-Agent Communication Alert ---\n"
                 f"You are receiving a direct message from another digital employee ({source_agent_name}). "
                 "CRITICAL INSTRUCTION: Your direct text reply will automatically be delivered back to them. "
-                "DO NOT use the `send_agent_message` tool to reply to this conversation. Just reply naturally in text.\n"
+                "DO NOT use the `send_message_to_agent` tool to reply to this conversation. Just reply naturally in text.\n"
                 "If they are asking you to create or analyze a file, deliver the file using `send_file_to_agent` after writing it."
             )
 

--- a/backend/app/api/relationships.py
+++ b/backend/app/api/relationships.py
@@ -303,7 +303,7 @@ async def _regenerate_relationships_file(db: AsyncSession, agent_id: uuid.UUID):
             label = AGENT_RELATION_LABELS.get(r.relation, r.relation)
             lines.append(f"### {a.name} — {a.role_description or '数字员工'}")
             lines.append(f"- 关系：{label}")
-            lines.append(f"- 可以用 send_agent_message 工具给 {a.name} 发消息协作")
+            lines.append(f"- 可以用 send_message_to_agent 工具给 {a.name} 发消息协作")
             if r.description:
                 lines.append(f"- {r.description}")
             lines.append("")

--- a/backend/app/services/tool_seeder.py
+++ b/backend/app/services/tool_seeder.py
@@ -281,7 +281,7 @@ BUILTIN_TOOLS = [
             "properties": {
                 "agent_name": {"type": "string", "description": "Target agent name"},
                 "message": {"type": "string", "description": "Message content"},
-                "msg_type": {"type": "string", "enum": ["chat", "task_request", "info_share"], "description": "Message type"},
+                "msg_type": {"type": "string", "enum": ["notify", "consult", "task_delegate"], "description": "Message type: notify (notification), consult (ask a question), task_delegate (delegate a task)"},
             },
             "required": ["agent_name", "message"],
         },


### PR DESCRIPTION
## Summary

Fixes two issues found during analysis of #310 (inter-agent communication timeouts):

### 1. Stale tool name references (`send_agent_message` → `send_message_to_agent`)

Two locations in the codebase reference `send_agent_message`, a tool name that does not exist in the tool registry. The correct name is `send_message_to_agent`.

| File | Line | Fix |
|------|------|-----|
| `backend/app/api/relationships.py` | L306 | Fixed tool name in `relationships.md` generation |
| `backend/app/api/gateway.py` | L416 | Fixed tool name in OpenClaw A2A communication prompt |

**Impact:**
- `relationships.py`: The stale name was written into the agent's `relationships.md` workspace file, which is injected into the LLM system prompt. This guided the LLM to call a non-existent tool, increasing tool call failure rate.
- `gateway.py`: The prompt told OpenClaw agents *"DO NOT use the \`send_agent_message\` tool"*. Since that tool does not exist, the LLM could attempt to call the similarly-named `send_message_to_agent` (which **does** exist) — the exact opposite of the prompt's intent, potentially causing infinite message recursion.

### 2. Inconsistent `msg_type` enum values

Unified the `msg_type` enum in `tool_seeder.py` to match `agent_tools.py`:

| Location | Before | After |
|----------|--------|-------|
| `tool_seeder.py` | `["chat", "task_request", "info_share"]` | `["notify", "consult", "task_delegate"]` |

Since `seed_builtin_tools()` upserts `parameters_schema` into the DB on every startup, and `get_agent_tools_for_llm()` reads from the DB, this change takes effect on the next application restart. The `msg_type` parameter is currently unused (dead parameter) in `_send_message_to_agent`, so this has no runtime behavioral change — it just removes the inconsistency for future development.

## Testing

Verified by creating a new agent with agent relationships after applying the fix:
- Before: `relationships.md` contained `send_agent_message` (incorrect)
- After: `relationships.md` correctly contains `send_message_to_agent` ✅

Closes #315