### PR TITLE
fix(wecom): correct auth_provider_registry import and call signature

### DIFF
--- a/backend/app/api/wecom.py
+++ b/backend/app/api/wecom.py
@@ -32,7 +32,7 @@ from app.models.channel_config import ChannelConfig
 from app.models.identity import IdentityProvider, SSOScanSession
 from app.models.user import User
 from app.services.activity_logger import log_activity
-from app.services.auth_provider import auth_provider_registry
+from app.services.auth_registry import auth_provider_registry
 from app.services.channel_session import find_or_create_channel_session
 from app.services.channel_user_service import channel_user_service
 from app.services.platform_service import platform_service
@@ -686,7 +686,7 @@ async def wecom_callback(
 
     # 2. Extract user info and login/register via RegistrationService
     try:
-        auth_provider = auth_provider_registry.get_provider(provider)
+        auth_provider = await auth_provider_registry.get_provider(db, "wecom", str(tenant_id) if tenant_id else None)
         
         token_data = await auth_provider.exchange_code_for_token(code)
         access_token_str = token_data.get("access_token")


### PR DESCRIPTION
## Summary

- Fix wrong import path: `auth_provider_registry` is in `app.services.auth_registry`, not `app.services.auth_provider`
- Fix call signature: `get_provider(provider)` → `await get_provider(db, "wecom", tenant_id)` to match `AuthProviderRegistry` interface
- This was causing `ImportError` on backend startup (`docker compose up`)

## Root Cause

`wecom.py` imported `auth_provider_registry` from the wrong module. The same registry is correctly imported from `auth_registry` in `sso.py` and `dingtalk.py`.

## Test plan

- [x] `docker compose up` — backend container starts without ImportError
- [x] WeCom SSO callback still works end-to-end