### PR TITLE
feat: inject platform base_url into agent system prompt and webhook URLs

### DIFF
--- a/backend/app/services/agent_context.py
+++ b/backend/app/services/agent_context.py
@@ -564,4 +564,24 @@ You have internet access through these tools — **use them proactively when you
     if current_user_name:
         dynamic_parts.append(f"\n## Current Conversation\nYou are currently chatting with **{current_user_name}**. Address them by name when appropriate.")
 
+    # Inject platform base URL so agent knows where it is deployed
+    try:
+        from app.services.platform_service import platform_service
+        _platform_url = (await platform_service.get_public_base_url()).rstrip("/")
+        platform_lines = [
+            "\n## Platform Base URLs",
+            "You are running on the Clawith platform. Always use these URLs exactly -- never guess or invent domain names.",
+            "",
+            "- **Platform base**: " + _platform_url,
+            "- **Webhook**: " + _platform_url + "/api/webhooks/t/<token>  (replace <token> with actual trigger token)",
+            "- **Public page**: " + _platform_url + "/p/<short_id>  (replace <short_id> with actual page id returned by publish_page)",
+            "- **File download**: " + _platform_url + "/api/agents/<agent_id>/files/download?path=<rel_path>",
+            "- **Gateway poll**: " + _platform_url + "/api/gateway/poll  (used by external agents to check inbox)",
+            "",
+            "Never use placeholder domains (clawith.com, try.clawith.ai, webhook.clawith.com, api.clawith.ai, etc.).",
+        ]
+        dynamic_parts.append("\n".join(platform_lines))
+    except Exception:
+        pass
+
     return "\n".join(static_parts), "\n".join(dynamic_parts)

--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -5544,6 +5544,7 @@ async def _handle_cancel_trigger(agent_id: uuid.UUID, arguments: dict) -> str:
 async def _handle_list_triggers(agent_id: uuid.UUID) -> str:
     """List all active triggers for the agent."""
     from app.models.trigger import AgentTrigger
+    from app.services.platform_service import platform_service
 
     try:
         async with async_session() as db:
@@ -5554,15 +5555,24 @@ async def _handle_list_triggers(agent_id: uuid.UUID) -> str:
             )
             triggers = result.scalars().all()
 
+            # Resolve base URL for webhook triggers
+            _base_url = (await platform_service.get_public_base_url(db)).rstrip("/")
+
         if not triggers:
             return "No triggers found. Use set_trigger to create one."
 
-        lines = ["| Name | Type | Config | Reason | Status | Fires |", "|------|------|--------|--------|--------|-------|"]
+        lines = ["| Name | Type | Config | Webhook URL | Reason | Status | Fires |", "|------|------|--------|-------------|--------|--------|-------|"]
         for t in triggers:
             status = "✅ active" if t.is_enabled else "⏸ disabled"
-            config_str = str(t.config)[:50]
+            config = t.config or {}
+            if t.type == "webhook" and config.get("token"):
+                config_str = f"token: {config['token']}"
+                webhook_url = f"{_base_url}/api/webhooks/t/{config['token']}"
+            else:
+                config_str = str(config)[:50]
+                webhook_url = "-"
             reason_str = t.reason[:40] if t.reason else ""
-            lines.append(f"| {t.name} | {t.type} | {config_str} | {reason_str} | {status} | {t.fire_count} |")
+            lines.append(f"| {t.name} | {t.type} | {config_str} | {webhook_url} | {reason_str} | {status} | {t.fire_count} |")
 
         return "\n".join(lines)
 


### PR DESCRIPTION
## Summary
- Agent system prompt now includes platform URL patterns (webhook, public page, file download, gateway)
- `list_triggers` returns full webhook URLs instead of relative paths
- Uses existing `platform_service.get_public_base_url()`

## Test plan
- [x] E2E: asked Morty for platform URL → correctly returned all 5 URL patterns