### PR TITLE
fix: strip orphaned tool_result messages after conversation truncation

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -515,10 +515,15 @@ async def websocket_chat(
                         async def _on_failover(reason: str):
                             await websocket.send_json({"type": "info", "content": f"Primary model error, {reason}"})
 
+                        # To prevent tool call message pairs(assistant + tool) from being broken down.
+                        _truncated = conversation[-ctx_size:]
+                        while _truncated and _truncated[0].get("role") == "tool":
+                            _truncated.pop(0)
+
                         return await call_llm_with_failover(
                             primary_model=llm_model,
                             fallback_model=fallback_llm_model,
-                            messages=conversation[-ctx_size:],
+                            messages=_truncated,
                             agent_name=agent_name,
                             role_description=role_description,
                             agent_id=agent_id,


### PR DESCRIPTION
## Summary
- Fix HTTP 400 errors caused by orphaned `tool_result` blocks in the conversation history sent to the Anthropic API.
- After truncating the conversation to `ctx_size`, strip any leading `role="tool"` messages whose corresponding `assistant` (tool_use) message was cut off by the truncation boundary.

Closes #415 

## Root Cause
Each `tool_call` DB record expands into 2 messages (assistant + tool) during history reconstruction, so `conversation[-ctx_size:]` can split a pair — keeping the tool result but dropping the tool use. The Anthropic API requires every `tool_result` to have a matching `tool_use` in the preceding assistant message.

## Test plan
- [ ] Reproduce with a session containing ~50 tool-call rounds and `context_window_size = 100`
- [ ] Verify the LLM call succeeds after the fix
- [ ] Verify normal sessions without tool calls are unaffected