### PR TITLE
feat(ui): polish chat sidebar — segment control, session items, select chevron

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,12 @@
   --accent-subtle: rgba(225, 225, 232, 0.08);
   --accent-text: #c0c0cc;
 
+  --segment-active-bg: var(--accent-primary);
+  --segment-active-text: var(--text-inverse);
+
+  /* Select chevron — @tabler/icons chevron-down, colored to --text-secondary */
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%238b8b9e' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M6 9l6 6l6 -6'/%3E%3C/svg%3E");
+
   --success: #22c55e;
   --success-subtle: rgba(34, 197, 94, 0.12);
   --warning: #f59e0b;
@@ -195,6 +201,12 @@
   --accent-subtle: rgba(58, 58, 66, 0.08);
   --accent-text: #3a3a42;
 
+  --segment-active-bg: var(--bg-elevated);
+  --segment-active-text: var(--text-primary);
+
+  /* Select chevron — @tabler/icons chevron-down, colored to --text-secondary */
+  --select-chevron: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='%236b6b80' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath stroke='none' d='M0 0h24v24H0z' fill='none'/%3E%3Cpath d='M6 9l6 6l6 -6'/%3E%3C/svg%3E");
+
   --success: #16a34a;
   --success-subtle: rgba(22, 163, 74, 0.08);
   --warning: #d97706;
@@ -279,8 +291,7 @@ button {
 }
 
 input,
-textarea,
-select {
+textarea {
   font-family: inherit;
   font-size: inherit;
   color: inherit;
@@ -290,6 +301,26 @@ select {
   padding: var(--space-2) var(--space-3);
   outline: none;
   transition: border-color var(--transition-fast);
+}
+
+select {
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+  background-color: var(--bg-elevated);
+  background-image: var(--select-chevron);
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 16px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 4px 32px 4px 12px;
+  outline: none;
+  transition: border-color var(--transition-fast);
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  text-overflow: ellipsis;
 }
 
 /* Theme-colored radio and checkbox */
@@ -1044,23 +1075,74 @@ select:focus {
   border-bottom-color: var(--accent-primary);
 }
 
-/* Session sidebar admin tabs — same underline pattern as .tabs/.tab, compact for narrow column */
-.tabs.session-sidebar-session-tabs {
-  gap: var(--space-5);
-  margin-bottom: var(--space-2);
-  margin-top: 0;
-  padding: 2px 12px 0;
-  position: relative;
-  background: transparent;
-  z-index: auto;
-  top: auto;
+/* Session sidebar admin tabs — segment control style */
+.session-sidebar-segment-control {
+  display: flex;
+  margin: 0 12px 8px;
+  padding: 2px;
+  height: 28px;
+  background: var(--accent-subtle);
+  border-radius: 6px;
+  border: 1px solid var(--border-subtle);
+  box-sizing: border-box;
 }
 
-.tabs.session-sidebar-session-tabs .tab {
-  flex: 0 1 auto;
-  padding: var(--space-2) var(--space-1) 10px;
+.session-sidebar-segment-control .segment-item {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   font-size: 12px;
+  color: var(--text-tertiary);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
   white-space: nowrap;
+  user-select: none;
+  border: none;
+  background: none;
+  padding: 0;
+  line-height: 1;
+}
+
+.session-sidebar-segment-control .segment-item:hover {
+  color: var(--text-secondary);
+}
+
+.session-sidebar-segment-control .segment-item.active {
+  background: var(--segment-active-bg);
+  color: var(--segment-active-text);
+  font-weight: 500;
+}
+
+/* Session item — delete button & message count hover behaviour */
+.session-del-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  transition: color 0.35s ease-in-out, background 0.35s ease-in-out;
+}
+
+.session-item:hover .session-del-btn {
+  display: flex;
+}
+
+.session-del-btn:hover {
+  color: var(--status-error);
+  background: var(--bg-hover);
+}
+
+.session-item:hover .session-msg-count {
+  display: none;
 }
 
 /* Page header */
@@ -1345,7 +1427,7 @@ select:focus {
 .login-field input,
 .login-field select {
   height: 44px;
-  padding: 0 14px;
+  padding: 0 32px 0 14px;
   background: var(--bg-secondary);
   border: 1px solid var(--border-default);
   border-radius: 10px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1115,6 +1115,32 @@ select:focus {
   font-weight: 500;
 }
 
+/* New session button */
+.new-session-btn {
+  width: 100%;
+  height: 28px;
+  padding: 0 10px;
+  background: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: all 0.15s ease;
+  box-sizing: border-box;
+  line-height: 1;
+}
+
+.new-session-btn:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border-color: var(--accent-primary);
+}
+
 /* Session item — delete button & message count hover behaviour */
 .session-del-btn {
   display: none;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -531,21 +531,21 @@ select:focus {
   opacity: 1;
 }
 
-/* Pinned icon swap: show pin by default, unpin on hover */
+/* Pinned icon swap: show pin by default, unpin only when hovering the button itself */
 .sidebar-pin-btn.pinned .pin-hover {
   display: none;
 }
 
-.sidebar-agent-item:hover .sidebar-pin-btn.pinned .pin-default {
+.sidebar-pin-btn.pinned:hover .pin-default {
   display: none;
 }
 
-.sidebar-agent-item:hover .sidebar-pin-btn.pinned .pin-hover {
+.sidebar-pin-btn.pinned:hover .pin-hover {
   display: inline;
 }
 
-/* When pinned and hovered, turn red to indicate unpin */
-.sidebar-agent-item:hover .sidebar-pin-btn.pinned {
+/* When hovering the pin button itself on a pinned agent, turn red to indicate unpin */
+.sidebar-pin-btn.pinned:hover {
   color: var(--error);
   background: var(--error-subtle);
 }

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -4052,43 +4052,17 @@ function AgentDetailInner() {
                                         )}
                                     </div>
                                     {!canViewAllAgentChatSessions && (
-                                        <div style={{ padding: '0 12px 10px' }}>
+                                        <div style={{ padding: '0 12px 8px' }}>
                                             <button
                                                 type="button"
                                                 onClick={createNewSession}
-                                                style={{
-                                                    width: '100%',
-                                                    height: '28px',
-                                                    padding: '0 10px',
-                                                    background: 'none',
-                                                    border: '1px solid var(--border-subtle)',
-                                                    borderRadius: '6px',
-                                                    cursor: 'pointer',
-                                                    fontSize: '12px',
-                                                    color: 'var(--text-secondary)',
-                                                    textAlign: 'left',
-                                                    display: 'flex',
-                                                    alignItems: 'center',
-                                                    gap: '6px',
-                                                    transition: 'all 0.15s ease',
-                                                    boxSizing: 'border-box',
-                                                }}
-                                                onMouseEnter={(e) => {
-                                                    e.currentTarget.style.background = 'var(--bg-secondary)';
-                                                    e.currentTarget.style.color = 'var(--text-primary)';
-                                                    e.currentTarget.style.borderColor = 'var(--accent-primary)';
-                                                }}
-                                                onMouseLeave={(e) => {
-                                                    e.currentTarget.style.background = 'none';
-                                                    e.currentTarget.style.color = 'var(--text-secondary)';
-                                                    e.currentTarget.style.borderColor = 'var(--border-subtle)';
-                                                }}
+                                                className="new-session-btn"
                                             >
-                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ display: 'block', flexShrink: 0 }}>
                                                     <line x1="12" y1="5" x2="12" y2="19" />
                                                     <line x1="5" y1="12" x2="19" y2="12" />
                                                 </svg>
-                                                {t('agent.chat.newSession')}
+                                                <span>{t('agent.chat.newSession')}</span>
                                             </button>
                                         </div>
                                     )}
@@ -4137,40 +4111,13 @@ function AgentDetailInner() {
                                                     <button
                                                         type="button"
                                                         onClick={createNewSession}
-                                                        style={{
-                                                            width: '100%',
-                                                            height: '28px',
-                                                            padding: '0 10px',
-                                                            background: 'none',
-                                                            border: '1px solid var(--border-subtle)',
-                                                            borderRadius: '6px',
-                                                            cursor: 'pointer',
-                                                            fontSize: '12px',
-                                                            color: 'var(--text-secondary)',
-                                                            textAlign: 'center',
-                                                            display: 'flex',
-                                                            alignItems: 'center',
-                                                            justifyContent: 'center',
-                                                            gap: '6px',
-                                                            transition: 'all 0.15s ease',
-                                                            boxSizing: 'border-box',
-                                                        }}
-                                                        onMouseEnter={(e) => {
-                                                            e.currentTarget.style.background = 'var(--bg-secondary)';
-                                                            e.currentTarget.style.color = 'var(--text-primary)';
-                                                            e.currentTarget.style.borderColor = 'var(--accent-primary)';
-                                                        }}
-                                                        onMouseLeave={(e) => {
-                                                            e.currentTarget.style.background = 'none';
-                                                            e.currentTarget.style.color = 'var(--text-secondary)';
-                                                            e.currentTarget.style.borderColor = 'var(--border-subtle)';
-                                                        }}
+                                                        className="new-session-btn"
                                                     >
-                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+                                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden style={{ display: 'block', flexShrink: 0 }}>
                                                             <line x1="12" y1="5" x2="12" y2="19" />
                                                             <line x1="5" y1="12" x2="19" y2="12" />
                                                         </svg>
-                                                        {t('agent.chat.newSession')}
+                                                        <span>{t('agent.chat.newSession')}</span>
                                                     </button>
                                                 </div>
                                             )}

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -4095,12 +4095,12 @@ function AgentDetailInner() {
                                 </div>
 
                                 {canViewAllAgentChatSessions && (
-                                    <div className="tabs session-sidebar-session-tabs" role="tablist">
+                                    <div className="session-sidebar-segment-control" role="tablist">
                                         <div
                                             role="tab"
                                             tabIndex={0}
                                             aria-selected={chatScope === 'mine'}
-                                            className={`tab ${chatScope === 'mine' ? 'active' : ''}`}
+                                            className={`segment-item ${chatScope === 'mine' ? 'active' : ''}`}
                                             onClick={onAdminTabMine}
                                             onKeyDown={(e) => {
                                                 if (e.key === 'Enter' || e.key === ' ') {
@@ -4115,7 +4115,7 @@ function AgentDetailInner() {
                                             role="tab"
                                             tabIndex={0}
                                             aria-selected={chatScope === 'all'}
-                                            className={`tab ${chatScope === 'all' ? 'active' : ''}`}
+                                            className={`segment-item ${chatScope === 'all' ? 'active' : ''}`}
                                             onClick={onAdminTabOthers}
                                             onKeyDown={(e) => {
                                                 if (e.key === 'Enter' || e.key === ' ') {
@@ -4192,24 +4192,25 @@ function AgentDetailInner() {
                                                     return (
                                                         <div key={s.id} onClick={() => { setChatScope('mine'); selectSession(s, 'mine'); }}
                                                             className="session-item"
-                                                            style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px', position: 'relative' }}
-                                                            onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0.5'; }}
-                                                            onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; const btn = e.currentTarget.querySelector('.del-btn') as HTMLElement; if (btn) btn.style.opacity = '0'; }}>
-                                                            <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
-                                                                <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>{s.title}</div>
-                                                                {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
+                                                            style={{ padding: '8px 12px', cursor: 'pointer', borderLeft: isActive ? '2px solid var(--accent-primary)' : '2px solid transparent', background: isActive ? 'var(--bg-secondary)' : 'transparent', marginBottom: '1px', display: 'flex', alignItems: 'center', gap: '4px' }}
+                                                            onMouseEnter={e => { if (!isActive) e.currentTarget.style.background = 'var(--bg-secondary)'; }}
+                                                            onMouseLeave={e => { if (!isActive) e.currentTarget.style.background = 'transparent'; }}>
+                                                            <div style={{ flex: 1, minWidth: 0 }}>
+                                                                <div style={{ display: 'flex', alignItems: 'center', gap: '5px', marginBottom: '2px' }}>
+                                                                    <div style={{ fontSize: '12px', fontWeight: isActive ? 600 : 400, color: 'var(--text-primary)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1, minWidth: 0 }}>{s.title}</div>
+                                                                    {chLabel && <span style={{ fontSize: '9px', padding: '1px 4px', borderRadius: '3px', background: 'var(--bg-tertiary)', color: 'var(--text-tertiary)', flexShrink: 0 }}>{chLabel}</span>}
+                                                                </div>
+                                                                <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
+                                                                    {s.last_message_at
+                                                                        ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+                                                                        : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
+                                                                    {s.message_count > 0 && <span className="session-msg-count" style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
+                                                                </div>
                                                             </div>
-                                                            <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', display: 'flex', alignItems: 'center', gap: '6px' }}>
-                                                                {s.last_message_at
-                                                                    ? new Date(s.last_message_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
-                                                                    : new Date(s.created_at).toLocaleString(i18n.language === 'zh' ? 'zh-CN' : 'en-US', { month: 'short', day: 'numeric' })}
-                                                                {s.message_count > 0 && <span style={{ marginLeft: 'auto' }}>{s.message_count}</span>}
-                                                            </div>
-                                                            <button className="del-btn" onClick={(e) => { e.stopPropagation(); deleteSession(s.id); }}
-                                                                style={{ position: 'absolute', top: '4px', right: '4px', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 4px', opacity: 0, fontSize: '14px', color: 'var(--text-tertiary)', lineHeight: 1, transition: 'opacity 0.15s' }}
-                                                                onMouseEnter={e => { e.currentTarget.style.opacity = '1'; e.currentTarget.style.color = 'var(--status-error)'; }}
-                                                                onMouseLeave={e => { e.currentTarget.style.opacity = '0.5'; e.currentTarget.style.color = 'var(--text-tertiary)'; }}
-                                                                title={t('chat.deleteSession', 'Delete session')}>×</button>
+                                                            <button className="session-del-btn" onClick={(e) => { e.stopPropagation(); deleteSession(s.id); }}
+                                                                title={t('chat.deleteSession', 'Delete session')}>
+                                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18"/><path d="M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/></svg>
+                                                            </button>
                                                         </div>
                                                     );
                                                 })}
@@ -4221,7 +4222,7 @@ function AgentDetailInner() {
                                                 <select
                                                     value={allUserFilter}
                                                     onChange={(e) => setAllUserFilter(e.target.value)}
-                                                    style={{ width: '100%', height: '28px', padding: '0 8px', fontSize: '12px', background: 'var(--bg-secondary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', color: 'var(--text-primary)', cursor: 'pointer' }}
+                                                    style={{ width: '100%', height: '28px', fontSize: '12px', backgroundColor: 'var(--bg-secondary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', color: 'var(--text-primary)' }}
                                                 >
                                                     <option value="">{t('agent.chat.allUsers')}</option>
                                                     {otherUserPickerOptions.map(([uid, label]) => (


### PR DESCRIPTION
## Summary

- **Segment control for session tabs**: Replace the underline-style tab switcher (My Sessions / Other Users) with a segment control. 28px height, accent-colored active state that follows the admin-configured theme color (primary button style in dark mode, pure white in light mode). Uses new design tokens `--segment-active-bg` / `--segment-active-text`.
- **Session item delete button rework**: Move from absolute-positioned `×` overlay to inline flexbox layout. On hover, the title text area shrinks gracefully to reveal a trash icon (14px icon, 24px hit area). Message count hides on hover. Transitions at 0.35s ease-in-out.
- **Global select chevron icon**: Hide the native browser dropdown arrow with `appearance: none` and add a Tabler Icons `chevron-down` via CSS `background-image`. Icon color matches `--text-secondary` per theme. Proper `padding-right: 32px` prevents text overlapping the icon. Fix an inline style issue where `background` shorthand was overriding `background-image`.

## Test plan

- [ ] Open any Agent → Chat tab as an admin user (to see the My Sessions / Other Users toggle)
- [ ] Verify the segment control renders at 28px height with proper active state styling
- [ ] Switch between dark and light mode — active state should be accent-colored (dark) / white (light)
- [ ] Hover over session items — delete button appears, title text shrinks, message count hides
- [ ] Click the delete button — session is deleted
- [ ] Check the user filter `<select>` dropdown in "Other Users" tab — chevron-down icon visible, text does not overlap
- [ ] Verify select chevron appears correctly on other pages (login, enterprise settings, etc.)
- [ ] Test with a custom admin theme color — segment control active state should follow the accent


Made with [Cursor](https://cursor.com)