### PR TITLE
fix: use agent context_window_size across all channels instead of hardcoded limits

### DIFF
--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -1497,11 +1497,11 @@ async def _call_agent_llm(
         return f"⚠️ {agent.name} 未配置 LLM 模型，请在管理后台设置。"
 
     # Build conversation messages (without system prompt — call_llm adds it)
+    # NOTE: history is already truncated to ctx_size by the SQL .limit() in
+    # each caller, so no further slicing is needed here.
     messages: list[dict] = []
-    from app.models.agent import DEFAULT_CONTEXT_WINDOW_SIZE
-    ctx_size = agent.context_window_size or DEFAULT_CONTEXT_WINDOW_SIZE
     if history:
-        messages.extend(history[-ctx_size:])
+        messages.extend(history)
     messages.append({"role": "user", "content": user_text})
 
     # Use actual user_id so the system prompt knows who it's chatting with


### PR DESCRIPTION
## Summary
- Remove redundant `history[-ctx_size:]` truncation in `_call_agent_llm` — SQL `.limit()` already handles it
- Ensures agent's configured `context_window_size` is respected consistently

## Test plan
- [x] Verified no hardcoded truncation in `_call_agent_llm`
- [x] Backend runtime verification passed