### PR TITLE
feat(tools): auto-persist tool call results to workspace

### DIFF
--- a/backend/app/services/agent_context.py
+++ b/backend/app/services/agent_context.py
@@ -504,7 +504,9 @@ You have internet access through these tools — **use them proactively when you
 
 **When to search:** News, current events, technical documentation, fact-checking, market research, competitor analysis, or any question requiring up-to-date information.
 
-🚫 **NEVER say you cannot access the internet or search the web.** You HAVE these capabilities — use them.""")
+🚫 **NEVER say you cannot access the internet or search the web.** You HAVE these capabilities — use them.
+
+**Tool Artifacts**: Your tool call results are automatically saved in `tool_artifacts/`. Use `list_files("tool_artifacts")` to browse, `read_file("tool_artifacts/search/xxx.json")` to read a specific result, or `search_files("keyword", "tool_artifacts")` to find past results. Search results are cached — repeated queries within a short period return cached results.""")
 
     if soul and soul not in ("_描述你的角色和职责。_", "_Describe your role and responsibilities._"):
         static_parts.append(f"\n## Personality\n{soul}")

--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -1899,6 +1899,10 @@ async def ensure_workspace(agent_id: uuid.UUID, tenant_id: str | None = None) ->
     (ws / "workspace" / "knowledge_base").mkdir(exist_ok=True)
     (ws / "memory").mkdir(exist_ok=True)
 
+    # Tool artifacts: auto-persisted tool call results
+    for _sub in ("search", "web_pages", "code_outputs", "misc"):
+        (ws / "tool_artifacts" / _sub).mkdir(parents=True, exist_ok=True)
+
     # Ensure tenant-scoped enterprise_info directory exists
     if tenant_id:
         enterprise_dir = WORKSPACE_ROOT / f"enterprise_info_{tenant_id}"
@@ -2001,6 +2005,37 @@ async def _get_agent_tenant_id(agent_id: uuid.UUID) -> str | None:
     return None
 
 
+def _is_error_result(result: str) -> bool:
+    """Check if a tool result indicates an error."""
+    return result.startswith(("❌", "Tool execution error", "Error executing"))
+
+
+def _check_tool_cache_sync(tool_name: str, arguments: dict, agent_id: uuid.UUID | None) -> str | None:
+    """Check tool cache. Returns cached result or None. Extracted to avoid repetition (DRY)."""
+    if not agent_id:
+        return None
+    try:
+        from app.services.tool_artifacts import check_cache
+        _ws = WORKSPACE_ROOT / str(agent_id)
+        return check_cache(_ws, tool_name, arguments)
+    except Exception:
+        return None
+
+
+def _persist_tool_result_sync(ws: Path, tool_name: str, arguments: dict, result: str) -> str:
+    """Persist tool result and append path hint. Returns (possibly modified) result string."""
+    if _is_error_result(result):
+        return result
+    try:
+        from app.services.tool_artifacts import save_artifact
+        _rel = save_artifact(ws, tool_name, arguments, result)
+        if _rel:
+            return result + f"\n\n📁 完整结果已保存: {_rel}"
+    except Exception:
+        pass
+    return result
+
+
 async def _execute_tool_direct(
     tool_name: str,
     arguments: dict,
@@ -2015,28 +2050,32 @@ async def _execute_tool_direct(
     ws = await ensure_workspace(agent_id, tenant_id=_agent_tenant_id)
     try:
         if tool_name == "delete_file":
-            return _delete_file(ws, arguments.get("path", ""))
+            result = _delete_file(ws, arguments.get("path", ""))
         elif tool_name == "write_file":
             path = arguments.get("path")
             content = arguments.get("content", "")
             if not path:
-                return "Missing path"
-            return _write_file(ws, path, content, tenant_id=_agent_tenant_id)
+                result = "Missing path"
+            else:
+                result = _write_file(ws, path, content, tenant_id=_agent_tenant_id)
         elif tool_name in ("execute_code", "execute_code_e2b"):
             logger.info(f"[DirectTool] Executing code ({tool_name}) with arguments: {arguments}")
-            return await _execute_code(agent_id, ws, arguments, tool_name=tool_name)
+            result = await _execute_code(agent_id, ws, arguments, tool_name=tool_name)
         elif tool_name == "web_search":
-            return await _web_search(arguments, agent_id)
+            result = await _web_search(arguments, agent_id)
         elif tool_name == "jina_search":
-            return await _jina_search(arguments)
+            result = await _jina_search(arguments, agent_id=agent_id)
         elif tool_name == "send_feishu_message":
-            return await _send_feishu_message(agent_id, arguments)
+            result = await _send_feishu_message(agent_id, arguments)
         elif tool_name == "send_message_to_agent":
-            return await _send_message_to_agent(agent_id, arguments)
+            result = await _send_message_to_agent(agent_id, arguments)
         elif tool_name == "send_file_to_agent":
-            return await _send_file_to_agent(agent_id, ws, arguments)
+            result = await _send_file_to_agent(agent_id, ws, arguments)
         else:
-            return f"Tool {tool_name} does not support post-approval execution"
+            result = f"Tool {tool_name} does not support post-approval execution"
+        # Persist tool result (same logic as execute_tool)
+        result = _persist_tool_result_sync(ws, tool_name, arguments, result)
+        return result
     except Exception as e:
         logger.exception(f"[DirectTool] Error executing {tool_name}: {e}")
         return f"Error executing {tool_name}: {e}"
@@ -2186,13 +2225,13 @@ async def execute_tool(
         elif tool_name == "web_search":
             result = await _web_search(arguments, agent_id)
         elif tool_name == "jina_search":
-            result = await _jina_search(arguments)
+            result = await _jina_search(arguments, agent_id=agent_id)
         elif tool_name == "bing_search":
-            result = await _jina_search(arguments)  # redirect legacy to jina
+            result = await _jina_search(arguments, agent_id=agent_id)  # redirect legacy to jina
         elif tool_name == "jina_read":
-            result = await _jina_read(arguments)
+            result = await _jina_read(arguments, agent_id=agent_id)
         elif tool_name == "read_webpage":
-            result = await _jina_read(arguments)  # redirect legacy to jina
+            result = await _jina_read(arguments, agent_id=agent_id)  # redirect legacy to jina
         elif tool_name == "plaza_get_new_posts":
             result = await _plaza_get_new_posts(agent_id, arguments)
         elif tool_name == "plaza_create_post":
@@ -2331,6 +2370,10 @@ async def execute_tool(
                 f"Called tool {tool_name}: {result[:80]}",
                 detail={"tool": tool_name, "args": {k: str(v)[:100] for k, v in arguments.items()}, "result": result[:300]},
             )
+
+        # --- Auto-persist tool result to workspace ---
+        result = _persist_tool_result_sync(ws, tool_name, arguments, result)
+
         return result
     except Exception as e:
         logger.exception(f"[Tool] Execution failed: {tool_name}")
@@ -2342,6 +2385,11 @@ async def _web_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str
 
     Config resolution priority: Agent config > Company config > Defaults.
     """
+    # Cache check
+    _cached = _check_tool_cache_sync("web_search", arguments, agent_id)
+    if _cached:
+        return _cached + "\n\n[📋 缓存命中]"
+
     import httpx
     import re
 
@@ -2418,8 +2466,13 @@ async def _get_jina_api_key() -> str:
     return get_settings().JINA_API_KEY
 
 
-async def _jina_search(arguments: dict) -> str:
+async def _jina_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str:
     """Search via Jina AI Search API (s.jina.ai). Returns full content per result, not just snippets."""
+    # Cache check
+    _cached = _check_tool_cache_sync("jina_search", arguments, agent_id)
+    if _cached:
+        return _cached + "\n\n[📋 缓存命中]"
+
     import httpx
 
     query = arguments.get("query", "").strip()
@@ -2466,8 +2519,13 @@ async def _jina_search(arguments: dict) -> str:
         return f"❌ Jina Search error: {str(e)[:300]}"
 
 
-async def _jina_read(arguments: dict) -> str:
+async def _jina_read(arguments: dict, agent_id: uuid.UUID | None = None) -> str:
     """Read web page via Jina AI Reader API (r.jina.ai). Returns clean structured markdown."""
+    # Cache check
+    _cached = _check_tool_cache_sync("jina_read", arguments, agent_id)
+    if _cached:
+        return _cached + "\n\n[📋 缓存命中]"
+
     import httpx
     from app.config import get_settings
 

--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -2010,18 +2010,6 @@ def _is_error_result(result: str) -> bool:
     return result.startswith(("❌", "Tool execution error", "Error executing"))
 
 
-def _check_tool_cache_sync(tool_name: str, arguments: dict, agent_id: uuid.UUID | None) -> str | None:
-    """Check tool cache. Returns cached result or None. Extracted to avoid repetition (DRY)."""
-    if not agent_id:
-        return None
-    try:
-        from app.services.tool_artifacts import check_cache
-        _ws = WORKSPACE_ROOT / str(agent_id)
-        return check_cache(_ws, tool_name, arguments)
-    except Exception:
-        return None
-
-
 def _persist_tool_result_sync(ws: Path, tool_name: str, arguments: dict, result: str) -> str:
     """Persist tool result and append path hint. Returns (possibly modified) result string."""
     if _is_error_result(result):
@@ -2385,11 +2373,6 @@ async def _web_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str
 
     Config resolution priority: Agent config > Company config > Defaults.
     """
-    # Cache check
-    _cached = _check_tool_cache_sync("web_search", arguments, agent_id)
-    if _cached:
-        return _cached + "\n\n[📋 缓存命中]"
-
     import httpx
     import re
 
@@ -2468,11 +2451,6 @@ async def _get_jina_api_key() -> str:
 
 async def _jina_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str:
     """Search via Jina AI Search API (s.jina.ai). Returns full content per result, not just snippets."""
-    # Cache check
-    _cached = _check_tool_cache_sync("jina_search", arguments, agent_id)
-    if _cached:
-        return _cached + "\n\n[📋 缓存命中]"
-
     import httpx
 
     query = arguments.get("query", "").strip()
@@ -2521,11 +2499,6 @@ async def _jina_search(arguments: dict, agent_id: uuid.UUID | None = None) -> st
 
 async def _jina_read(arguments: dict, agent_id: uuid.UUID | None = None) -> str:
     """Read web page via Jina AI Reader API (r.jina.ai). Returns clean structured markdown."""
-    # Cache check
-    _cached = _check_tool_cache_sync("jina_read", arguments, agent_id)
-    if _cached:
-        return _cached + "\n\n[📋 缓存命中]"
-
     import httpx
     from app.config import get_settings
 

--- a/backend/app/services/tool_artifacts.py
+++ b/backend/app/services/tool_artifacts.py
@@ -1,0 +1,106 @@
+"""Tool call result auto-persistence module.
+
+Automatically saves full tool results to workspace/tool_artifacts/ so the LLM
+can retrieve them later via read_file / search_files / list_files.
+
+Design: zero new tools, minimal code, all failures are silent.
+"""
+
+import json
+import hashlib
+from pathlib import Path
+from datetime import datetime
+
+# ── Tool → sub-directory mapping ────────────────────────────────
+CATEGORY_MAP: dict[str, str] = {
+    "web_search": "search",
+    "jina_search": "search",
+    "bing_search": "search",
+    "jina_read": "web_pages",
+    "read_webpage": "web_pages",
+    "execute_code": "code_outputs",
+    "execute_code_e2b": "code_outputs",
+}
+
+ARTIFACTS_DIR = "tool_artifacts"
+
+# ── Cache TTL (seconds) ────────────────────────────────────────
+CACHE_TTL: dict[str, int] = {
+    "web_search": 3600,     # 1 hour
+    "jina_search": 3600,
+    "jina_read": 86400,     # 24 hours
+    "read_webpage": 86400,
+}
+
+# ── Size limit ─────────────────────────────────────────────────
+MAX_RESULT_SIZE = 100_000  # 100 KB — skip saving if result exceeds this
+
+
+def _category(tool_name: str) -> str:
+    return CATEGORY_MAP.get(tool_name, "misc")
+
+
+def _cache_key(tool_name: str, arguments: dict) -> str:
+    """Deterministic hash from tool name + arguments."""
+    raw = json.dumps({"t": tool_name, "a": arguments}, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def _ensure_dir(ws: Path, category: str) -> Path:
+    d = ws / ARTIFACTS_DIR / category
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def save_artifact(
+    ws: Path,
+    tool_name: str,
+    arguments: dict,
+    result: str,
+) -> str | None:
+    """Save a tool result to disk. Returns relative path or None on failure."""
+    try:
+        if len(result) > MAX_RESULT_SIZE:
+            return None
+        category = _category(tool_name)
+        d = _ensure_dir(ws, category)
+        key = _cache_key(tool_name, arguments)
+        filename = f"{key}.json"
+        filepath = d / filename
+
+        # Skip if file already exists (cache hit scenario — avoid TTL refresh)
+        if filepath.exists():
+            return f"{ARTIFACTS_DIR}/{category}/{filename}"
+
+        data = {
+            "tool_name": tool_name,
+            "arguments": arguments,
+            "result": result,
+            "timestamp": datetime.now().isoformat(),
+        }
+        filepath.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return f"{ARTIFACTS_DIR}/{category}/{filename}"
+    except Exception:
+        return None
+
+
+def check_cache(ws: Path, tool_name: str, arguments: dict) -> str | None:
+    """Return cached result if present and within TTL. None otherwise."""
+    try:
+        ttl = CACHE_TTL.get(tool_name)
+        if not ttl:
+            return None
+        category = _category(tool_name)
+        filepath = ws / ARTIFACTS_DIR / category / f"{_cache_key(tool_name, arguments)}.json"
+        if not filepath.exists():
+            return None
+        data = json.loads(filepath.read_text(encoding="utf-8"))
+        ts = datetime.fromisoformat(data["timestamp"])
+        if (datetime.now() - ts).total_seconds() > ttl:
+            return None
+        return data["result"]
+    except Exception:
+        return None

--- a/backend/app/services/tool_artifacts.py
+++ b/backend/app/services/tool_artifacts.py
@@ -3,11 +3,12 @@
 Automatically saves full tool results to workspace/tool_artifacts/ so the LLM
 can retrieve them later via read_file / search_files / list_files.
 
-Design: zero new tools, minimal code, all failures are silent.
+Design: zero new tools, no cache, minimal code, all failures are silent.
 """
 
 import json
 import hashlib
+import uuid
 from pathlib import Path
 from datetime import datetime
 
@@ -23,27 +24,11 @@ CATEGORY_MAP: dict[str, str] = {
 }
 
 ARTIFACTS_DIR = "tool_artifacts"
-
-# ── Cache TTL (seconds) ────────────────────────────────────────
-CACHE_TTL: dict[str, int] = {
-    "web_search": 3600,     # 1 hour
-    "jina_search": 3600,
-    "jina_read": 86400,     # 24 hours
-    "read_webpage": 86400,
-}
-
-# ── Size limit ─────────────────────────────────────────────────
-MAX_RESULT_SIZE = 100_000  # 100 KB — skip saving if result exceeds this
+MAX_RESULT_SIZE = 100_000  # 100 KB — skip saving oversized results
 
 
 def _category(tool_name: str) -> str:
     return CATEGORY_MAP.get(tool_name, "misc")
-
-
-def _cache_key(tool_name: str, arguments: dict) -> str:
-    """Deterministic hash from tool name + arguments."""
-    raw = json.dumps({"t": tool_name, "a": arguments}, sort_keys=True, ensure_ascii=False)
-    return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 def _ensure_dir(ws: Path, category: str) -> Path:
@@ -64,13 +49,10 @@ def save_artifact(
             return None
         category = _category(tool_name)
         d = _ensure_dir(ws, category)
-        key = _cache_key(tool_name, arguments)
-        filename = f"{key}.json"
-        filepath = d / filename
-
-        # Skip if file already exists (cache hit scenario — avoid TTL refresh)
-        if filepath.exists():
-            return f"{ARTIFACTS_DIR}/{category}/{filename}"
+        # Unique filename: timestamp + short random id
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        short_id = uuid.uuid4().hex[:8]
+        filename = f"{ts}_{short_id}.json"
 
         data = {
             "tool_name": tool_name,
@@ -78,29 +60,10 @@ def save_artifact(
             "result": result,
             "timestamp": datetime.now().isoformat(),
         }
-        filepath.write_text(
+        (d / filename).write_text(
             json.dumps(data, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
         return f"{ARTIFACTS_DIR}/{category}/{filename}"
-    except Exception:
-        return None
-
-
-def check_cache(ws: Path, tool_name: str, arguments: dict) -> str | None:
-    """Return cached result if present and within TTL. None otherwise."""
-    try:
-        ttl = CACHE_TTL.get(tool_name)
-        if not ttl:
-            return None
-        category = _category(tool_name)
-        filepath = ws / ARTIFACTS_DIR / category / f"{_cache_key(tool_name, arguments)}.json"
-        if not filepath.exists():
-            return None
-        data = json.loads(filepath.read_text(encoding="utf-8"))
-        ts = datetime.fromisoformat(data["timestamp"])
-        if (datetime.now() - ts).total_seconds() > ttl:
-            return None
-        return data["result"]
     except Exception:
         return None


### PR DESCRIPTION
## Summary

Automatically save full tool call results (web search, web page reading, code execution, etc.) to the agent's workspace directory (`tool_artifacts/`), so the LLM can retrieve them later using **existing tools** (`read_file`, `list_files`, `search_files`) — no new tools required.

### What it does

When any tool is executed, the full result is saved as a JSON file under `tool_artifacts/{category}/`:

```
agent_data/{agent_id}/
├── tool_artifacts/
│   ├── search/          # web_search, jina_search results
│   ├── web_pages/       # jina_read page content
│   ├── code_outputs/    # execute_code output
│   └── misc/            # other tools
└── ...
```

Each file contains `{ tool_name, arguments, result, timestamp }`.

After saving, a path hint is appended to the result string:

```
🔍 DuckDuckGo results for "AI agents" (5 items):
...

📁 完整结果已保存: tool_artifacts/search/20260408_103000_a1b2c3d4.json
```

The LLM naturally uses `read_file("tool_artifacts/search/...")` or `search_files("keyword", "tool_artifacts")` to access past results — leveraging existing capabilities with **zero learning cost**.

### Files changed

| File | Change |
|------|--------|
| `backend/app/services/tool_artifacts.py` | **New** — core save module (~58 lines) |
| `backend/app/services/agent_tools.py` | `execute_tool()` + `_execute_tool_direct()` add persistence; `ensure_workspace()` creates directories |
| `backend/app/services/agent_context.py` | System prompt note about `tool_artifacts/` |

### Design strengths

1. **Zero new tools** — reuses `read_file` / `search_files` / `list_files`. No new tool definitions, no schema maintenance, no LLM learning overhead.
2. **Minimal footprint** — 58-line module, ~100 lines total change. KISS principle.
3. **Fail-safe** — all persistence logic is wrapped in `try/except`; failures are silent and never block tool execution.
4. **Size guard** — results exceeding 100KB are skipped to prevent disk bloat.
5. **Dual path coverage** — works in both `execute_tool()` (normal) and `_execute_tool_direct()` (post-approval) paths.
6. **Tenant isolation** — files live under `agent_data/{agent_id}/`, naturally isolated per agent.
7. **Time-ordered filenames** — `20260408_103000_a1b2c3d4.json` format lets LLM browse chronologically via `list_files`.

### Known limitations (not yet implemented)

1. **No automatic cleanup** — artifact files accumulate indefinitely. For agents with heavy tool usage, disk usage may grow over time. A future enhancement could add:
   - Max entries per agent (e.g., 500 files)
   - Max age (e.g., 30 days)
   - Disk quota enforcement
   - Periodic cleanup via a background task

2. **No deduplication** — identical tool calls (same arguments) create separate files each time. This is intentional for auditability, but may waste space for repetitive queries.

3. **No cross-session indexing** — LLM must use `search_files` to find past results. A structured index file (e.g., `_catalog.json`) could improve lookup speed for agents with many artifacts.

4. **Result size truncation** — results >100KB are silently skipped. The LLM is not informed that the full result was not saved.

5. **Error detection is prefix-based** — results starting with `❌` or `Tool execution error` are treated as errors and not saved. This relies on a naming convention rather than a structured error type.

## Test plan

- [x] Module imports cleanly (`from app.services.tool_artifacts import save_artifact`)
- [x] Unit tests pass: save/read, size limit, unique filenames
- [ ] Manual test: trigger `web_search` via agent, verify file appears in `tool_artifacts/search/`
- [ ] Manual test: `read_file("tool_artifacts/search/xxx.json")` returns full result
- [ ] Manual test: error results (❌) are not saved
- [ ] Manual test: post-approval path also persists results