### PR TITLE
Restrict workspace file deletion to managers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,17 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
 }
 
+function EnterpriseAdminRoute({ children }: { children: React.ReactNode }) {
+    const user = useAuthStore((s) => s.user);
+    const canAccessEnterpriseSettings =
+        user?.role === 'org_admin' ||
+        user?.role === 'platform_admin' ||
+        !!user?.is_platform_admin;
+
+    if (!canAccessEnterpriseSettings) return <Navigate to="/plaza" replace />;
+    return <>{children}</>;
+}
+
 /* ─── Notification Bar ─── */
 type NotificationBarConfig = { enabled: boolean; text: string };
 type NotificationBarUpdateEvent = CustomEvent<NotificationBarConfig>;
@@ -213,7 +224,7 @@ export default function App() {
                     <Route path="agents/:id/chat" element={<AgentDetail />} />
                     <Route path="agents/:id/settings" element={<AgentDetail />} />
                     <Route path="messages" element={<Messages />} />
-                    <Route path="enterprise" element={<EnterpriseSettings />} />
+                    <Route path="enterprise" element={<EnterpriseAdminRoute><EnterpriseSettings /></EnterpriseAdminRoute>} />
                     <Route path="okr" element={<OKR />} />
                     <Route path="invitations" element={<InvitationCodes />} />
                     <Route path="admin/platform-settings" element={<AdminCompanies />} />

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -255,6 +255,7 @@ export default function Layout() {
     const activeAgentRootMatch = useMatch('/agents/:id');
     const activeAgentId = activeAgentNestedMatch?.params.id || activeAgentRootMatch?.params.id;
     const canAccessPlatformSettings = user?.role === 'platform_admin' || !!(user as any)?.is_platform_admin;
+    const canAccessEnterpriseSettings = user?.role === 'org_admin' || user?.role === 'platform_admin' || !!(user as any)?.is_platform_admin;
 
     const [showAccountSettings, setShowAccountSettings] = useState(false);
     const [showAccountMenu, setShowAccountMenu] = useState(false);
@@ -810,17 +811,19 @@ export default function Layout() {
                                     <IconPlus size={17} stroke={1.6} />
                                     <span>{isChinese ? '创建或加入新公司' : 'Create or join company'}</span>
                                 </button>
-                                <button
-                                    type="button"
-                                    className="tenant-switcher-action"
-                                    onClick={() => {
-                                        setShowTenantMenu(false);
-                                        navigate('/enterprise');
-                                    }}
-                                >
-                                    <IconSettings size={16} stroke={1.6} />
-                                    <span>{isChinese ? '公司信息设置' : 'Company settings'}</span>
-                                </button>
+                                {canAccessEnterpriseSettings && (
+                                    <button
+                                        type="button"
+                                        className="tenant-switcher-action"
+                                        onClick={() => {
+                                            setShowTenantMenu(false);
+                                            navigate('/enterprise');
+                                        }}
+                                    >
+                                        <IconSettings size={16} stroke={1.6} />
+                                        <span>{isChinese ? '公司信息设置' : 'Company settings'}</span>
+                                    </button>
+                                )}
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
## Summary

Restricts workspace file deletion to agent managers/admins and hides delete actions from non-managers.

Closes #433

## Checklist

- [x] Tested locally
- [x] No unrelated changes included
