### PR TITLE
fix Docker access port to 3008

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ bash restart.sh
 git clone https://github.com/dataelement/Clawith.git
 cd Clawith && cp .env.example .env
 docker compose up -d
-# → http://localhost:3000
+# → http://localhost:3008
 ```
 
 **To update an existing deployment:**

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -108,7 +108,7 @@ bash restart.sh
 git clone https://github.com/dataelement/Clawith.git
 cd Clawith && cp .env.example .env
 docker compose up -d
-# → http://localhost:3000
+# → http://localhost:3008
 ```
 
 **更新已有部署：**


### PR DESCRIPTION
## Summary

Fixed the incorrect Docker access port in README.md and zhe-CN version.

In my first practice , I encountered 404 multiple times finally find The correct access address is http://localhost:3008\login
we can see the config indocker-compose.yml
   ports:
      - "${FRONTEND_PORT:-3008}:3000"

## Checklist

- [x] Tested locally
- [x] No unrelated changes included
