### PR TITLE
feat: add AWS Bedrock provider support

### DIFF
--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -237,7 +237,9 @@ async def update_llm_model(
             model.label = data.label
         if hasattr(data, 'base_url') and data.base_url is not None:
             model.base_url = data.base_url
-        if data.api_key and data.api_key.strip() and not data.api_key.startswith('****'):  # Skip masked values
+        if data.clear_api_key is True:
+            model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
+        elif data.api_key and data.api_key.strip() and not data.api_key.startswith('****'):  # Skip masked values
             model.api_key_encrypted = encrypt_data(data.api_key.strip(), settings.SECRET_KEY)
         if data.temperature is not None:
             model.temperature = data.temperature

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -85,9 +85,10 @@ async def test_llm_model(
     """Test an LLM model configuration by making a simple API call."""
     import time
 
-    # Resolve API key: use provided key, or look up from stored model
+    # Resolve API key: use provided key, and only fall back to stored model key
+    # for non-Bedrock tests.
     api_key = data.api_key if data.api_key and not data.api_key.startswith('****') else None
-    if not api_key and data.model_id:
+    if not api_key and data.model_id and data.provider != "bedrock":
         result = await db.execute(select(LLMModel).where(LLMModel.id == data.model_id))
         existing = result.scalar_one_or_none()
         if existing:

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -85,10 +85,12 @@ async def test_llm_model(
     """Test an LLM model configuration by making a simple API call."""
     import time
 
-    # Resolve API key: use provided key, and only fall back to stored model key
-    # for non-Bedrock tests.
-    api_key = data.api_key if data.api_key and not data.api_key.startswith('****') else None
-    if not api_key and data.model_id and data.provider != "bedrock":
+    # Resolve API key: use provided key, or fall back to stored model key.
+    # For Bedrock, only reuse stored key when request carries a masked value
+    # (edit mode unchanged credentials). A blank key should use AWS default chain.
+    is_masked_api_key = bool(data.api_key and data.api_key.startswith('****'))
+    api_key = data.api_key if data.api_key and not is_masked_api_key else None
+    if not api_key and data.model_id and (data.provider != "bedrock" or is_masked_api_key):
         result = await db.execute(select(LLMModel).where(LLMModel.id == data.model_id))
         existing = result.scalar_one_or_none()
         if existing:

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -92,7 +92,7 @@ async def test_llm_model(
         existing = result.scalar_one_or_none()
         if existing:
             api_key = get_model_api_key(existing)
-    if not api_key:
+    if not api_key and data.provider != "bedrock":
         return {"success": False, "latency_ms": 0, "error": "API Key is required"}
 
     start = time.time()

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -228,6 +228,8 @@ async def update_llm_model(
     if not model:
         raise HTTPException(status_code=404, detail="Model not found")
 
+    previous_provider = model.provider
+
     try:
         if data.provider:
             model.provider = data.provider
@@ -238,6 +240,10 @@ async def update_llm_model(
         if hasattr(data, 'base_url') and data.base_url is not None:
             model.base_url = data.base_url
         if data.clear_api_key is True:
+            model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
+        elif previous_provider != "bedrock" and model.provider == "bedrock":
+            # Switching to Bedrock without new credentials should not retain
+            # old non-Bedrock provider keys, which are incompatible JSON-wise.
             model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
         elif data.api_key and data.api_key.strip() and not data.api_key.startswith('****'):  # Skip masked values
             model.api_key_encrypted = encrypt_data(data.api_key.strip(), settings.SECRET_KEY)

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -251,6 +251,10 @@ async def update_llm_model(
             # Switching to Bedrock without new credentials should not retain
             # old non-Bedrock provider keys, which are incompatible JSON-wise.
             model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
+        elif previous_provider == "bedrock" and model.provider != "bedrock" and not has_new_api_key:
+            # Switching away from Bedrock without replacing credentials should
+            # clear stored Bedrock JSON to avoid persisting incompatible keys.
+            model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
         elif has_new_api_key:  # Skip masked values
             model.api_key_encrypted = encrypt_data(data.api_key.strip(), settings.SECRET_KEY)
         if data.temperature is not None:

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -231,6 +231,12 @@ async def update_llm_model(
     previous_provider = model.provider
 
     try:
+        has_new_api_key = bool(
+            data.api_key
+            and data.api_key.strip()
+            and not data.api_key.startswith('****')
+        )
+
         if data.provider:
             model.provider = data.provider
         if data.model:
@@ -241,11 +247,11 @@ async def update_llm_model(
             model.base_url = data.base_url
         if data.clear_api_key is True:
             model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
-        elif previous_provider != "bedrock" and model.provider == "bedrock":
+        elif previous_provider != "bedrock" and model.provider == "bedrock" and not has_new_api_key:
             # Switching to Bedrock without new credentials should not retain
             # old non-Bedrock provider keys, which are incompatible JSON-wise.
             model.api_key_encrypted = encrypt_data("", settings.SECRET_KEY)
-        elif data.api_key and data.api_key.strip() and not data.api_key.startswith('****'):  # Skip masked values
+        elif has_new_api_key:  # Skip masked values
             model.api_key_encrypted = encrypt_data(data.api_key.strip(), settings.SECRET_KEY)
         if data.temperature is not None:
             model.temperature = data.temperature

--- a/backend/app/api/wecom.py
+++ b/backend/app/api/wecom.py
@@ -32,7 +32,7 @@ from app.models.channel_config import ChannelConfig
 from app.models.identity import IdentityProvider, SSOScanSession
 from app.models.user import User
 from app.services.activity_logger import log_activity
-from app.services.auth_provider import auth_provider_registry
+from app.services.auth_registry import auth_provider_registry
 from app.services.channel_session import find_or_create_channel_session
 from app.services.channel_user_service import channel_user_service
 from app.services.platform_service import platform_service

--- a/backend/app/api/wecom.py
+++ b/backend/app/api/wecom.py
@@ -686,7 +686,13 @@ async def wecom_callback(
 
     # 2. Extract user info and login/register via RegistrationService
     try:
-        auth_provider = auth_provider_registry.get_provider(provider)
+        auth_provider = await auth_provider_registry.get_provider(
+            db,
+            "wecom",
+            str(tenant_id) if tenant_id else (str(provider.tenant_id) if provider.tenant_id else None),
+        )
+        if not auth_provider:
+            return HTMLResponse("Auth failed: WeCom provider unavailable")
         
         token_data = await auth_provider.exchange_code_for_token(code)
         access_token_str = token_data.get("access_token")

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -386,6 +386,7 @@ class LLMModelUpdate(BaseModel):
     provider: str | None = None
     model: str | None = None
     api_key: str | None = None
+    clear_api_key: bool | None = None
     base_url: str | None = None
     label: str | None = None
     temperature: float | None = Field(None, ge=0.0, le=2.0)

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -2062,6 +2062,25 @@ class BedrockClient(LLMClient):
                 if event is _SENTINEL:
                     break
 
+                stream_error_key = next(
+                    (
+                        key
+                        for key in (
+                            "internalServerException",
+                            "modelStreamErrorException",
+                            "validationException",
+                            "throttlingException",
+                            "serviceUnavailableException",
+                        )
+                        if key in event
+                    ),
+                    None,
+                )
+                if stream_error_key:
+                    details = event.get(stream_error_key) or {}
+                    message = details.get("message") or details.get("originalMessage") or str(details)
+                    raise LLMError(f"Bedrock stream error ({stream_error_key}): {message}")
+
                 if "contentBlockStart" in event:
                     start = event["contentBlockStart"].get("start", {})
                     if "toolUse" in start:

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -1972,7 +1972,7 @@ class BedrockClient(LLMClient):
                 })
 
         stop_reason = response.get("stopReason", "")
-        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+        finish_reason = self._map_bedrock_finish_reason(stop_reason)
 
         usage = None
         usage_raw = response.get("usage")
@@ -1990,6 +1990,15 @@ class BedrockClient(LLMClient):
             usage=usage,
             model=self.model,
         )
+
+    @staticmethod
+    def _map_bedrock_finish_reason(stop_reason: str | None) -> str:
+        """Map Bedrock stop reasons to unified finish reasons."""
+        if stop_reason == "tool_use":
+            return "tool_calls"
+        if stop_reason:
+            return stop_reason
+        return "stop"
 
     async def complete(
         self,
@@ -2146,7 +2155,7 @@ class BedrockClient(LLMClient):
                 except Exception:
                     pass
 
-        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+        finish_reason = self._map_bedrock_finish_reason(stop_reason)
 
         return LLMResponse(
             content=full_content,

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -2005,13 +2005,28 @@ class BedrockClient(LLMClient):
         if stream_body is None:
             raise LLMError("Bedrock ConverseStream returned no stream body")
 
-        # Iterate stream events (sync iterator, wrap each next() call)
-        def _iter_events():
-            return list(stream_body)
+        # Process stream events incrementally via an asyncio.Queue so that
+        # on_chunk callbacks fire as each token arrives rather than after
+        # the entire response has been buffered.
+        _SENTINEL = object()
+        queue: asyncio.Queue = asyncio.Queue()
 
-        events = await asyncio.to_thread(_iter_events)
+        def _producer():
+            """Read the sync Bedrock iterator and push events into the queue."""
+            try:
+                for event in stream_body:
+                    queue.put_nowait(event)
+            finally:
+                queue.put_nowait(_SENTINEL)
 
-        for event in events:
+        # Start the blocking iterator in a background thread
+        producer_task = asyncio.get_event_loop().run_in_executor(None, _producer)
+
+        while True:
+            event = await queue.get()
+            if event is _SENTINEL:
+                break
+
             if "contentBlockStart" in event:
                 start = event["contentBlockStart"].get("start", {})
                 if "toolUse" in start:
@@ -2054,6 +2069,9 @@ class BedrockClient(LLMClient):
                         "output_tokens": usage_raw.get("outputTokens", 0),
                         "total_tokens": usage_raw.get("inputTokens", 0) + usage_raw.get("outputTokens", 0),
                     }
+
+        # Ensure the producer thread has finished
+        await producer_task
 
         finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
 

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -2033,56 +2033,62 @@ class BedrockClient(LLMClient):
         # Start the blocking iterator in a background thread
         producer_task = loop.run_in_executor(None, _producer)
 
-        while True:
-            event = await queue.get()
-            if event is _SENTINEL:
-                break
+        try:
+            while True:
+                event = await queue.get()
+                if event is _SENTINEL:
+                    break
 
-            if "contentBlockStart" in event:
-                start = event["contentBlockStart"].get("start", {})
-                if "toolUse" in start:
-                    tu = start["toolUse"]
-                    current_tool = {
-                        "id": tu.get("toolUseId", ""),
-                        "type": "function",
-                        "function": {
-                            "name": tu.get("name", ""),
-                            "arguments": "",
-                        },
-                    }
-                    current_tool_args = ""
+                if "contentBlockStart" in event:
+                    start = event["contentBlockStart"].get("start", {})
+                    if "toolUse" in start:
+                        tu = start["toolUse"]
+                        current_tool = {
+                            "id": tu.get("toolUseId", ""),
+                            "type": "function",
+                            "function": {
+                                "name": tu.get("name", ""),
+                                "arguments": "",
+                            },
+                        }
+                        current_tool_args = ""
 
-            elif "contentBlockDelta" in event:
-                delta = event["contentBlockDelta"].get("delta", {})
-                if "text" in delta:
-                    text = delta["text"]
-                    full_content += text
-                    if on_chunk:
-                        await on_chunk(text)
-                elif "toolUse" in delta:
-                    current_tool_args += delta["toolUse"].get("input", "")
+                elif "contentBlockDelta" in event:
+                    delta = event["contentBlockDelta"].get("delta", {})
+                    if "text" in delta:
+                        text = delta["text"]
+                        full_content += text
+                        if on_chunk:
+                            await on_chunk(text)
+                    elif "toolUse" in delta:
+                        current_tool_args += delta["toolUse"].get("input", "")
 
-            elif "contentBlockStop" in event:
-                if current_tool is not None:
-                    current_tool["function"]["arguments"] = current_tool_args
-                    tool_calls.append(current_tool)
-                    current_tool = None
-                    current_tool_args = ""
+                elif "contentBlockStop" in event:
+                    if current_tool is not None:
+                        current_tool["function"]["arguments"] = current_tool_args
+                        tool_calls.append(current_tool)
+                        current_tool = None
+                        current_tool_args = ""
 
-            elif "messageStop" in event:
-                stop_reason = event["messageStop"].get("stopReason")
+                elif "messageStop" in event:
+                    stop_reason = event["messageStop"].get("stopReason")
 
-            elif "metadata" in event:
-                usage_raw = event["metadata"].get("usage")
-                if isinstance(usage_raw, dict):
-                    final_usage = {
-                        "input_tokens": usage_raw.get("inputTokens", 0),
-                        "output_tokens": usage_raw.get("outputTokens", 0),
-                        "total_tokens": usage_raw.get("inputTokens", 0) + usage_raw.get("outputTokens", 0),
-                    }
+                elif "metadata" in event:
+                    usage_raw = event["metadata"].get("usage")
+                    if isinstance(usage_raw, dict):
+                        final_usage = {
+                            "input_tokens": usage_raw.get("inputTokens", 0),
+                            "output_tokens": usage_raw.get("outputTokens", 0),
+                            "total_tokens": usage_raw.get("inputTokens", 0) + usage_raw.get("outputTokens", 0),
+                        }
 
-        # Ensure the producer thread has finished
-        await producer_task
+        finally:
+            # Ensure the producer thread finishes even if on_chunk raised
+            try:
+                stream_body.close()
+            except Exception:
+                pass
+            await producer_task
 
         finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
 
@@ -2126,9 +2132,11 @@ class BedrockClient(LLMClient):
         return params
 
     async def close(self) -> None:
-        """Close the boto3 client."""
-        # boto3 clients don't require explicit closing
-        pass
+        """Close the boto3 client and release connection pool resources."""
+        try:
+            self._boto_client.close()
+        except Exception:
+            pass
 
 
 # ============================================================================

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -1727,6 +1727,7 @@ class BedrockClient(LLMClient):
     def _create_boto_client(self) -> Any:
         """Create boto3 bedrock-runtime client from packed credentials."""
         import boto3
+        from botocore.config import Config
 
         kwargs: dict[str, Any] = {}
 
@@ -1744,6 +1745,12 @@ class BedrockClient(LLMClient):
         if self.base_url:
             kwargs["endpoint_url"] = self.base_url
 
+        # Honor configured timeout
+        kwargs["config"] = Config(
+            read_timeout=self.timeout,
+            connect_timeout=min(self.timeout, 10.0),
+        )
+
         return boto3.client("bedrock-runtime", **kwargs)
 
     def _parse_credentials(self) -> dict[str, str]:
@@ -1754,8 +1761,11 @@ class BedrockClient(LLMClient):
             creds = json.loads(self.api_key)
             if isinstance(creds, dict):
                 return creds
-        except (json.JSONDecodeError, TypeError):
-            pass
+        except (json.JSONDecodeError, TypeError) as exc:
+            logger.warning(
+                "Bedrock api_key contains non-JSON value; "
+                "falling back to default AWS credentials: %s", exc
+            )
         return {}
 
     def _get_headers(self) -> dict[str, str]:
@@ -2010,17 +2020,18 @@ class BedrockClient(LLMClient):
         # the entire response has been buffered.
         _SENTINEL = object()
         queue: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_event_loop()
 
         def _producer():
             """Read the sync Bedrock iterator and push events into the queue."""
             try:
                 for event in stream_body:
-                    queue.put_nowait(event)
+                    loop.call_soon_threadsafe(queue.put_nowait, event)
             finally:
-                queue.put_nowait(_SENTINEL)
+                loop.call_soon_threadsafe(queue.put_nowait, _SENTINEL)
 
         # Start the blocking iterator in a background thread
-        producer_task = asyncio.get_event_loop().run_in_executor(None, _producer)
+        producer_task = loop.run_in_executor(None, _producer)
 
         while True:
             event = await queue.get()

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -1699,6 +1699,409 @@ class AnthropicClient(LLMClient):
         if self._client and not self._client.is_closed:
             await self._client.aclose()
 
+
+# ============================================================================
+# AWS Bedrock Client (Converse API)
+# ============================================================================
+
+class BedrockClient(LLMClient):
+    """Client for AWS Bedrock Converse API.
+
+    Supports Claude, Llama, Mistral, and other Bedrock-hosted models.
+    AWS credentials are packed as JSON in the api_key parameter:
+        {"access_key": "...", "secret_key": "...", "region": "us-east-1"}
+    If empty or {}, falls back to boto3 default credential chain (IAM role, env vars).
+    The base_url parameter can be used for VPC endpoint overrides.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str | None = None,
+        model: str | None = None,
+        timeout: float = 120.0,
+    ):
+        super().__init__(api_key, base_url, model, timeout)
+        self._boto_client = self._create_boto_client()
+
+    def _create_boto_client(self) -> Any:
+        """Create boto3 bedrock-runtime client from packed credentials."""
+        import boto3
+
+        kwargs: dict[str, Any] = {}
+
+        # Parse JSON-packed credentials
+        creds = self._parse_credentials()
+        if creds.get("access_key") and creds.get("secret_key"):
+            kwargs["aws_access_key_id"] = creds["access_key"]
+            kwargs["aws_secret_access_key"] = creds["secret_key"]
+            if creds.get("session_token"):
+                kwargs["aws_session_token"] = creds["session_token"]
+        if creds.get("region"):
+            kwargs["region_name"] = creds["region"]
+
+        # VPC endpoint override via base_url
+        if self.base_url:
+            kwargs["endpoint_url"] = self.base_url
+
+        return boto3.client("bedrock-runtime", **kwargs)
+
+    def _parse_credentials(self) -> dict[str, str]:
+        """Parse AWS credentials from JSON-packed api_key."""
+        if not self.api_key or not self.api_key.strip():
+            return {}
+        try:
+            creds = json.loads(self.api_key)
+            if isinstance(creds, dict):
+                return creds
+        except (json.JSONDecodeError, TypeError):
+            pass
+        return {}
+
+    def _get_headers(self) -> dict[str, str]:
+        """Not used — boto3 handles auth internally."""
+        return {}
+
+    # -- Message conversion helpers --
+
+    def _messages_to_bedrock(
+        self, messages: list[LLMMessage]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Convert LLMMessage list to Bedrock Converse format.
+
+        Returns (system_prompts, bedrock_messages).
+        """
+        system_prompts: list[dict[str, Any]] = []
+        bedrock_messages: list[dict[str, Any]] = []
+
+        for msg in messages:
+            if msg.role == "system":
+                text = msg.content or ""
+                if isinstance(text, list):
+                    text = "\n".join(
+                        p.get("text", "") for p in text if isinstance(p, dict) and p.get("type") == "text"
+                    )
+                if msg.dynamic_content:
+                    text = f"{text}\n\n{msg.dynamic_content}"
+                if text:
+                    system_prompts.append({"text": text})
+                continue
+
+            if msg.role == "user":
+                content_blocks = self._content_to_bedrock_blocks(msg.content)
+                if content_blocks:
+                    bedrock_messages.append({"role": "user", "content": content_blocks})
+                continue
+
+            if msg.role == "assistant":
+                content_blocks = self._content_to_bedrock_blocks(msg.content)
+                if msg.tool_calls:
+                    for tc in msg.tool_calls:
+                        fn = tc.get("function", {})
+                        args_raw = fn.get("arguments", "{}")
+                        if isinstance(args_raw, str):
+                            try:
+                                args_parsed = json.loads(args_raw)
+                            except json.JSONDecodeError:
+                                args_parsed = {}
+                        elif isinstance(args_raw, dict):
+                            args_parsed = args_raw
+                        else:
+                            args_parsed = {}
+                        content_blocks.append({
+                            "toolUse": {
+                                "toolUseId": tc.get("id", ""),
+                                "name": fn.get("name", ""),
+                                "input": args_parsed,
+                            }
+                        })
+                if content_blocks:
+                    bedrock_messages.append({"role": "assistant", "content": content_blocks})
+                continue
+
+            if msg.role == "tool":
+                result_content: list[dict[str, Any]] = []
+                if isinstance(msg.content, list):
+                    for part in msg.content:
+                        if isinstance(part, dict) and part.get("type") == "text":
+                            result_content.append({"text": part.get("text", "")})
+                        elif isinstance(part, dict) and part.get("type") == "image_url":
+                            img_block = self._image_url_to_bedrock(part)
+                            if img_block:
+                                result_content.append(img_block)
+                else:
+                    result_content.append({"text": msg.content or ""})
+
+                bedrock_messages.append({
+                    "role": "user",
+                    "content": [{
+                        "toolResult": {
+                            "toolUseId": msg.tool_call_id or "",
+                            "content": result_content,
+                        }
+                    }],
+                })
+
+        return system_prompts, bedrock_messages
+
+    def _content_to_bedrock_blocks(self, content: str | list | None) -> list[dict[str, Any]]:
+        """Convert message content to Bedrock content blocks."""
+        if content is None:
+            return []
+        if isinstance(content, str):
+            return [{"text": content}] if content else []
+        if isinstance(content, list):
+            blocks: list[dict[str, Any]] = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                ptype = part.get("type")
+                if ptype == "text":
+                    text = part.get("text", "")
+                    if text:
+                        blocks.append({"text": text})
+                elif ptype == "image_url":
+                    img_block = self._image_url_to_bedrock(part)
+                    if img_block:
+                        blocks.append(img_block)
+            return blocks
+        return [{"text": str(content)}]
+
+    def _image_url_to_bedrock(self, part: dict[str, Any]) -> dict[str, Any] | None:
+        """Convert an OpenAI image_url content part to Bedrock image block."""
+        img_url = part.get("image_url", {}).get("url", "")
+        if not img_url.startswith("data:image/"):
+            return None
+        try:
+            header, b64_data = img_url.split(",", 1)
+            media_type = header.split(":")[1].split(";")[0]  # e.g. image/jpeg
+            # Bedrock format mapping
+            format_map = {
+                "image/jpeg": "jpeg",
+                "image/png": "png",
+                "image/gif": "gif",
+                "image/webp": "webp",
+            }
+            fmt = format_map.get(media_type, "jpeg")
+            import base64
+            return {
+                "image": {
+                    "format": fmt,
+                    "source": {"bytes": base64.b64decode(b64_data)},
+                }
+            }
+        except (ValueError, IndexError):
+            return None
+
+    def _convert_tools(self, tools: list[dict] | None) -> dict[str, Any] | None:
+        """Convert OpenAI-style tools to Bedrock toolConfig."""
+        if not tools:
+            return None
+        tool_list: list[dict[str, Any]] = []
+        for tool in tools:
+            if tool.get("type") != "function":
+                continue
+            fn = tool.get("function", {})
+            spec: dict[str, Any] = {
+                "name": fn.get("name", ""),
+                "description": fn.get("description", ""),
+                "inputSchema": {
+                    "json": fn.get("parameters", {"type": "object"}),
+                },
+            }
+            tool_list.append({"toolSpec": spec})
+        if not tool_list:
+            return None
+        return {"tools": tool_list}
+
+    def _parse_bedrock_response(self, response: dict[str, Any]) -> LLMResponse:
+        """Parse Bedrock Converse response into LLMResponse."""
+        output = response.get("output", {})
+        message = output.get("message", {})
+        content_blocks = message.get("content", [])
+
+        text_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+
+        for block in content_blocks:
+            if "text" in block:
+                text_parts.append(block["text"])
+            elif "toolUse" in block:
+                tu = block["toolUse"]
+                args = tu.get("input", {})
+                tool_calls.append({
+                    "id": tu.get("toolUseId", ""),
+                    "type": "function",
+                    "function": {
+                        "name": tu.get("name", ""),
+                        "arguments": json.dumps(args, ensure_ascii=False) if isinstance(args, dict) else str(args),
+                    },
+                })
+
+        stop_reason = response.get("stopReason", "")
+        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+
+        usage = None
+        usage_raw = response.get("usage")
+        if isinstance(usage_raw, dict):
+            usage = {
+                "input_tokens": usage_raw.get("inputTokens", 0),
+                "output_tokens": usage_raw.get("outputTokens", 0),
+                "total_tokens": usage_raw.get("inputTokens", 0) + usage_raw.get("outputTokens", 0),
+            }
+
+        return LLMResponse(
+            content="".join(text_parts),
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            usage=usage,
+            model=self.model,
+        )
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Non-streaming completion via Bedrock Converse API."""
+        params = self._build_converse_params(messages, tools, temperature, max_tokens)
+
+        try:
+            response = await asyncio.to_thread(self._boto_client.converse, **params)
+        except Exception as e:
+            raise LLMError(f"Bedrock Converse error: {e}")
+
+        return self._parse_bedrock_response(response)
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        on_chunk: ChunkCallback | None = None,
+        on_thinking: ThinkingCallback | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        """Streaming completion via Bedrock ConverseStream API."""
+        params = self._build_converse_params(messages, tools, temperature, max_tokens)
+
+        try:
+            response = await asyncio.to_thread(self._boto_client.converse_stream, **params)
+        except Exception as e:
+            raise LLMError(f"Bedrock ConverseStream error: {e}")
+
+        full_content = ""
+        tool_calls: list[dict[str, Any]] = []
+        current_tool: dict[str, Any] | None = None
+        current_tool_args = ""
+        final_usage: dict[str, int] | None = None
+        stop_reason: str | None = None
+
+        stream_body = response.get("stream")
+        if stream_body is None:
+            raise LLMError("Bedrock ConverseStream returned no stream body")
+
+        # Iterate stream events (sync iterator, wrap each next() call)
+        def _iter_events():
+            return list(stream_body)
+
+        events = await asyncio.to_thread(_iter_events)
+
+        for event in events:
+            if "contentBlockStart" in event:
+                start = event["contentBlockStart"].get("start", {})
+                if "toolUse" in start:
+                    tu = start["toolUse"]
+                    current_tool = {
+                        "id": tu.get("toolUseId", ""),
+                        "type": "function",
+                        "function": {
+                            "name": tu.get("name", ""),
+                            "arguments": "",
+                        },
+                    }
+                    current_tool_args = ""
+
+            elif "contentBlockDelta" in event:
+                delta = event["contentBlockDelta"].get("delta", {})
+                if "text" in delta:
+                    text = delta["text"]
+                    full_content += text
+                    if on_chunk:
+                        await on_chunk(text)
+                elif "toolUse" in delta:
+                    current_tool_args += delta["toolUse"].get("input", "")
+
+            elif "contentBlockStop" in event:
+                if current_tool is not None:
+                    current_tool["function"]["arguments"] = current_tool_args
+                    tool_calls.append(current_tool)
+                    current_tool = None
+                    current_tool_args = ""
+
+            elif "messageStop" in event:
+                stop_reason = event["messageStop"].get("stopReason")
+
+            elif "metadata" in event:
+                usage_raw = event["metadata"].get("usage")
+                if isinstance(usage_raw, dict):
+                    final_usage = {
+                        "input_tokens": usage_raw.get("inputTokens", 0),
+                        "output_tokens": usage_raw.get("outputTokens", 0),
+                        "total_tokens": usage_raw.get("inputTokens", 0) + usage_raw.get("outputTokens", 0),
+                    }
+
+        finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
+
+        return LLMResponse(
+            content=full_content,
+            tool_calls=tool_calls,
+            finish_reason=finish_reason,
+            usage=final_usage,
+            model=self.model,
+        )
+
+    def _build_converse_params(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict] | None,
+        temperature: float | None,
+        max_tokens: int | None,
+    ) -> dict[str, Any]:
+        """Build parameter dict for converse / converse_stream."""
+        system_prompts, bedrock_messages = self._messages_to_bedrock(messages)
+
+        params: dict[str, Any] = {
+            "modelId": self.model,
+            "messages": bedrock_messages,
+        }
+        if system_prompts:
+            params["system"] = system_prompts
+
+        inference_config: dict[str, Any] = {}
+        if max_tokens:
+            inference_config["maxTokens"] = max_tokens
+        if temperature is not None:
+            inference_config["temperature"] = temperature
+        if inference_config:
+            params["inferenceConfig"] = inference_config
+
+        tool_config = self._convert_tools(tools)
+        if tool_config:
+            params["toolConfig"] = tool_config
+
+        return params
+
+    async def close(self) -> None:
+        """Close the boto3 client."""
+        # boto3 clients don't require explicit closing
+        pass
+
+
 # ============================================================================
 # Factory and Utilities
 # ============================================================================
@@ -1709,7 +2112,7 @@ class ProviderSpec:
 
     provider: str
     display_name: str
-    protocol: Literal["openai_compatible", "anthropic", "openai_responses", "gemini"]
+    protocol: Literal["openai_compatible", "anthropic", "openai_responses", "gemini", "bedrock"]
     default_base_url: str | None
     supports_tool_choice: bool = True
     default_max_tokens: int = 4096
@@ -1845,6 +2248,24 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
         default_base_url=None,
         default_max_tokens=4096,
     ),
+    "bedrock": ProviderSpec(
+        provider="bedrock",
+        display_name="AWS Bedrock",
+        protocol="bedrock",
+        default_base_url=None,
+        supports_tool_choice=True,
+        default_max_tokens=4096,
+        model_max_tokens={
+            "anthropic.claude-3-5-sonnet": 8192,
+            "anthropic.claude-3-opus": 4096,
+            "anthropic.claude-3-haiku": 4096,
+            "anthropic.claude-3-5-haiku": 8192,
+            "anthropic.claude-sonnet-4": 16384,
+            "anthropic.claude-opus-4": 16384,
+            "meta.llama3": 4096,
+            "mistral.": 4096,
+        },
+    ),
 }
 
 
@@ -1885,6 +2306,8 @@ PROVIDER_CLIENTS: dict[str, type[LLMClient]] = {
         if spec.protocol == "openai_responses"
         else GeminiClient
         if spec.protocol == "gemini"
+        else BedrockClient
+        if spec.protocol == "bedrock"
         else OpenAICompatibleClient
     )
     for spec in PROVIDER_REGISTRY.values()
@@ -2004,6 +2427,13 @@ def create_llm_client(
             model=model,
             timeout=timeout,
             supports_tool_choice=spec.supports_tool_choice,
+        )
+    elif spec and spec.protocol == "bedrock":
+        return BedrockClient(
+            api_key=api_key,
+            base_url=final_base_url,
+            model=model,
+            timeout=timeout,
         )
     elif normalized_provider in PROVIDER_CLIENTS:
         supports_tool_choice = normalized_provider in TOOL_CHOICE_PROVIDERS

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -7,6 +7,8 @@ Provides a consistent interface for all LLM operations across the application.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
 import re
 from abc import ABC, abstractmethod
@@ -1915,8 +1917,6 @@ class BedrockClient(LLMClient):
                 "image/webp": "webp",
             }
             fmt = format_map.get(media_type, "jpeg")
-            import base64
-            import binascii
             return {
                 "image": {
                     "format": fmt,

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -1894,13 +1894,14 @@ class BedrockClient(LLMClient):
             }
             fmt = format_map.get(media_type, "jpeg")
             import base64
+            import binascii
             return {
                 "image": {
                     "format": fmt,
-                    "source": {"bytes": base64.b64decode(b64_data)},
+                    "source": {"bytes": base64.b64decode(b64_data, validate=True)},
                 }
             }
-        except (ValueError, IndexError):
+        except (ValueError, IndexError, binascii.Error):
             return None
 
     def _convert_tools(self, tools: list[dict] | None) -> dict[str, Any] | None:

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -1759,14 +1759,36 @@ class BedrockClient(LLMClient):
             return {}
         try:
             creds = json.loads(self.api_key)
-            if isinstance(creds, dict):
-                return creds
+            if not isinstance(creds, dict):
+                raise LLMError("Bedrock credentials must be a JSON object")
+
+            # Empty object explicitly means default AWS credential chain.
+            if not creds:
+                return {}
+
+            has_access = bool(creds.get("access_key"))
+            has_secret = bool(creds.get("secret_key"))
+            if has_access != has_secret:
+                raise LLMError(
+                    "Bedrock credentials require both access_key and secret_key when using static keys"
+                )
+
+            if creds.get("session_token") and not has_access:
+                raise LLMError("session_token requires access_key and secret_key")
+
+            allowed_keys = {"access_key", "secret_key", "session_token", "region"}
+            if not any(k in creds for k in allowed_keys):
+                raise LLMError(
+                    "Bedrock credentials JSON has no supported fields; "
+                    "use access_key/secret_key[/session_token]/region or leave blank for default chain"
+                )
+
+            return creds
         except (json.JSONDecodeError, TypeError) as exc:
-            logger.warning(
-                "Bedrock api_key contains non-JSON value; "
-                "falling back to default AWS credentials: %s", exc
-            )
-        return {}
+            raise LLMError(
+                "Invalid Bedrock credentials JSON. "
+                "Expected {\"access_key\":\"...\",\"secret_key\":\"...\",\"region\":\"us-east-1\"}"
+            ) from exc
 
     def _get_headers(self) -> dict[str, str]:
         """Not used — boto3 handles auth internally."""
@@ -2089,7 +2111,21 @@ class BedrockClient(LLMClient):
                 stream_body.close()
             except Exception:
                 pass
-            await producer_task
+            import sys
+
+            pending_exc = sys.exc_info()[1]
+            if pending_exc is None:
+                # No earlier failure: surface producer errors as provider errors.
+                try:
+                    await producer_task
+                except Exception as e:
+                    raise LLMError(f"Bedrock stream producer error: {e}") from e
+            else:
+                # Preserve the original exception from consumer/on_chunk path.
+                try:
+                    await producer_task
+                except Exception:
+                    pass
 
         finish_reason = "tool_calls" if stop_reason == "tool_use" else "stop"
 

--- a/backend/app/services/llm/utils.py
+++ b/backend/app/services/llm/utils.py
@@ -15,6 +15,7 @@ from app.models.llm import LLMModel
 # Re-export all client classes and functions from client.py
 from .client import (
     AnthropicClient,
+    BedrockClient,
     GeminiClient,
     LLMClient,
     LLMError,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pypinyin>=0.52.0",
     "anyascii>=0.3.2",
     "Pillow>=10.0.0",
+    "boto3>=1.35.0",
 ]
 
 [project.optional-dependencies]

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -2077,6 +2077,8 @@ export default function EnterpriseSettings() {
                                             const newProvider = e.target.value;
                                             const spec = providerOptions.find(p => p.provider === newProvider);
                                             const updates: any = { provider: newProvider };
+                                            updates.api_key = '';
+                                            updates.clear_api_key = false;
                                             if (spec?.default_base_url) {
                                                 updates.base_url = spec.default_base_url;
                                             } else {
@@ -2196,6 +2198,8 @@ export default function EnterpriseSettings() {
                                                         const newProvider = e.target.value;
                                                         const spec = providerOptions.find(p => p.provider === newProvider);
                                                         const updates: any = { provider: newProvider };
+                                                        updates.api_key = '';
+                                                        updates.clear_api_key = false;
                                                         if (spec?.default_base_url) {
                                                             updates.base_url = spec.default_base_url;
                                                         } else {

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -1955,7 +1955,7 @@ export default function EnterpriseSettings() {
     });
     const [showAddModel, setShowAddModel] = useState(false);
     const [editingModelId, setEditingModelId] = useState<string | null>(null);
-    const [modelForm, setModelForm] = useState({ provider: 'anthropic', model: '', api_key: '', base_url: '', label: '', supports_vision: false, max_output_tokens: '' as string, request_timeout: '' as string, temperature: '' as string });
+    const [modelForm, setModelForm] = useState({ provider: 'anthropic', model: '', api_key: '', clear_api_key: false, base_url: '', label: '', supports_vision: false, max_output_tokens: '' as string, request_timeout: '' as string, temperature: '' as string });
     const { data: providerSpecs = [] } = useQuery({
         queryKey: ['llm-provider-specs'],
         queryFn: () => fetchJson<LLMProviderSpec[]>('/enterprise/llm-providers'),
@@ -2055,7 +2055,7 @@ export default function EnterpriseSettings() {
                                 const defaultSpec = providerOptions[0];
                                 setModelForm({
                                     provider: defaultSpec?.provider || 'anthropic',
-                                    model: '', api_key: '',
+                                    model: '', api_key: '', clear_api_key: false,
                                     base_url: defaultSpec?.default_base_url || '',
                                     label: '', supports_vision: false,
                                     max_output_tokens: defaultSpec ? String(defaultSpec.default_max_tokens) : '4096',
@@ -2235,8 +2235,18 @@ export default function EnterpriseSettings() {
                                                 )}
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                                     <label className="form-label">{isBedrock ? 'AWS Credentials (JSON)' : t('enterprise.llm.apiKey')}</label>
-                                                    <input className="form-input" type={isBedrock ? 'text' : 'password'} placeholder={isBedrock ? '{"access_key": "...", "secret_key": "...", "region": "us-east-1"}' : '•••••••• (Leave blank to keep unchanged)'} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
+                                                    <input className="form-input" type={isBedrock ? 'text' : 'password'} placeholder={isBedrock ? '{"access_key": "...", "secret_key": "...", "region": "us-east-1"}' : '•••••••• (Leave blank to keep unchanged)'} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value, clear_api_key: false })} />
                                                     {isBedrock && <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px' }}>Leave blank to keep existing credentials unchanged.</div>}
+                                                    {isBedrock && (
+                                                        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '6px', cursor: 'pointer', fontSize: '12px', color: 'var(--text-secondary)' }}>
+                                                            <input
+                                                                type="checkbox"
+                                                                checked={Boolean(modelForm.clear_api_key)}
+                                                                onChange={e => setModelForm({ ...modelForm, clear_api_key: e.target.checked, api_key: e.target.checked ? '' : modelForm.api_key })}
+                                                            />
+                                                            Use default AWS credential chain (clear stored credentials)
+                                                        </label>
+                                                    )}
                                                 </div>
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                                     <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '13px' }}>
@@ -2343,7 +2353,7 @@ export default function EnterpriseSettings() {
                                                 {m.supports_vision && <span className="badge" style={{ background: 'rgba(99,102,241,0.15)', color: 'rgb(99,102,241)', fontSize: '10px' }}>Vision</span>}
                                                 <button className="btn btn-ghost" onClick={() => {
                                                     setEditingModelId(m.id);
-                                                    setModelForm({ provider: m.provider, model: m.model, label: m.label, base_url: m.base_url || '', api_key: m.api_key_masked || '', supports_vision: m.supports_vision || false, max_output_tokens: m.max_output_tokens ? String(m.max_output_tokens) : '', request_timeout: m.request_timeout ? String(m.request_timeout) : '', temperature: m.temperature !== null && m.temperature !== undefined ? String(m.temperature) : '' });
+                                                    setModelForm({ provider: m.provider, model: m.model, label: m.label, base_url: m.base_url || '', api_key: m.api_key_masked || '', clear_api_key: false, supports_vision: m.supports_vision || false, max_output_tokens: m.max_output_tokens ? String(m.max_output_tokens) : '', request_timeout: m.request_timeout ? String(m.request_timeout) : '', temperature: m.temperature !== null && m.temperature !== undefined ? String(m.temperature) : '' });
                                                     setShowAddModel(true);
                                                 }} style={{ fontSize: '12px' }}>✏️ {t('enterprise.tools.edit')}</button>
                                                 <button className="btn btn-ghost" onClick={() => deleteModel.mutate({ id: m.id })} style={{ color: 'var(--error)' }}>{t('common.delete')}</button>

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -2194,7 +2194,17 @@ export default function EnterpriseSettings() {
                                                     <label className="form-label">{t('enterprise.llm.provider')}</label>
                                                     <select className="form-input" value={modelForm.provider} onChange={e => {
                                                         const newProvider = e.target.value;
-                                                        setModelForm(f => ({ ...f, provider: newProvider }));
+                                                        const spec = providerOptions.find(p => p.provider === newProvider);
+                                                        const updates: any = { provider: newProvider };
+                                                        if (spec?.default_base_url) {
+                                                            updates.base_url = spec.default_base_url;
+                                                        } else {
+                                                            updates.base_url = '';
+                                                        }
+                                                        if (spec) {
+                                                            updates.max_output_tokens = String(spec.default_max_tokens);
+                                                        }
+                                                        setModelForm(f => ({ ...f, ...updates }));
                                                     }}>
                                                         {providerOptions.map((p) => (
                                                             <option key={p.provider} value={p.provider}>{p.display_name}</option>

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -1961,7 +1961,8 @@ export default function EnterpriseSettings() {
         queryFn: () => fetchJson<LLMProviderSpec[]>('/enterprise/llm-providers'),
         enabled: activeTab === 'llm',
     });
-    const providerOptions = providerSpecs.length > 0 ? providerSpecs : FALLBACK_LLM_PROVIDERS;
+    const providerOptions = (providerSpecs.length > 0 ? providerSpecs : FALLBACK_LLM_PROVIDERS).slice().sort((a, b) => a.display_name.localeCompare(b.display_name));
+    const isBedrock = modelForm.provider === 'bedrock';
     const addModel = useMutation({
         mutationFn: (data: any) => fetchJson(`/enterprise/llm-models${selectedTenantId ? `?tenant_id=${selectedTenantId}` : ''}`, { method: 'POST', body: JSON.stringify(data) }),
         onSuccess: () => { qc.invalidateQueries({ queryKey: ['llm-models', selectedTenantId] }); setShowAddModel(false); setEditingModelId(null); },
@@ -2104,13 +2105,16 @@ export default function EnterpriseSettings() {
                                         <label className="form-label">{t('enterprise.llm.label')}</label>
                                         <input className="form-input" placeholder={t('enterprise.llm.labelPlaceholder')} value={modelForm.label} onChange={e => setModelForm({ ...modelForm, label: e.target.value })} />
                                     </div>
+                                    {!isBedrock && (
                                     <div className="form-group">
                                         <label className="form-label">{t('enterprise.llm.baseUrl')}</label>
                                         <input className="form-input" placeholder={t('enterprise.llm.baseUrlPlaceholder')} value={modelForm.base_url} onChange={e => setModelForm({ ...modelForm, base_url: e.target.value })} />
                                     </div>
-                                    <div className="form-group" style={{ gridColumn: 'span 2' }}>
-                                        <label className="form-label">{t('enterprise.llm.apiKey')}</label>
-                                        <input className="form-input" type="password" placeholder={t('enterprise.llm.apiKeyPlaceholder')} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
+                                    )}
+                                    <div className="form-group" style={{ gridColumn: isBedrock ? 'span 2' : 'span 2' }}>
+                                        <label className="form-label">{isBedrock ? 'AWS Credentials (JSON)' : t('enterprise.llm.apiKey')}</label>
+                                        <input className="form-input" type={isBedrock ? 'text' : 'password'} placeholder={isBedrock ? '{"access_key": "...", "secret_key": "...", "region": "us-east-1"}' : t('enterprise.llm.apiKeyPlaceholder')} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
+                                        {isBedrock && <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px' }}>Leave empty to use the default AWS credential chain (env vars, ~/.aws/credentials, instance role).</div>}
                                     </div>
                                     <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                         <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '13px' }}>
@@ -2137,7 +2141,7 @@ export default function EnterpriseSettings() {
                                 </div>
                                 <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', alignItems: 'center' }}>
                                     <button className="btn btn-secondary" onClick={() => { setShowAddModel(false); setEditingModelId(null); }}>{t('common.cancel')}</button>
-                                    <button className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }} disabled={!modelForm.model || !modelForm.api_key} onClick={async () => {
+                                    <button className="btn btn-secondary" style={{ display: 'flex', alignItems: 'center', gap: '6px' }} disabled={!modelForm.model || (!isBedrock && !modelForm.api_key)} onClick={async () => {
                                         const btn = document.activeElement as HTMLButtonElement;
                                         const origText = btn?.textContent || '';
                                         if (btn) btn.textContent = t('enterprise.llm.testing');
@@ -2171,7 +2175,7 @@ export default function EnterpriseSettings() {
                                             temperature: modelForm.temperature !== '' ? Number(modelForm.temperature) : null
                                         };
                                         addModel.mutate(data);
-                                    }} disabled={!modelForm.model || !modelForm.api_key}>
+                                    }} disabled={!modelForm.model || (!isBedrock && !modelForm.api_key)}>
                                         {t('common.save')}
                                     </button>
                                 </div>
@@ -2213,13 +2217,16 @@ export default function EnterpriseSettings() {
                                                     <label className="form-label">{t('enterprise.llm.label')}</label>
                                                     <input className="form-input" placeholder={t('enterprise.llm.labelPlaceholder')} value={modelForm.label} onChange={e => setModelForm({ ...modelForm, label: e.target.value })} />
                                                 </div>
+                                                {!isBedrock && (
                                                 <div className="form-group">
                                                     <label className="form-label">{t('enterprise.llm.baseUrl')}</label>
                                                     <input className="form-input" placeholder={t('enterprise.llm.baseUrlPlaceholder')} value={modelForm.base_url} onChange={e => setModelForm({ ...modelForm, base_url: e.target.value })} />
                                                 </div>
+                                                )}
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
-                                                    <label className="form-label">{t('enterprise.llm.apiKey')}</label>
-                                                    <input className="form-input" type="password" placeholder="•••••••• (Leave blank to keep unchanged)" value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
+                                                    <label className="form-label">{isBedrock ? 'AWS Credentials (JSON)' : t('enterprise.llm.apiKey')}</label>
+                                                    <input className="form-input" type={isBedrock ? 'text' : 'password'} placeholder={isBedrock ? '{"access_key": "...", "secret_key": "...", "region": "us-east-1"}' : '•••••••• (Leave blank to keep unchanged)'} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
+                                                    {isBedrock && <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px' }}>Leave empty to use the default AWS credential chain (env vars, ~/.aws/credentials, instance role).</div>}
                                                 </div>
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                                     <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '13px' }}>

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -2236,7 +2236,7 @@ export default function EnterpriseSettings() {
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                                     <label className="form-label">{isBedrock ? 'AWS Credentials (JSON)' : t('enterprise.llm.apiKey')}</label>
                                                     <input className="form-input" type={isBedrock ? 'text' : 'password'} placeholder={isBedrock ? '{"access_key": "...", "secret_key": "...", "region": "us-east-1"}' : '•••••••• (Leave blank to keep unchanged)'} value={modelForm.api_key} onChange={e => setModelForm({ ...modelForm, api_key: e.target.value })} />
-                                                    {isBedrock && <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px' }}>Leave empty to use the default AWS credential chain (env vars, ~/.aws/credentials, instance role).</div>}
+                                                    {isBedrock && <div style={{ fontSize: '11px', color: 'var(--text-tertiary)', marginTop: '4px' }}>Leave blank to keep existing credentials unchanged.</div>}
                                                 </div>
                                                 <div className="form-group" style={{ gridColumn: 'span 2' }}>
                                                     <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer', fontSize: '13px' }}>


### PR DESCRIPTION
Adds AWS Bedrock as a native LLM provider using the boto3 Converse API.

Backend:

BedrockClient class with streaming, tool calling, and vision support
Provider registry entry for Bedrock (Claude, Llama, Mistral model families)
boto3>=1.35.0 dependency
Credentials packed as JSON in existing [api_key] field, with fallback to default AWS credential chain
Frontend:

Bedrock-specific Add Model form: hides Base URL, shows AWS Credentials JSON input with helper text
Provider dropdown sorted alphabetically
Bugfix:

Fix import path in [wecom.py] (auth_provider → auth_registry)
