### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ FEISHU_REDIRECT_URI=http://localhost:3000/auth/feishu/callback
 # Without a key, the tools still work but with lower rate limits
 JINA_API_KEY=
 
+# Exa API key (for exa_search tool and web_search Exa engine — get one at https://exa.ai)
+EXA_API_KEY=
+
 # Public app URL used in user-facing links, such as password reset emails.
 # Leave empty for auto-discovery from the browser request.
 # Set explicitly for production (e.g. https://your-domain.com) — required for

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -103,6 +103,9 @@ class Settings(BaseSettings):
     # Jina AI (Reader + Search APIs)
     JINA_API_KEY: str = ""
 
+    # Exa AI (Search API)
+    EXA_API_KEY: str = ""
+
 
     # Sandbox configuration
     SANDBOX_TYPE: SandboxType = SandboxType.SUBPROCESS

--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -2029,6 +2029,8 @@ async def _execute_tool_direct(
             return await _web_search(arguments, agent_id)
         elif tool_name == "jina_search":
             return await _jina_search(arguments)
+        elif tool_name == "exa_search":
+            return await _exa_search(arguments, agent_id)
         elif tool_name == "send_feishu_message":
             return await _send_feishu_message(agent_id, arguments)
         elif tool_name == "send_message_to_agent":
@@ -2187,6 +2189,8 @@ async def execute_tool(
             result = await _web_search(arguments, agent_id)
         elif tool_name == "jina_search":
             result = await _jina_search(arguments)
+        elif tool_name == "exa_search":
+            result = await _exa_search(arguments, agent_id)
         elif tool_name == "bing_search":
             result = await _jina_search(arguments)  # redirect legacy to jina
         elif tool_name == "jina_read":
@@ -2364,6 +2368,8 @@ async def _web_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str
             return await _search_google(query, api_key, max_results, language)
         elif engine == "bing" and api_key:
             return await _search_bing(query, api_key, max_results, language)
+        elif engine == "exa" and api_key:
+            return await _search_exa(query, api_key, max_results)
         else:
             return await _search_duckduckgo(query, max_results)
     except Exception as e:
@@ -2584,6 +2590,124 @@ async def _search_bing(query: str, api_key: str, max_results: int, language: str
     if not results:
         return f'🔍 No results found for "{query}"'
     return f'🔍 Bing search for "{query}" ({len(results)} items):\n\n' + "\n\n---\n\n".join(results)
+
+
+async def _search_exa(query: str, api_key: str, max_results: int) -> str:
+    """Search via Exa AI API (exa.ai). Used by the web_search engine selector."""
+    import httpx
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            "https://api.exa.ai/search",
+            json={
+                "query": query,
+                "type": "auto",
+                "numResults": max_results,
+                "contents": {"text": {"maxCharacters": 1000}},
+            },
+            headers={
+                "x-api-key": api_key,
+                "Content-Type": "application/json",
+                "x-exa-integration": "clawith",
+            },
+            timeout=15,
+        )
+        data = resp.json()
+
+    if resp.status_code != 200:
+        return f"❌ Exa search failed: {data.get('error', data.get('message', str(data)[:200]))}"
+
+    results = []
+    for r in data.get("results", [])[:max_results]:
+        title = r.get("title", "Untitled")
+        url = r.get("url", "")
+        text = (r.get("text") or "")[:300]
+        results.append(f"**{title}**\n{url}\n{text}")
+
+    if not results:
+        return f'🔍 No results found for "{query}"'
+    return f'🔍 Exa search for "{query}" ({len(results)} items):\n\n' + "\n\n---\n\n".join(results)
+
+
+async def _exa_search(arguments: dict, agent_id: uuid.UUID | None = None) -> str:
+    """Full-featured Exa AI search with category filtering, domain filtering, and content modes."""
+    import httpx
+
+    query = arguments.get("query", "").strip()
+    if not query:
+        return "❌ Please provide search keywords"
+
+    config = await _get_tool_config(agent_id, "exa_search") or {}
+    api_key = config.get("api_key", "") or get_settings().EXA_API_KEY
+    if not api_key:
+        return "❌ Exa API key is required. Set it in tool settings or the EXA_API_KEY environment variable."
+
+    max_results = min(arguments.get("max_results", 5), 10)
+    search_type = arguments.get("search_type", "auto")
+    category = arguments.get("category") or None
+    content_mode = arguments.get("content_mode", "text")
+    include_domains = arguments.get("include_domains")
+    exclude_domains = arguments.get("exclude_domains")
+
+    body: dict = {
+        "query": query,
+        "type": search_type,
+        "numResults": max_results,
+        "contents": {},
+    }
+
+    if category:
+        body["category"] = category
+    if include_domains:
+        body["includeDomains"] = [d.strip() for d in include_domains.split(",") if d.strip()]
+    if exclude_domains:
+        body["excludeDomains"] = [d.strip() for d in exclude_domains.split(",") if d.strip()]
+
+    if content_mode == "highlights":
+        body["contents"]["highlights"] = {"numSentences": 3}
+    elif content_mode == "summary":
+        body["contents"]["summary"] = {}
+    else:
+        body["contents"]["text"] = {"maxCharacters": 1000}
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                "https://api.exa.ai/search",
+                json=body,
+                headers={
+                    "x-api-key": api_key,
+                    "Content-Type": "application/json",
+                    "x-exa-integration": "clawith",
+                },
+                timeout=15,
+            )
+            data = resp.json()
+
+        if resp.status_code != 200:
+            return f"❌ Exa search failed: {data.get('error', data.get('message', str(data)[:200]))}"
+
+        items = data.get("results", [])[:max_results]
+        if not items:
+            return f'🔍 No results found for "{query}"'
+
+        parts = []
+        for i, r in enumerate(items, 1):
+            title = r.get("title", "Untitled")
+            url = r.get("url", "")
+            content = ""
+            if content_mode == "highlights" and r.get("highlights"):
+                content = " ... ".join(r["highlights"])
+            elif content_mode == "summary" and r.get("summary"):
+                content = r["summary"]
+            elif r.get("text"):
+                content = r["text"][:500]
+            parts.append(f"**{i}. {title}**\n{url}\n{content}")
+
+        return f'🔍 Exa search for "{query}" ({len(items)} items):\n\n' + "\n\n---\n\n".join(parts)
+
+    except Exception as e:
+        return f"❌ Exa search error: {str(e)[:300]}"
 
 
 async def _send_channel_file(agent_id: uuid.UUID, ws: Path, arguments: dict) -> str:

--- a/backend/app/services/tool_seeder.py
+++ b/backend/app/services/tool_seeder.py
@@ -310,7 +310,7 @@ BUILTIN_TOOLS = [
     {
         "name": "web_search",
         "display_name": "Web Search",
-        "description": "Search the internet using a configurable search engine. Supports DuckDuckGo (free), Tavily, Google, and Bing. Configure the search engine in the tool settings.",
+        "description": "Search the internet using a configurable search engine. Supports DuckDuckGo (free), Tavily, Google, Bing, and Exa. Configure the search engine in the tool settings.",
         "category": "search",
         "icon": "🔍",
         "is_default": True,
@@ -339,6 +339,7 @@ BUILTIN_TOOLS = [
                         {"value": "tavily", "label": "Tavily (AI search, needs API key)"},
                         {"value": "google", "label": "Google Custom Search (needs API key)"},
                         {"value": "bing", "label": "Bing Search API (needs API key)"},
+                        {"value": "exa", "label": "Exa (AI-powered search, needs API key)"},
                     ],
                     "default": "duckduckgo",
                 },
@@ -348,7 +349,7 @@ BUILTIN_TOOLS = [
                     "type": "password",
                     "default": "",
                     "placeholder": "Required for engines that need an API key",
-                    "depends_on": {"search_engine": ["tavily", "google", "bing"]},
+                    "depends_on": {"search_engine": ["tavily", "google", "bing", "exa"]},
                 },
                 {
                     "key": "max_results",
@@ -424,6 +425,56 @@ BUILTIN_TOOLS = [
                     "type": "password",
                     "default": "",
                     "placeholder": "jina_xxxxxxxxxxxxxxxx (get one at jina.ai)",
+                },
+            ]
+        },
+    },
+    {
+        "name": "exa_search",
+        "display_name": "Exa Search",
+        "description": "AI-powered web search using Exa (exa.ai). Supports semantic search, category filtering, domain filtering, and multiple content modes (text, highlights, summary). Requires an Exa API key.",
+        "category": "search",
+        "icon": "🔎",
+        "is_default": False,
+        "parameters_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "max_results": {"type": "integer", "description": "Number of results (default 5, max 10)"},
+                "search_type": {
+                    "type": "string",
+                    "description": "Search type: auto (default), neural, or fast",
+                    "enum": ["auto", "neural", "fast"],
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Filter by category: company, research paper, news, personal site, financial report, or people",
+                },
+                "include_domains": {
+                    "type": "string",
+                    "description": "Comma-separated domains to restrict results to (e.g. 'arxiv.org, github.com')",
+                },
+                "exclude_domains": {
+                    "type": "string",
+                    "description": "Comma-separated domains to exclude from results",
+                },
+                "content_mode": {
+                    "type": "string",
+                    "description": "Content retrieval mode: text (default), highlights, or summary",
+                    "enum": ["text", "highlights", "summary"],
+                },
+            },
+            "required": ["query"],
+        },
+        "config": {},
+        "config_schema": {
+            "fields": [
+                {
+                    "key": "api_key",
+                    "label": "Exa API Key",
+                    "type": "password",
+                    "default": "",
+                    "placeholder": "Get your API key at exa.ai",
                 },
             ]
         },


### PR DESCRIPTION
## Summary

- Add **Exa Search** as a standalone tool (`exa_search`) with full-featured AI-powered web search: semantic search types (auto/neural/fast), content modes (text/highlights/summary), category filtering (company, research paper, news, etc.), and domain filtering
- Add **Exa** as a new engine option in the existing `web_search` tool, alongside DuckDuckGo, Tavily, Google, and Bing
- API key configurable via tool settings UI or `EXA_API_KEY` environment variable

## Usage

Once enabled, agents can use the Exa search tool:

```
# Simple search
{"tool": "exa_search", "arguments": {"query": "latest AI research papers"}}

# With filtering
{"tool": "exa_search", "arguments": {
    "query": "Series B funding announcements",
    "category": "news",
    "include_domains": "techcrunch.com, bloomberg.com",
    "content_mode": "highlights"
}}

# Via web_search engine selector
# Set search_engine to "exa" in tool settings, then use web_search as usual
```

## Files changed

- `backend/app/services/tool_seeder.py` — Exa search tool definition + web_search engine option
- `backend/app/services/agent_tools.py` — `_search_exa` (simple) and `_exa_search` (full-featured) implementations
- `backend/app/config.py` — `EXA_API_KEY` setting
- `.env.example` — `EXA_API_KEY` documentation

## Test plan

- [ ] Set `EXA_API_KEY` in `.env` or tool settings and verify `exa_search` returns results
- [ ] Test different content modes: `text`, `highlights`, `summary`
- [ ] Test category filtering (e.g. `research paper`, `news`)
- [ ] Test domain filtering with `include_domains` / `exclude_domains`
- [ ] Select "Exa" engine in `web_search` tool settings and verify it works
- [ ] Verify error message when no API key is configured
- [ ] Verify existing search engines (DuckDuckGo, Tavily, etc.) are unaffected