### PR TITLE
feat: inject secrets.md management instructions into agent system prompt

### DIFF
--- a/backend/app/services/agent_context.py
+++ b/backend/app/services/agent_context.py
@@ -396,6 +396,28 @@ You have a dedicated workspace with this structure:
   - workspace/     → Your work files (reports, documents, etc.)
   - relationships.md → Your relationship list
   - enterprise_info/ → Shared company information
+  - secrets.md       → PRIVATE credentials store (passwords, API keys, connection strings)
+
+🔐 **SECRETS MANAGEMENT — ABSOLUTE RULES (VIOLATION = CRITICAL FAILURE)**:
+
+1. **MANDATORY STORAGE**: When a user provides ANY sensitive credential (password, API key, database connection string, token, secret), you MUST IMMEDIATELY call `write_file(path="secrets.md", content="...")` to store it. This is NOT optional.
+
+2. **VERIFY THE TOOL CALL**: You must see an actual `write_file` tool call result confirming "Written to secrets.md" before telling the user it's saved. NEVER claim "I've saved it" without a real tool call result — that is a hallucination.
+
+3. **NEVER store credentials in memory/memory.md** or any other file. ONLY secrets.md.
+
+4. **NEVER output credential values in chat messages**. Refer to them by name only (e.g. "the MySQL connection stored in secrets.md").
+
+5. **Reading credentials**: When you need to use a stored credential, call `read_file(path="secrets.md")` first, then use the value in tool calls.
+
+6. **secrets.md format** — use clear labels:
+   ```
+   ## Database Connections
+   - mysql_prod: mysql://user:pass@host:3306/db
+
+   ## API Keys
+   - openai: sk-xxx
+   ```
 
 ⚠️ CRITICAL RULES — YOU MUST FOLLOW THESE STRICTLY:
 


### PR DESCRIPTION
## Summary
- Add secrets.md to agent workspace structure documentation in system prompt
- Strict rules: credentials must be stored via write_file, never displayed in chat, referenced by name only
- Agents will proactively use secrets.md for credential storage and retrieval

## Test plan
- [x] E2E browser test: asked Morty to save API key → called write_file → saved to secrets.md → did not leak key in response