### PR TITLE
Extract hardcoded frontend copy to existing i18n keys

### DIFF
--- a/frontend/src/components/ChannelConfig.tsx
+++ b/frontend/src/components/ChannelConfig.tsx
@@ -803,7 +803,8 @@ export default function ChannelConfig({ mode, agentId, canManage = true, values,
                                             <span style={{ color: 'var(--accent-primary)' }}>{webhookUrl}</span>
                                             <LinearCopyButton
                                                 textToCopy={webhookUrl}
-                                                label="Copy"
+                                                label={t('common.copy')}
+                                                copiedLabel={t('common.copied')}
                                                 iconOnly={true}
                                                 className=""
                                                 style={{ marginLeft: '6px', padding: '1px 4px', cursor: 'pointer', borderRadius: '3px', border: '1px solid var(--border-color)', background: 'var(--bg-primary)', color: 'var(--text-secondary)', verticalAlign: 'middle' }}

--- a/frontend/src/components/FileBrowser.tsx
+++ b/frontend/src/components/FileBrowser.tsx
@@ -512,7 +512,7 @@ export default function FileBrowser({
                 {renderBreadcrumbs()}
                 <div style={{ display: 'flex', gap: '6px', marginLeft: 'auto' }}>
                     {upload && api.upload && (
-                        <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={handleUpload}>⬆ Upload</button>
+                        <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={handleUpload}>{t('common.upload', '⬆ Upload')}</button>
                     )}
                     {newFolder && (
                         <button className="btn btn-secondary" style={{ fontSize: '12px' }}

--- a/frontend/src/pages/AdminCompanies.tsx
+++ b/frontend/src/pages/AdminCompanies.tsx
@@ -196,7 +196,7 @@ function PlatformTab() {
         try {
             await adminApi.updatePlatformSettings({ [key]: value });
             setSettings((s: any) => ({ ...s, [key]: value }));
-            showToast('Setting updated');
+            showToast(t('admin.settingUpdated', 'Setting updated'));
         } catch (e: any) {
             showToast(e.message || 'Failed', 'error');
         }
@@ -773,7 +773,7 @@ function CompaniesTab() {
 
     const columns: { key: SortKey; label: string; flex: string }[] = [
         { key: 'name', label: t('admin.company', 'Company'), flex: '2fr' },
-        { key: 'sso_enabled', label: 'SSO', flex: '100px' },
+        { key: 'sso_enabled', label: t('admin.sso', 'SSO'), flex: '100px' },
         { key: 'org_admin_email', label: t('admin.orgAdmin', 'Admin Email'), flex: '1.5fr' },
         { key: 'user_count', label: t('admin.users', 'Users'), flex: '70px' },
         { key: 'agent_count', label: t('admin.agents', 'Agents'), flex: '70px' },

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -234,8 +234,8 @@ function SsoChannelSection({ idpType, existingProvider, tenant, t }: {
                             style={{ fontSize: '11px', width: 'auto', minWidth: '70px', height: '33px' }}
                             disabled={!domain}
                             textToCopy={domain ? (domain.startsWith('http') ? domain : `https://${domain}`) : ''}
-                            label={t('common.copy', 'Copy')}
-                            copiedLabel="Copied"
+                            label={t('common.copy')}
+                            copiedLabel={t('common.copied')}
                         />
                     </div>
                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
@@ -267,8 +267,8 @@ function SsoChannelSection({ idpType, existingProvider, tenant, t }: {
                             style={{ fontSize: '11px', width: 'auto', minWidth: '70px', height: '33px' }}
                             disabled={!callbackUrl}
                             textToCopy={callbackUrl}
-                            label={t('common.copy', 'Copy')}
-                            copiedLabel="Copied"
+                            label={t('common.copy')}
+                            copiedLabel={t('common.copied')}
                         />
                     </div>
                     <div style={{ fontSize: '10px', color: 'var(--text-tertiary)', marginTop: '4px' }}>
@@ -536,10 +536,10 @@ function OrgTab({ tenant }: { tenant: any }) {
     };
 
     const IDP_TYPES = [
-        { type: 'feishu', name: 'Feishu', desc: 'Feishu / Lark Integration', icon: <img src="/feishu.png" width="20" height="20" alt="Feishu" /> },
-        { type: 'wecom', name: 'WeCom', desc: 'WeChat Work Integration', icon: <img src="/wecom.png" width="20" height="20" style={{ borderRadius: '4px' }} alt="WeCom" /> },
-        { type: 'dingtalk', name: 'DingTalk', desc: 'DingTalk App Integration', icon: <img src="/dingtalk.png" width="20" height="20" style={{ borderRadius: '4px' }} alt="DingTalk" /> },
-        { type: 'oauth2', name: 'OAuth2', desc: 'Generic OIDC Provider', icon: <div style={{ width: 20, height: 20, background: 'var(--accent-primary)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: 10, fontWeight: 700 }}>O</div> }
+        { type: 'feishu', name: t('enterprise.identity.providers.feishu.name', 'Feishu'), desc: t('enterprise.identity.providers.feishu.desc', 'Feishu / Lark Integration'), icon: <img src="/feishu.png" width="20" height="20" alt="Feishu" /> },
+        { type: 'wecom', name: t('enterprise.identity.providers.wecom.name', 'WeCom'), desc: t('enterprise.identity.providers.wecom.desc', 'WeChat Work Integration'), icon: <img src="/wecom.png" width="20" height="20" style={{ borderRadius: '4px' }} alt="WeCom" /> },
+        { type: 'dingtalk', name: t('enterprise.identity.providers.dingtalk.name', 'DingTalk'), desc: t('enterprise.identity.providers.dingtalk.desc', 'DingTalk App Integration'), icon: <img src="/dingtalk.png" width="20" height="20" style={{ borderRadius: '4px' }} alt="DingTalk" /> },
+        { type: 'oauth2', name: t('enterprise.identity.providers.oauth2.name', 'OAuth2'), desc: t('enterprise.identity.providers.oauth2.desc', 'Generic OIDC Provider'), icon: <div style={{ width: 20, height: 20, background: 'var(--accent-primary)', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#fff', fontSize: 10, fontWeight: 700 }}>O</div> }
     ];
 
     const handleExpand = (type: string, existingProvider?: any) => {
@@ -597,8 +597,8 @@ function OrgTab({ tenant }: { tenant: any }) {
                                             className="btn btn-ghost"
                                             style={{ position: 'absolute', top: '8px', right: '8px', fontSize: '10px', color: '#abb2bf', padding: '4px 8px', background: 'rgba(255,255,255,0.1)', cursor: 'pointer', border: 'none', borderRadius: '4px', height: 'fit-content', minWidth: '60px' }}
                                             textToCopy={FEISHU_SYNC_PERM_JSON}
-                                            label="Copy"
-                                            copiedLabel="Copied✓"
+                                            label={t('common.copy')}
+                                            copiedLabel={t('common.copied') + '✓'}
                                         />
                                         {FEISHU_SYNC_PERM_JSON}
                                     </div>
@@ -642,15 +642,15 @@ function OrgTab({ tenant }: { tenant: any }) {
                 {type === 'oauth2' ? (
                     <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                         <div className="form-group">
-                            <label className="form-label">Client ID</label>
+                            <label className="form-label">{t('enterprise.identity.clientId')}</label>
                             <input className="form-input" value={form.app_id} onChange={e => setForm({ ...form, app_id: e.target.value })} />
                         </div>
                         <div className="form-group">
-                            <label className="form-label">Client Secret</label>
+                            <label className="form-label">{t('enterprise.identity.clientSecret')}</label>
                             <input className="form-input" type="password" value={form.app_secret} onChange={e => setForm({ ...form, app_secret: e.target.value })} />
                         </div>
                         <div className="form-group" style={{ gridColumn: '1 / -1' }}>
-                            <label className="form-label">Authorize URL</label>
+                            <label className="form-label">{t('enterprise.identity.authorizeUrl')}</label>
                             <input className="form-input" value={form.authorize_url} onChange={e => setForm({ ...form, authorize_url: e.target.value })} />
                         </div>
                     </div>
@@ -708,11 +708,11 @@ function OrgTab({ tenant }: { tenant: any }) {
                             <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{t('enterprise.identity.providerHints.dingtalk')}</div>
                         </div>
                         <div className="form-group">
-                            <label className="form-label">App Key</label>
+                            <label className="form-label">{t('enterprise.identity.appKey')}</label>
                             <input className="form-input" value={form.config.app_key || ''} onChange={e => setForm({ ...form, config: { ...form.config, app_key: e.target.value } })} placeholder="dingxxxxxxxxxxxx" />
                         </div>
                         <div className="form-group">
-                            <label className="form-label">App Secret</label>
+                            <label className="form-label">{t('enterprise.identity.appSecret')}</label>
                             <input className="form-input" type="password" value={form.config.app_secret || ''} onChange={e => setForm({ ...form, config: { ...form.config, app_secret: e.target.value } })} />
                         </div>
                     </div>
@@ -872,7 +872,7 @@ function OrgTab({ tenant }: { tenant: any }) {
                         {t('enterprise.identity.title', 'Organization & Directory Sync')}
                     </h3>
                     <div style={{ fontSize: '12px', color: 'var(--text-secondary)', marginTop: '4px' }}>
-                        Configure enterprise directory synchronization and Identity Provider settings.
+                        {t('enterprise.identity.description', 'Configure enterprise directory synchronization and Identity Provider settings.')}
                     </div>
                 </div>
 
@@ -897,7 +897,7 @@ function OrgTab({ tenant }: { tenant: any }) {
                                     <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
                                         {existingProvider ? (
                                             <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'flex-end', gap: '8px' }}>
-                                                <span className="badge badge-success" style={{ fontSize: '10px' }}>Active</span>
+                                                <span className="badge badge-success" style={{ fontSize: '10px' }}>{t('enterprise.identity.active', 'Active')}</span>
                                                 {existingProvider.last_synced_at && (
                                                     <span style={{ fontSize: '10px', color: 'var(--text-tertiary)' }}>
                                                         Synced: {new Date(existingProvider.last_synced_at).toLocaleDateString()}
@@ -905,7 +905,7 @@ function OrgTab({ tenant }: { tenant: any }) {
                                                 )}
                                             </div>
                                         ) : (
-                                            <span className="badge badge-secondary" style={{ fontSize: '10px' }}>Not configured</span>
+                                            <span className="badge badge-secondary" style={{ fontSize: '10px' }}>{t('enterprise.identity.notConfigured', 'Not configured')}</span>
                                         )}
                                         <div style={{ color: 'var(--text-tertiary)', transform: isExpanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s', fontSize: '12px' }}>
                                             ▼
@@ -992,9 +992,9 @@ function ThemeColorPicker() {
                     style={{ width: '120px', fontSize: '13px', fontFamily: 'var(--font-mono)' }}
                     onKeyDown={e => e.key === 'Enter' && handleCustom()}
                 />
-                <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={handleCustom}>Apply</button>
+                <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={handleCustom}>{t('common.apply', 'Apply')}</button>
                 {currentColor && (
-                    <button className="btn btn-ghost" style={{ fontSize: '12px', color: 'var(--text-tertiary)' }} onClick={handleReset}>Reset</button>
+                    <button className="btn btn-ghost" style={{ fontSize: '12px', color: 'var(--text-tertiary)' }} onClick={handleReset}>{t('common.reset', 'Reset')}</button>
                 )}
                 {currentColor && (
                     <div style={{ width: '20px', height: '20px', borderRadius: '4px', background: currentColor, border: '1px solid var(--border-default)' }} />
@@ -1630,7 +1630,7 @@ function CompanyTimezoneEditor() {
                     disabled={saving}
                 >
                     {COMMON_TIMEZONES.map(tz => (
-                        <option key={tz} value={tz}>{tz}</option>
+                        <option key={tz} value={tz}>{t(`enterprise.timezone.zones.${tz}`, tz)}</option>
                     ))}
                 </select>
                 {saved && <span style={{ color: 'var(--success)', fontSize: '12px' }}>✅</span>}
@@ -2168,7 +2168,7 @@ export default function EnterpriseSettings() {
                                     {editingModelId === m.id ? (
                                         /* Inline edit form */
                                         <div className="card" style={{ border: '1px solid var(--accent-primary)' }}>
-                                            <h3 style={{ marginBottom: '16px' }}>Edit Model</h3>
+                                            <h3 style={{ marginBottom: '16px' }}>{t('enterprise.llm.editModel', 'Edit Model')}</h3>
                                             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
                                                 <div className="form-group">
                                                     <label className="form-label">{t('enterprise.llm.provider')}</label>
@@ -2307,7 +2307,7 @@ export default function EnterpriseSettings() {
                                                         transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
                                                     }} />
                                                 </button>
-                                                {m.supports_vision && <span className="badge" style={{ background: 'rgba(99,102,241,0.15)', color: 'rgb(99,102,241)', fontSize: '10px' }}>Vision</span>}
+                                                {m.supports_vision && <span className="badge" style={{ background: 'rgba(99,102,241,0.15)', color: 'rgb(99,102,241)', fontSize: '10px' }}>{t('enterprise.llm.vision', 'Vision')}</span>}
                                                 <button className="btn btn-ghost" onClick={() => {
                                                     setEditingModelId(m.id);
                                                     setModelForm({ provider: m.provider, model: m.model, label: m.label, base_url: m.base_url || '', api_key: m.api_key_masked || '', supports_vision: m.supports_vision || false, max_output_tokens: m.max_output_tokens ? String(m.max_output_tokens) : '', request_timeout: m.request_timeout ? String(m.request_timeout) : '', temperature: m.temperature !== null && m.temperature !== undefined ? String(m.temperature) : '' });

--- a/frontend/src/pages/OpenClawSettings.tsx
+++ b/frontend/src/pages/OpenClawSettings.tsx
@@ -142,8 +142,8 @@ export default function OpenClawSettings({ agent, agentId }: OpenClawSettingsPro
                                 <LinearCopyButton
                                     className="btn btn-secondary"
                                     textToCopy={activeKey}
-                                    label="Copy"
-                                    copiedLabel="Copied"
+                                    label={t('common.copy')}
+                                    copiedLabel={t('common.copied')}
                                     style={{ padding: '4px 12px', fontSize: '12px', whiteSpace: 'nowrap', minWidth: '70px', height: 'fit-content' }}
                                 />
                                 <button

--- a/frontend/src/pages/PlatformDashboard.tsx
+++ b/frontend/src/pages/PlatformDashboard.tsx
@@ -282,9 +282,9 @@ export default function PlatformDashboard() {
                 </div>
                 <div style={{ height: '280px', width: '100%' }}>
                     {loadingEnhanced ? (
-                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>Loading...</div>
+                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>{t('platformDashboard.loading')}</div>
                     ) : data.length === 0 ? (
-                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>No data</div>
+                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>{t('platformDashboard.noData')}</div>
                     ) : (
                         <ResponsiveContainer width="100%" height="100%">
                             <PieChart>
@@ -320,14 +320,14 @@ export default function PlatformDashboard() {
         return (
             <div className="card" style={{ flex: 1, minWidth: '300px', padding: '20px' }}>
                 <div style={{ fontSize: '13px', fontWeight: 600, marginBottom: '20px', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center' }}>
-                    Top 10 Tool Categories
-                    <InfoTooltip text="Most popular tool categories across all active agent configurations" />
+                    {t('platformDashboard.charts.toolCategories.title')}
+                    <InfoTooltip text={t('platformDashboard.charts.toolCategories.tooltip')} />
                 </div>
                 <div style={{ height: '280px', width: '100%' }}>
                     {loadingEnhanced ? (
-                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>Loading...</div>
+                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>{t('platformDashboard.loading')}</div>
                     ) : data.length === 0 ? (
-                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>No data</div>
+                        <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--text-tertiary)', fontSize: '12px' }}>{t('platformDashboard.noData')}</div>
                     ) : (
                         <ResponsiveContainer width="100%" height="100%">
                             <BarChart data={data} layout="vertical" margin={{ top: 5, right: 20, left: 60, bottom: 5 }}>
@@ -335,7 +335,7 @@ export default function PlatformDashboard() {
                                 <XAxis type="number" tick={{ fontSize: 10, fill: 'var(--text-tertiary)' }} tickLine={false} axisLine={false} />
                                 <YAxis dataKey="category" type="category" tick={{ fontSize: 11, fill: 'var(--text-secondary)' }} tickLine={false} axisLine={false} width={55} />
                                 <Tooltip content={<CustomTooltip />} />
-                                <Bar dataKey="count" name="Enabled" fill="#3b82f6" radius={[0, 4, 4, 0]} barSize={18} />
+                                <Bar dataKey="count" name={t('platformDashboard.charts.legend.enabled')} fill="#3b82f6" radius={[0, 4, 4, 0]} barSize={18} />
                             </BarChart>
                         </ResponsiveContainer>
                     )}
@@ -359,21 +359,21 @@ export default function PlatformDashboard() {
                     display: 'flex',
                     alignItems: 'center',
                 }}>
-                    Churn Warning
-                    <InfoTooltip text="Companies that consumed >10M tokens but have had no activity in the past 14 days" />
+                    {t('platformDashboard.churn.title')}
+                    <InfoTooltip text={t('platformDashboard.churn.tooltip')} />
                 </div>
                 {loadingEnhanced ? (
-                    <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>Loading...</div>
+                    <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('platformDashboard.loading')}</div>
                 ) : data.length === 0 ? (
-                    <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>No churn warnings — all active companies are healthy</div>
+                    <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('platformDashboard.churn.noWarnings')}</div>
                 ) : (
                     <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '13px' }}>
                         <thead>
                             <tr style={{ borderBottom: '1px solid var(--border-subtle)', color: 'var(--text-tertiary)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
-                                <th style={{ padding: '12px 20px', textAlign: 'left', fontWeight: 600 }}>Company</th>
-                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>Total Tokens</th>
-                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>Last Active</th>
-                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>Days Inactive</th>
+                                <th style={{ padding: '12px 20px', textAlign: 'left', fontWeight: 600 }}>{t('platformDashboard.churn.company')}</th>
+                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>{t('platformDashboard.churn.totalTokens')}</th>
+                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>{t('platformDashboard.churn.lastActive')}</th>
+                                <th style={{ padding: '12px 20px', textAlign: 'right', fontWeight: 600 }}>{t('platformDashboard.churn.daysInactive')}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -427,11 +427,11 @@ export default function PlatformDashboard() {
                 <InfoTooltip text={tooltip} />
             </div>
             {loadingLeaders ? (
-                <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>Loading...</div>
+                <div style={{ padding: '40px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('platformDashboard.loading')}</div>
             ) : (
                 <div>
                     {items.map((item, i) => renderItem(item, i))}
-                    {items.length === 0 && <div style={{ padding: '20px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>No data</div>}
+                    {items.length === 0 && <div style={{ padding: '20px', textAlign: 'center', fontSize: '12px', color: 'var(--text-tertiary)' }}>{t('platformDashboard.noData')}</div>}
                 </div>
             )}
         </div>
@@ -456,7 +456,7 @@ export default function PlatformDashboard() {
                                 border: 'none', cursor: 'pointer', transition: 'all 0.2s'
                             }}
                         >
-                            Last {d} Days
+                            {d === 7 ? t('platformDashboard.timeRange.last7Days') : t('platformDashboard.timeRange.last30Days')}
                         </button>
                     ))}
                 </div>
@@ -465,40 +465,40 @@ export default function PlatformDashboard() {
             {/* Summary Cards */}
             <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
                 <MetricCard
-                    label="Avg Tokens / Session"
+                    label={t('platformDashboard.metrics.avgTokensPerSession.label')}
                     value={enhanced ? formatTokens(enhanced.avg_tokens_per_session_30d) : '-'}
-                    tooltip="Average token consumption per chat session in the last 30 days. Calculated as total tokens / total sessions."
+                    tooltip={t('platformDashboard.metrics.avgTokensPerSession.tooltip')}
                 />
                 <MetricCard
-                    label="7-Day Retention"
+                    label={t('platformDashboard.metrics.retention7Day.label')}
                     value={enhanced ? `${enhanced.retention_rate_7d}%` : '-'}
-                    tooltip={`Percentage of established companies (>14 days old) that were active last week and remain active this week. ${enhanced ? `${enhanced.retained_companies} of ${enhanced.last_week_active_companies} companies retained.` : ''}`}
+                    tooltip={enhanced ? t('platformDashboard.metrics.retention7Day.tooltipWithCount', { retained: enhanced.retained_companies, total: enhanced.last_week_active_companies }) : t('platformDashboard.metrics.retention7Day.tooltip')}
                 />
             </div>
 
             {/* Existing Trend Charts */}
             <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
-                <ChartCard title="Companies" tooltip="Cumulative and daily new company registrations" dataKeyTotal="total_companies" dataKeyNew="new_companies" color="#3b82f6" />
-                <ChartCard title="Users" tooltip="Cumulative and daily new user registrations" dataKeyTotal="total_users" dataKeyNew="new_users" color="#10b981" />
-                <ChartCard title="Token Usage" tooltip="Cumulative and daily token consumption across all agents" dataKeyTotal="total_tokens" dataKeyNew="new_tokens" color="#8b5cf6" />
+                <ChartCard title={t('platformDashboard.charts.companies.title')} tooltip={t('platformDashboard.charts.companies.tooltip')} dataKeyTotal="total_companies" dataKeyNew="new_companies" color="#3b82f6" />
+                <ChartCard title={t('platformDashboard.charts.users.title')} tooltip={t('platformDashboard.charts.users.tooltip')} dataKeyTotal="total_users" dataKeyNew="new_users" color="#10b981" />
+                <ChartCard title={t('platformDashboard.charts.tokenUsage.title')} tooltip={t('platformDashboard.charts.tokenUsage.tooltip')} dataKeyTotal="total_tokens" dataKeyNew="new_tokens" color="#8b5cf6" />
             </div>
 
             {/* New Trend Charts: Sessions + Active Users */}
             <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
                 <ChartCard
-                    title="Daily Sessions"
-                    tooltip="Number of new chat sessions created per day and cumulative total"
+                    title={t('platformDashboard.charts.dailySessions.title')}
+                    tooltip={t('platformDashboard.charts.dailySessions.tooltip')}
                     dataKeyTotal="total_sessions"
                     dataKeyNew="new_sessions"
                     color="#f59e0b"
                 />
                 <MultiLineChart
-                    title="Active Users"
-                    tooltip="DAU: distinct users who sent at least 1 message that day. WAU: distinct users active in a rolling 7-day window. MAU: distinct users active in a rolling 30-day window."
+                    title={t('platformDashboard.charts.activeUsers.title')}
+                    tooltip={t('platformDashboard.charts.activeUsers.tooltip')}
                     lines={[
-                        { key: 'dau', name: 'DAU', color: '#10b981' },
-                        { key: 'wau', name: 'WAU', color: '#3b82f6' },
-                        { key: 'mau', name: 'MAU', color: '#8b5cf6' },
+                        { key: 'dau', name: t('platformDashboard.charts.legend.dau'), color: '#10b981' },
+                        { key: 'wau', name: t('platformDashboard.charts.legend.wau'), color: '#3b82f6' },
+                        { key: 'mau', name: t('platformDashboard.charts.legend.mau'), color: '#8b5cf6' },
                     ]}
                 />
             </div>
@@ -512,8 +512,8 @@ export default function PlatformDashboard() {
             {/* Leaderboards */}
             <div style={{ display: 'flex', gap: '20px', flexWrap: 'wrap' }}>
                 <LeaderboardCard
-                    title="Top 20 Companies by Tokens"
-                    tooltip="Companies ranked by total cumulative token consumption across all their agents"
+                    title={t('platformDashboard.leaderboards.topCompanies.title')}
+                    tooltip={t('platformDashboard.leaderboards.topCompanies.tooltip')}
                     items={topCompanies}
                     renderItem={(c, i) => (
                         <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '12px 20px', borderBottom: '1px solid var(--border-subtle)', fontSize: '13px' }}>
@@ -528,8 +528,8 @@ export default function PlatformDashboard() {
                     )}
                 />
                 <LeaderboardCard
-                    title="Top 20 Agents by Tokens"
-                    tooltip="Individual agents ranked by total cumulative token consumption"
+                    title={t('platformDashboard.leaderboards.topAgents.title')}
+                    tooltip={t('platformDashboard.leaderboards.topAgents.tooltip')}
                     items={topAgents}
                     renderItem={(a, i) => (
                         <div key={i} style={{ display: 'flex', justifyContent: 'space-between', padding: '12px 20px', borderBottom: '1px solid var(--border-subtle)', fontSize: '13px' }}>

--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -165,24 +165,27 @@ export default function UserManagement() {
     };
 
     const periodLabel = (period: string) => {
-        if (isChinese) {
-            const map: Record<string, string> = { permanent: '永久', daily: '每天', weekly: '每周', monthly: '每月' };
-            return map[period] || period;
-        }
-        return PERIOD_OPTIONS.find(p => p.value === period)?.label || period;
+        const periodMap: Record<string, string> = {
+            permanent: t('enterprise.users.permanent', 'Permanent'),
+            daily: t('enterprise.users.daily', 'Daily'),
+            weekly: t('enterprise.users.weekly', 'Weekly'),
+            monthly: t('enterprise.users.monthly', 'Monthly')
+        };
+        return periodMap[period] || period;
     };
 
     // Role label & styling helpers
     const roleBadge = (role: string) => {
-        const styles: Record<string, { bg: string; color: string; label: string; labelZh: string }> = {
-            platform_admin: { bg: 'rgba(239,68,68,0.12)', color: '#ef4444', label: 'Platform Admin', labelZh: 'Platform Admin' },
-            org_admin:      { bg: 'rgba(168,85,247,0.12)', color: '#a855f7', label: 'Admin', labelZh: 'Admin' },
+        const styles: Record<string, { bg: string; color: string; labelKey: string }> = {
+            platform_admin: { bg: 'rgba(239,68,68,0.12)', color: '#ef4444', labelKey: 'enterprise.users.platformAdmin' },
+            org_admin:      { bg: 'rgba(168,85,247,0.12)', color: '#a855f7', labelKey: 'enterprise.users.orgAdmin' },
         };
         const s = styles[role];
         if (!s) return null;
+        const labelText = t(s.labelKey, role === 'platform_admin' ? 'Platform Admin' : 'Admin');
         return (
             <span style={{ marginLeft: '6px', fontSize: '10px', background: s.bg, color: s.color, borderRadius: '4px', padding: '1px 6px', fontWeight: 500 }}>
-                {isChinese ? s.labelZh : s.label}
+                {labelText}
             </span>
         );
     };
@@ -274,21 +277,21 @@ export default function UserManagement() {
                         gap: '10px', padding: '10px 16px', fontSize: '11px', fontWeight: 600,
                         color: 'var(--text-tertiary)', textTransform: 'uppercase', letterSpacing: '0.05em',
                     }}>
-                        <div>{t('enterprise.users.user', isChinese ? '用户' : 'User')}</div>
+                        <div>{t('enterprise.users.user', 'User')}</div>
                         <div>{t('enterprise.users.email', 'Email')}</div>
                         {/* Created At with sort toggle */}
                         <div
                             style={{ cursor: 'pointer', userSelect: 'none', display: 'flex', alignItems: 'center', gap: '3px' }}
                             onClick={toggleSort}
-                            title={isChinese ? '点击切换排序' : 'Click to toggle sort order'}
+                            title={t('enterprise.users.clickToSort', 'Click to toggle sort order')}
                         >
-                            {isChinese ? '注册时间' : 'Joined'} {sortOrder === 'asc' ? '↑' : '↓'}
+                            {t('enterprise.users.joined', 'Joined')} {sortOrder === 'asc' ? '↑' : '↓'}
                         </div>
-                        <div>{isChinese ? '角色' : 'Role'}</div>
-                        <div>{isChinese ? '来源' : 'Source'}</div>
-                        <div>{t('enterprise.users.msgQuota', isChinese ? '消息配额' : 'Msg Quota')}</div>
-                        <div>{t('enterprise.users.period', isChinese ? '周期' : 'Period')}</div>
-                        <div>{t('enterprise.users.agents', isChinese ? '数字员工' : 'Agents')}</div>
+                        <div>{t('enterprise.users.role', 'Role')}</div>
+                        <div>{t('enterprise.users.source', 'Source')}</div>
+                        <div>{t('enterprise.users.msgQuota', 'Msg Quota')}</div>
+                        <div>{t('enterprise.users.period', 'Period')}</div>
+                        <div>{t('enterprise.users.agents', 'Agents')}</div>
                         <div>{t('enterprise.users.ttl', 'TTL')}</div>
                         <div></div>
                     </div>
@@ -329,7 +332,7 @@ export default function UserManagement() {
                                         </select>
                                     ) : (
                                         <span style={{ fontSize: '11px', color: 'var(--text-secondary)' }}>
-                                            {user.role === 'platform_admin' ? 'Platform Admin'
+                                            {user.role === 'platform_admin' ? t('enterprise.users.platformAdmin', 'Platform Admin')
                                                 : user.role === 'org_admin' ? 'Admin' : 'Member'}
                                         </span>
                                     )}
@@ -337,11 +340,11 @@ export default function UserManagement() {
                                 <div>
                                     {user.source === 'feishu' ? (
                                         <span style={{ fontSize: '10px', background: 'rgba(58,132,255,0.12)', color: '#3a84ff', borderRadius: '4px', padding: '2px 7px', whiteSpace: 'nowrap' }}>
-                                            飞书
+                                            {t('common.channels.feishu', 'Feishu')}
                                         </span>
                                     ) : (
                                         <span style={{ fontSize: '10px', background: 'rgba(0,180,120,0.12)', color: 'var(--success)', borderRadius: '4px', padding: '2px 7px', whiteSpace: 'nowrap' }}>
-                                            {isChinese ? '注册' : 'Reg'}
+                                            {t('enterprise.users.registered', 'Reg')}
                                         </span>
                                     )}
                                 </div>


### PR DESCRIPTION
## Summary
- extract low-risk hardcoded frontend copy into existing i18n keys
- keep the scope to page text only, without carrying over the larger UI/style changes from #284
- reuse translation keys already present on main for admin, enterprise, common, and dashboard screens

## Included
- copy/copy-success labels in channel, enterprise SSO, and OpenClaw pages
- upload label in file browser
- translated admin and user management labels that were still hardcoded
- platform dashboard labels/tooltips/loading states moved to i18n lookups

## Not included
- template/skill mapping changes from #284
- broader layout or visual style adjustments
- other unrelated i18n reshuffling from #284

## Validation
- Reviewed diff to keep only the frontend hardcoded-copy extraction
- Could not run frontend build in this environment because  is not installed