### PR TITLE
Optimize relationship visibility and org path handling

### DIFF
--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.permissions import check_agent_access, is_agent_creator
+from app.core.permissions import build_visible_agents_query, check_agent_access, is_agent_creator
 from app.core.security import get_current_user
 from app.database import get_db
 from app.models.agent import Agent, AgentPermission
@@ -139,47 +139,16 @@ async def list_agents(
     db: AsyncSession = Depends(get_db),
 ):
     """List all agents the current user has access to."""
-    # platform_admin & org_admin see all agents (optionally filtered by tenant)
-    if current_user.role in ("platform_admin", "org_admin"):
-        stmt = select(Agent)
-        if tenant_id:
-            stmt = stmt.where(Agent.tenant_id == tenant_id)
-        result = await db.execute(stmt.order_by(Agent.created_at.desc()))
-        agents = result.scalars().all()
-        # Lazy reset token counters
-        needs_flush = False
-        for a in agents:
-            if await _lazy_reset_token_counters(a, db):
-                needs_flush = True
-        if needs_flush:
-            await db.commit()
-        return [AgentOut.model_validate(a) for a in agents]
+    requested_tenant_id = tenant_id
+    if current_user.role != "platform_admin":
+        requested_tenant_id = current_user.tenant_id
 
-    # agent_admin sees their own created agents + permitted
-    # member sees only permitted
-    # All scoped to user's tenant
-    user_tenant = current_user.tenant_id
+    stmt = build_visible_agents_query(
+        current_user,
+        tenant_id=requested_tenant_id,
+    ).order_by(Agent.created_at.desc())
 
-    # Get agents user created (within their tenant)
-    created = select(Agent).where(Agent.creator_id == current_user.id, Agent.tenant_id == user_tenant)
-
-    # Get agents user has permission to (within their tenant)
-    permitted_ids = (
-        select(AgentPermission.agent_id)
-        .where(
-            (AgentPermission.scope_type == "company")
-            | ((AgentPermission.scope_type == "user") & (AgentPermission.scope_id == current_user.id))
-        )
-    )
-    permitted = select(Agent).where(Agent.id.in_(permitted_ids), Agent.tenant_id == user_tenant)
-
-    # Union
-    from sqlalchemy import union_all
-
-    combined = union_all(created, permitted).subquery()
-    result = await db.execute(
-        select(Agent).where(Agent.id.in_(select(combined.c.id))).order_by(Agent.created_at.desc())
-    )
+    result = await db.execute(stmt)
     agents = result.scalars().all()
     # Lazy reset token counters
     needs_flush = False

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -17,6 +17,7 @@ from app.database import async_session, get_db
 from app.models.org import OrgDepartment, OrgMember
 from app.models.identity import IdentityProvider
 from app.models.user import User
+from app.services.org_sync_adapter import derive_member_department_paths
 from app.models.agent import Agent
 from app.models.llm import LLMModel
 from app.models.audit import AuditLog, ApprovalRequest, EnterpriseInfo
@@ -1282,13 +1283,17 @@ async def list_org_members(
     query = query.order_by(OrgMember.name).limit(100)
     result = await db.execute(query)
     rows = result.all()
+    member_paths = await derive_member_department_paths(
+        db,
+        [m for m, _provider_name, _provider_type in rows],
+    )
     return [
         {
             "id": str(m.id),
             "name": m.name,
             "email": m.email,
             "title": m.title,
-            "department_path": m.department_path,
+            "department_path": member_paths.get(m.id, m.department_path),
             "avatar_url": m.avatar_url,
             "external_id": m.external_id,
             "provider_id": str(m.provider_id) if m.provider_id else None,

--- a/backend/app/api/relationships.py
+++ b/backend/app/api/relationships.py
@@ -1,20 +1,21 @@
 """Agent relationship management API — human + agent-to-agent."""
 
-import json
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import select, delete
+from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.config import get_settings
+from app.core.permissions import build_visible_agents_query, check_agent_access
 from app.core.security import get_current_user
-from app.core.permissions import check_agent_access
+from app.models.agent import Agent
 from app.database import get_db
 from app.models.org import AgentRelationship, AgentAgentRelationship, OrgMember
+from app.services.org_sync_adapter import derive_member_department_paths
 from app.models.user import User
 
 settings = get_settings()
@@ -61,6 +62,22 @@ class AgentRelationshipBatchIn(BaseModel):
     relationships: list[AgentRelationshipIn]
 
 
+def _dedupe_human_relationships(items: list[RelationshipIn]) -> list[RelationshipIn]:
+    deduped: dict[str, RelationshipIn] = {}
+    for item in items:
+        deduped[item.member_id] = item
+    return list(deduped.values())
+
+
+def _dedupe_agent_relationships(items: list[AgentRelationshipIn], agent_id: uuid.UUID) -> list[AgentRelationshipIn]:
+    deduped: dict[str, AgentRelationshipIn] = {}
+    for item in items:
+        if item.target_agent_id == str(agent_id):
+            continue
+        deduped[item.target_agent_id] = item
+    return list(deduped.values())
+
+
 # ─── Human Relationships (existing) ───────────────────
 
 @router.get("/")
@@ -79,6 +96,10 @@ async def get_relationships(
         .options(selectinload(AgentRelationship.member))
     )
     rows = result.all()
+    member_paths = await derive_member_department_paths(
+        db,
+        [r.member for r, _provider_name in rows if r.member],
+    )
     return [
         {
             "id": str(r.id),
@@ -89,7 +110,7 @@ async def get_relationships(
             "member": {
                 "name": r.member.name,
                 "title": r.member.title,
-                "department_path": r.member.department_path,
+                "department_path": member_paths.get(r.member.id, r.member.department_path),
                 "avatar_url": r.member.avatar_url,
                 "email": r.member.email,
                 "provider_name": provider_name,
@@ -113,7 +134,7 @@ async def save_relationships(
         delete(AgentRelationship).where(AgentRelationship.agent_id == agent_id)
     )
 
-    for r in data.relationships:
+    for r in _dedupe_human_relationships(data.relationships):
         db.add(AgentRelationship(
             agent_id=agent_id,
             member_id=uuid.UUID(r.member_id),
@@ -152,6 +173,39 @@ async def delete_relationship(
 
 
 # ─── Agent-to-Agent Relationships (new) ───────────────
+
+@router.get("/agent-candidates")
+async def search_visible_agents(
+    agent_id: uuid.UUID,
+    search: str | None = None,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Search visible agent candidates for relationship creation."""
+    source_agent, _ = await check_agent_access(db, current_user, agent_id)
+
+    stmt = build_visible_agents_query(current_user, tenant_id=source_agent.tenant_id).where(Agent.id != agent_id)
+    if search:
+        stmt = stmt.where(
+            or_(
+                Agent.name.ilike(f"%{search}%"),
+                Agent.role_description.ilike(f"%{search}%"),
+            )
+        )
+
+    result = await db.execute(stmt.order_by(Agent.created_at.desc()).limit(50))
+    agents = result.scalars().all()
+    return [
+        {
+            "id": str(agent.id),
+            "name": agent.name,
+            "role_description": agent.role_description or "",
+            "avatar_url": agent.avatar_url or "",
+            "creator_id": str(agent.creator_id),
+        }
+        for agent in agents
+    ]
+
 
 @router.get("/agents")
 async def get_agent_relationships(
@@ -193,16 +247,20 @@ async def save_agent_relationships(
     db: AsyncSession = Depends(get_db),
 ):
     """Replace all agent-to-agent relationships."""
-    await check_agent_access(db, current_user, agent_id)
+    source_agent, _ = await check_agent_access(db, current_user, agent_id)
 
     await db.execute(
         delete(AgentAgentRelationship).where(AgentAgentRelationship.agent_id == agent_id)
     )
 
-    for r in data.relationships:
+    for r in _dedupe_agent_relationships(data.relationships, agent_id):
         target_id = uuid.UUID(r.target_agent_id)
-        if target_id == agent_id:
-            continue  # skip self-reference
+        target_result = await db.execute(
+            build_visible_agents_query(current_user, tenant_id=source_agent.tenant_id).where(Agent.id == target_id)
+        )
+        visible_target = target_result.scalar_one_or_none()
+        if not visible_target:
+            raise HTTPException(status_code=403, detail="Target agent is not visible to the current user")
         db.add(AgentAgentRelationship(
             agent_id=agent_id,
             target_agent_id=target_id,

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -5,11 +5,49 @@ from datetime import datetime, timezone
 from typing import Tuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import and_, false, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent import Agent, AgentPermission
 from app.models.user import User
+
+
+def build_visible_agents_query(
+    user: User,
+    *,
+    tenant_id: uuid.UUID | None = None,
+):
+    """Build a query for agents visible to the current user.
+
+    Visibility defaults to "same company + creator/self-permitted/company-wide".
+    This keeps private agents hidden from other users, including platform admins.
+    """
+    stmt = select(Agent)
+
+    target_tenant_id = tenant_id if tenant_id is not None else user.tenant_id
+    if target_tenant_id is None:
+        return stmt.where(false())
+
+    permitted_ids = (
+        select(AgentPermission.agent_id)
+        .where(
+            or_(
+                AgentPermission.scope_type == "company",
+                and_(
+                    AgentPermission.scope_type == "user",
+                    AgentPermission.scope_id == user.id,
+                ),
+            )
+        )
+    )
+
+    return stmt.where(
+        Agent.tenant_id == target_tenant_id,
+        or_(
+            Agent.creator_id == user.id,
+            Agent.id.in_(permitted_ids),
+        ),
+    )
 
 
 async def check_agent_access(db: AsyncSession, user: User, agent_id: uuid.UUID) -> Tuple[Agent, str]:
@@ -18,20 +56,15 @@ async def check_agent_access(db: AsyncSession, user: User, agent_id: uuid.UUID) 
     Returns (agent, access_level) where access_level is 'manage' or 'use'.
 
     Access is granted if:
-    1. User is platform admin → manage
-    2. User is the agent creator → manage
-    3. User has explicit permission (company/user scope) → from permission record
+    1. User is the agent creator → manage
+    2. User has explicit permission (company/user scope) → from permission record
     """
     result = await db.execute(select(Agent).where(Agent.id == agent_id))
     agent = result.scalar_one_or_none()
     if not agent:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
 
-    # Platform admins can access everything with manage
-    if user.role == "platform_admin":
-        return agent, "manage"
-
-    # Tenant isolation: non-platform-admin users can only access agents in their own tenant
+    # Tenant isolation applies to all users.
     if agent.tenant_id != user.tenant_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No access to this agent")
 
@@ -54,7 +87,7 @@ async def check_agent_access(db: AsyncSession, user: User, agent_id: uuid.UUID) 
 
 def is_agent_creator(user: User, agent: Agent) -> bool:
     """Check if the user is the creator (admin) of the agent."""
-    return agent.creator_id == user.id or user.role == "platform_admin"
+    return agent.creator_id == user.id
 
 
 def is_agent_expired(agent: Agent) -> bool:

--- a/backend/app/scripts/backfill_department_paths.py
+++ b/backend/app/scripts/backfill_department_paths.py
@@ -1,0 +1,66 @@
+"""Backfill department paths from the department tree and refresh member paths.
+
+Usage:
+  Docker: docker exec clawith-backend-1 python3 -m app.scripts.backfill_department_paths
+  Source: cd backend && python3 -m app.scripts.backfill_department_paths
+"""
+
+import asyncio
+
+from loguru import logger
+
+
+async def main():
+    from app.database import async_session
+    from app.models import (  # noqa: F401
+        activity_log, agent, audit, channel_config, chat_session,
+        gateway_message, identity, invitation_code, llm, notification, org,
+        participant, plaza, schedule, skill, system_settings, task,
+        tenant, tenant_setting, tool, trigger, user,
+    )
+    from app.models.identity import IdentityProvider
+    from app.models.org import OrgDepartment, OrgMember
+    from app.services.org_sync_adapter import build_department_path_map
+    from sqlalchemy import select
+
+    async with async_session() as db:
+        provider_result = await db.execute(select(IdentityProvider.id))
+        provider_ids = [pid for pid in provider_result.scalars().all()]
+        logger.info(f"Found {len(provider_ids)} providers to backfill")
+
+        updated_depts = 0
+        updated_members = 0
+
+        for provider_id in provider_ids:
+            dept_result = await db.execute(
+                select(OrgDepartment).where(OrgDepartment.provider_id == provider_id)
+            )
+            departments = dept_result.scalars().all()
+            if not departments:
+                continue
+
+            path_map = build_department_path_map(departments)
+            for dept in departments:
+                new_path = path_map.get(dept.id, (dept.name or "").strip())
+                if dept.path != new_path:
+                    dept.path = new_path
+                    updated_depts += 1
+
+            member_result = await db.execute(
+                select(OrgMember).where(OrgMember.provider_id == provider_id)
+            )
+            members = member_result.scalars().all()
+            for member in members:
+                new_path = path_map.get(member.department_id, "") if member.department_id else ""
+                if member.department_path != new_path:
+                    member.department_path = new_path
+                    updated_members += 1
+
+        await db.commit()
+        logger.info(
+            f"Department path backfill complete. Updated {updated_depts} departments and {updated_members} members."
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/app/services/org_sync_adapter.py
+++ b/backend/app/services/org_sync_adapter.py
@@ -20,10 +20,109 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.identity import IdentityProvider
 from app.models.org import OrgDepartment, OrgMember
 from app.models.user import User, Identity
-from pypinyin import pinyin, lazy_pinyin, Style
-from anyascii import anyascii as _anyascii
+
+try:
+    from anyascii import anyascii as _anyascii
+except ImportError:  # pragma: no cover - lightweight fallback for minimal test envs
+    def _anyascii(value: str) -> str:
+        return value
+
+try:
+    from pypinyin import Style, lazy_pinyin, pinyin
+except ImportError:  # pragma: no cover - lightweight fallback for minimal test envs
+    class Style:
+        FIRST_LETTER = "first_letter"
+
+    def lazy_pinyin(value: str, errors: str = "default") -> list[str]:
+        ascii_value = _anyascii(value)
+        return list(ascii_value) if ascii_value else list(value)
+
+    def pinyin(value: str, style: str | None = None) -> list[list[str]]:
+        ascii_value = _anyascii(value) or value
+        if style == Style.FIRST_LETTER:
+            return [[ch.lower()] for ch in ascii_value if ch.strip()]
+        return [[ascii_value]]
 
 from app.core.security import hash_password
+
+
+def build_department_path_map(departments: list[OrgDepartment]) -> dict[uuid.UUID, str]:
+    """Build department name paths by walking the internal department tree."""
+    dept_by_id = {dept.id: dept for dept in departments}
+    paths: dict[uuid.UUID, str] = {}
+
+    def is_virtual_root(dept: OrgDepartment) -> bool:
+        return not dept.parent_id and str(getattr(dept, "external_id", "") or "") == "0"
+
+    def compute_path(dept_id: uuid.UUID, visited: set[uuid.UUID] | None = None) -> str:
+        if dept_id in paths:
+            return paths[dept_id]
+        if visited is None:
+            visited = set()
+        if dept_id in visited:
+            dept = dept_by_id.get(dept_id)
+            fallback = (dept.name if dept else "") or ""
+            paths[dept_id] = fallback
+            return fallback
+
+        visited.add(dept_id)
+        dept = dept_by_id.get(dept_id)
+        if not dept:
+            return ""
+
+        if is_virtual_root(dept):
+            paths[dept_id] = ""
+            return ""
+
+        name = (dept.name or "").strip()
+        if not dept.parent_id or dept.parent_id not in dept_by_id:
+            paths[dept_id] = name
+            return name
+
+        parent_path = compute_path(dept.parent_id, visited)
+        full_path = f"{parent_path}/{name}" if parent_path else name
+        paths[dept_id] = full_path
+        return full_path
+
+    for dept in departments:
+        compute_path(dept.id)
+
+    return paths
+
+
+async def derive_member_department_paths(
+    db: AsyncSession,
+    members: list[OrgMember],
+) -> dict[uuid.UUID, str]:
+    """Resolve member department paths from department_id via the department tree."""
+    dept_ids = {member.department_id for member in members if member.department_id}
+    if not dept_ids:
+        return {}
+
+    departments: dict[uuid.UUID, OrgDepartment] = {}
+    pending_ids = set(dept_ids)
+
+    while pending_ids:
+        result = await db.execute(
+            select(OrgDepartment).where(OrgDepartment.id.in_(pending_ids))
+        )
+        batch = result.scalars().all()
+        if not batch:
+            break
+
+        next_pending: set[uuid.UUID] = set()
+        for department in batch:
+            departments[department.id] = department
+            if department.parent_id and department.parent_id not in departments:
+                next_pending.add(department.parent_id)
+        pending_ids = next_pending
+
+    dept_path_map = build_department_path_map(list(departments.values()))
+
+    return {
+        member.id: dept_path_map.get(member.department_id, member.department_path or "")
+        for member in members
+    }
 
 
 def _normalize_contact(value: str | None) -> str | None:
@@ -154,6 +253,9 @@ class BaseOrgSyncAdapter(ABC):
                     errors.append(f"Department {dept.external_id}: {str(e)}")
                     logger.error(f"[OrgSync] Failed to sync department {dept.external_id}: {e}")
 
+            await self._rebuild_department_paths(db, provider.id)
+            await db.flush()
+
             # Fetch and sync users (from all departments)
             for dept in departments:
                 try:
@@ -177,6 +279,9 @@ class BaseOrgSyncAdapter(ABC):
                         partial_failure = True
                         logger.error(f"[OrgSync] Failed to sync member {user.external_id} ({user.name}): {e}")
                         errors.append(f"Member {user.external_id}: {str(e)}")
+
+            await self._refresh_member_department_paths(db, provider.id)
+            await db.flush()
 
             # Update provider metadata if possible
             if self.provider:
@@ -348,7 +453,8 @@ class BaseOrgSyncAdapter(ABC):
         existing = result.scalars().first()
 
         now = datetime.now()
-        path = f"{dept.parent_external_id}/{dept.name}" if dept.parent_external_id else dept.name
+        # Path is rebuilt from the internal department tree after sync.
+        path = dept.name
 
         # Resolve parent_id from parent_external_id
         parent_id = None
@@ -386,6 +492,38 @@ class BaseOrgSyncAdapter(ABC):
             db.add(new_dept)
 
         await db.flush()
+
+    async def _rebuild_department_paths(self, db: AsyncSession, provider_id: uuid.UUID) -> dict[uuid.UUID, str]:
+        """Normalize OrgDepartment.path using parent_id/name reverse derivation."""
+        result = await db.execute(
+            select(OrgDepartment).where(OrgDepartment.provider_id == provider_id)
+        )
+        departments = result.scalars().all()
+        path_map = build_department_path_map(departments)
+
+        for dept in departments:
+            dept.path = path_map.get(dept.id, (dept.name or "").strip())
+
+        return path_map
+
+    async def _refresh_member_department_paths(self, db: AsyncSession, provider_id: uuid.UUID):
+        """Refresh OrgMember.department_path from the normalized department tree."""
+        dept_result = await db.execute(
+            select(OrgDepartment).where(OrgDepartment.provider_id == provider_id)
+        )
+        departments = dept_result.scalars().all()
+        dept_path_map = build_department_path_map(departments)
+
+        member_result = await db.execute(
+            select(OrgMember).where(OrgMember.provider_id == provider_id)
+        )
+        members = member_result.scalars().all()
+
+        for member in members:
+            if member.department_id:
+                member.department_path = dept_path_map.get(member.department_id, member.department_path or "")
+            else:
+                member.department_path = member.department_path or ""
 
     async def _upsert_member(
         self,

--- a/backend/tests/test_agent_visibility.py
+++ b/backend/tests/test_agent_visibility.py
@@ -1,0 +1,35 @@
+import uuid
+from types import SimpleNamespace
+
+from app.core.permissions import build_visible_agents_query
+
+
+def make_user(**overrides):
+    values = {
+        "id": uuid.uuid4(),
+        "role": "member",
+        "tenant_id": uuid.uuid4(),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_build_visible_agents_query_restricts_to_same_tenant_and_visible_permissions():
+    user = make_user()
+
+    stmt = build_visible_agents_query(user)
+    sql = str(stmt)
+
+    assert "agents.tenant_id" in sql
+    assert "agents.creator_id" in sql
+    assert "agent_permissions.scope_type" in sql
+    assert "agent_permissions.scope_id" in sql
+
+
+def test_build_visible_agents_query_platform_admin_still_uses_visibility_filters():
+    admin = make_user(role="platform_admin", tenant_id=None)
+
+    sql = str(build_visible_agents_query(admin, tenant_id=uuid.uuid4()))
+
+    assert "agents.tenant_id" in sql
+    assert "agent_permissions.scope_type" in sql

--- a/backend/tests/test_org_sync_adapter.py
+++ b/backend/tests/test_org_sync_adapter.py
@@ -1,10 +1,11 @@
 import asyncio
+import uuid
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
 
-from app.services.org_sync_adapter import BaseOrgSyncAdapter, ExternalUser
+from app.services.org_sync_adapter import BaseOrgSyncAdapter, ExternalUser, build_department_path_map
 
 
 class _DummyAdapter(BaseOrgSyncAdapter):
@@ -58,6 +59,12 @@ class _SyncAdapterWithFailure(_DummyAdapter):
     async def _update_member_counts(self, db, provider_id):
         self.member_counts_updated = True
 
+    async def _rebuild_department_paths(self, db, provider_id):
+        return {}
+
+    async def _refresh_member_department_paths(self, db, provider_id):
+        return None
+
     async def fetch_departments(self):
         return [SimpleNamespace(external_id="dept-1", name="Dept 1")]
 
@@ -100,3 +107,36 @@ def test_sync_org_structure_skips_reconcile_after_member_failure():
     assert adapter.reconcile_called is False
     assert adapter.member_counts_updated is True
     assert "Reconcile skipped due to partial sync failures" in result["errors"]
+
+
+def test_build_department_path_map_reconstructs_name_chain_from_internal_tree():
+    root_id = uuid.uuid4()
+    child_id = uuid.uuid4()
+    leaf_id = uuid.uuid4()
+
+    departments = [
+        SimpleNamespace(id=leaf_id, external_id="leaf", name="平台组", parent_id=child_id),
+        SimpleNamespace(id=child_id, external_id="child", name="研发部", parent_id=root_id),
+        SimpleNamespace(id=root_id, external_id="root", name="总部", parent_id=None),
+    ]
+
+    path_map = build_department_path_map(departments)
+
+    assert path_map[root_id] == "总部"
+    assert path_map[child_id] == "总部/研发部"
+    assert path_map[leaf_id] == "总部/研发部/平台组"
+
+
+def test_build_department_path_map_treats_external_zero_root_as_empty_path():
+    root_id = uuid.uuid4()
+    child_id = uuid.uuid4()
+
+    departments = [
+        SimpleNamespace(id=child_id, external_id="200", name="研发部", parent_id=root_id),
+        SimpleNamespace(id=root_id, external_id="0", name="Root", parent_id=None),
+    ]
+
+    path_map = build_department_path_map(departments)
+
+    assert path_map[root_id] == ""
+    assert path_map[child_id] == "研发部"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -246,6 +246,8 @@
       "humanRelationships": "Human Relationships",
       "agentRelationships": "Agent Relationships",
       "searchMembers": "Search org members...",
+      "searchAgents": "Search visible agents...",
+      "noSearchResults": "No available results",
       "noRelationships": "No relationships",
       "addRelationship": "Add Relationship",
       "supervisor": "Supervisor",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -253,6 +253,8 @@
       "humanRelationships": "人类关系",
       "agentRelationships": "数字员工关系",
       "searchMembers": "搜索组织架构成员...",
+      "searchAgents": "搜索可见数字员工...",
+      "noSearchResults": "没有可添加的结果",
       "noRelationships": "暂无关系",
       "addRelationship": "添加关系",
       "supervisor": "上级",

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -1031,17 +1031,17 @@ function AnalysisCard({
 
 function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; readOnly?: boolean }) {
     const { t } = useTranslation();
-    const qc = useQueryClient();
     const [search, setSearch] = useState('');
     const [searchResults, setSearchResults] = useState<any[]>([]);
-    const [adding, setAdding] = useState<any>(null);
+    const [selectedMembers, setSelectedMembers] = useState<any[]>([]);
     const [relation, setRelation] = useState('collaborator');
     const [description, setDescription] = useState('');
     // Agent relationships state
-    const [addingAgent, setAddingAgent] = useState(false);
+    const [agentSearch, setAgentSearch] = useState('');
+    const [agentSearchResults, setAgentSearchResults] = useState<any[]>([]);
+    const [selectedAgents, setSelectedAgents] = useState<any[]>([]);
     const [agentRelation, setAgentRelation] = useState('collaborator');
     const [agentDescription, setAgentDescription] = useState('');
-    const [selectedAgentId, setSelectedAgentId] = useState('');
     // Editing state
     const [editingId, setEditingId] = useState<string | null>(null);
     const [editRelation, setEditRelation] = useState('');
@@ -1060,26 +1060,87 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
         queryKey: ['agent-relationships', agentId],
         queryFn: () => fetchAuth<any[]>(`/agents/${agentId}/relationships/agents`),
     });
-    const { data: allAgents = [] } = useQuery({
-        queryKey: ['agents-for-rel'],
-        queryFn: () => fetchAuth<any[]>(`/agents/`),
-    });
-    const availableAgents = allAgents.filter((a: any) => a.id !== agentId);
+
+    const relatedMemberIds = useMemo(() => new Set(relationships.map((r: any) => r.member_id)), [relationships]);
+    const relatedAgentIds = useMemo(() => new Set(agentRelationships.map((r: any) => r.target_agent_id)), [agentRelationships]);
+    const selectedMemberIds = useMemo(() => new Set(selectedMembers.map((m: any) => m.id)), [selectedMembers]);
+    const selectedAgentIds = useMemo(() => new Set(selectedAgents.map((a: any) => a.id)), [selectedAgents]);
+
+    const visibleMemberResults = useMemo(
+        () => searchResults.filter((m: any) => !relatedMemberIds.has(m.id)),
+        [searchResults, relatedMemberIds],
+    );
+    const visibleAgentResults = useMemo(
+        () => agentSearchResults.filter((a: any) => !relatedAgentIds.has(a.id)),
+        [agentSearchResults, relatedAgentIds],
+    );
+
+    const loadOrgMembers = async (keyword = '') => {
+        const query = keyword.trim()
+            ? `?search=${encodeURIComponent(keyword.trim())}`
+            : '';
+        const results = await fetchAuth<any[]>(`/enterprise/org/members${query}`);
+        setSearchResults(results);
+    };
 
     useEffect(() => {
         if (!search || search.length < 1) { setSearchResults([]); return; }
-        const t = setTimeout(() => {
-            fetchAuth<any[]>(`/enterprise/org/members?search=${encodeURIComponent(search)}`).then(setSearchResults);
+        const timer = setTimeout(() => {
+            loadOrgMembers(search);
         }, 300);
-        return () => clearTimeout(t);
+        return () => clearTimeout(timer);
     }, [search]);
 
+    useEffect(() => {
+        if (!agentSearch || agentSearch.length < 1) { setAgentSearchResults([]); return; }
+        const timer = setTimeout(() => {
+            fetchAuth<any[]>(`/agents/${agentId}/relationships/agent-candidates?search=${encodeURIComponent(agentSearch)}`).then(setAgentSearchResults);
+        }, 300);
+        return () => clearTimeout(timer);
+    }, [agentId, agentSearch]);
+
+    const resetHumanDraft = () => {
+        setSearch('');
+        setSearchResults([]);
+        setSelectedMembers([]);
+        setRelation('collaborator');
+        setDescription('');
+    };
+
+    const resetAgentDraft = () => {
+        setAgentSearch('');
+        setAgentSearchResults([]);
+        setSelectedAgents([]);
+        setAgentRelation('collaborator');
+        setAgentDescription('');
+    };
+
+    const toggleMemberSelection = (member: any) => {
+        setSelectedMembers(prev =>
+            prev.some((item: any) => item.id === member.id)
+                ? prev.filter((item: any) => item.id !== member.id)
+                : [...prev, member]
+        );
+    };
+
+    const toggleAgentSelection = (agent: any) => {
+        setSelectedAgents(prev =>
+            prev.some((item: any) => item.id === agent.id)
+                ? prev.filter((item: any) => item.id !== agent.id)
+                : [...prev, agent]
+        );
+    };
+
     const addRelationship = async () => {
-        if (!adding) return;
-        const existing = relationships.map((r: any) => ({ member_id: r.member_id, relation: r.relation, description: r.description }));
-        existing.push({ member_id: adding.id, relation, description });
-        await fetchAuth(`/agents/${agentId}/relationships/`, { method: 'PUT', body: JSON.stringify({ relationships: existing }) });
-        setAdding(null); setSearch(''); setRelation('collaborator'); setDescription('');
+        if (!selectedMembers.length) return;
+        const existing = new Map(
+            relationships.map((r: any) => [r.member_id, { member_id: r.member_id, relation: r.relation, description: r.description }])
+        );
+        selectedMembers.forEach((member: any) => {
+            existing.set(member.id, { member_id: member.id, relation, description });
+        });
+        await fetchAuth(`/agents/${agentId}/relationships/`, { method: 'PUT', body: JSON.stringify({ relationships: Array.from(existing.values()) }) });
+        resetHumanDraft();
         refetch();
     };
     const removeRelationship = async (relId: string) => {
@@ -1112,11 +1173,15 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
         refetch();
     };
     const addAgentRelationship = async () => {
-        if (!selectedAgentId) return;
-        const existing = agentRelationships.map((r: any) => ({ target_agent_id: r.target_agent_id, relation: r.relation, description: r.description }));
-        existing.push({ target_agent_id: selectedAgentId, relation: agentRelation, description: agentDescription });
-        await fetchAuth(`/agents/${agentId}/relationships/agents`, { method: 'PUT', body: JSON.stringify({ relationships: existing }) });
-        setAddingAgent(false); setSelectedAgentId(''); setAgentRelation('collaborator'); setAgentDescription('');
+        if (!selectedAgents.length) return;
+        const existing = new Map(
+            agentRelationships.map((r: any) => [r.target_agent_id, { target_agent_id: r.target_agent_id, relation: r.relation, description: r.description }])
+        );
+        selectedAgents.forEach((agent: any) => {
+            existing.set(agent.id, { target_agent_id: agent.id, relation: agentRelation, description: agentDescription });
+        });
+        await fetchAuth(`/agents/${agentId}/relationships/agents`, { method: 'PUT', body: JSON.stringify({ relationships: Array.from(existing.values()) }) });
+        resetAgentDraft();
         refetchAgentRels();
     };
     const removeAgentRelationship = async (relId: string) => {
@@ -1208,44 +1273,72 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
                         ))}
                     </div>
                 )}
-                {!readOnly && !adding && (
-                    <div style={{ position: 'relative' }}>
-                        <input className="input" placeholder={t("agent.detail.searchMembers")} value={search} onChange={e => setSearch(e.target.value)} style={{ fontSize: '13px' }} />
-                        {searchResults.length > 0 && (
-                            <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, background: 'var(--bg-primary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', marginTop: '4px', maxHeight: '200px', overflowY: 'auto', zIndex: 10, boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
-                                {searchResults.map((m: any) => (
-                                    <div key={m.id} style={{ padding: '8px 12px', cursor: 'pointer', fontSize: '13px', borderBottom: '1px solid var(--border-subtle)' }}
-                                        onClick={() => { setAdding(m); setSearch(''); setSearchResults([]); }}
-                                        onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-elevated)')}
-                                        onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
-                                        <div style={{ fontWeight: 500 }}>{m.name}</div>
-                                        <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
-                                            {m.provider_name && <span style={{ color: 'var(--accent-color)', fontWeight: 500, marginRight: '6px' }}>[{m.provider_name}]</span>}
-                                            {m.department_path} · {m.email}
-                                        </div>
+                {!readOnly && (
+                    <div style={{ border: '1px solid var(--border-subtle)', borderRadius: '8px', padding: '12px', background: 'var(--bg-elevated)' }}>
+                        <div style={{ position: 'relative', marginBottom: '8px' }}>
+                            <input
+                                className="input"
+                                placeholder={t("agent.detail.searchMembers")}
+                                value={search}
+                                onChange={e => setSearch(e.target.value)}
+                                onFocus={() => {
+                                    if (!search.trim() && searchResults.length === 0) {
+                                        loadOrgMembers();
+                                    }
+                                }}
+                                style={{ fontSize: '13px' }}
+                            />
+                            {visibleMemberResults.length > 0 && (
+                                <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, background: 'var(--bg-primary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', marginTop: '4px', maxHeight: '200px', overflowY: 'auto', zIndex: 10, boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
+                                    {visibleMemberResults.map((m: any) => {
+                                        const checked = selectedMemberIds.has(m.id);
+                                        return (
+                                            <div key={m.id} style={{ padding: '8px 12px', cursor: 'pointer', fontSize: '13px', borderBottom: '1px solid var(--border-subtle)', display: 'flex', alignItems: 'flex-start', gap: '8px' }}
+                                                onClick={() => toggleMemberSelection(m)}
+                                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-elevated)')}
+                                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
+                                                <input type="checkbox" checked={checked} readOnly style={{ marginTop: '2px' }} />
+                                                <div style={{ minWidth: 0, flex: 1 }}>
+                                                    <div style={{ fontWeight: 500 }}>{m.name}</div>
+                                                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>
+                                                        {m.provider_name && <span style={{ color: 'var(--accent-color)', fontWeight: 500, marginRight: '6px' }}>[{m.provider_name}]</span>}
+                                                        {m.department_path} · {m.email}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                        {search && visibleMemberResults.length === 0 && (
+                            <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
+                                {t('agent.detail.noSearchResults', 'No available results')}
+                            </div>
+                        )}
+                        {selectedMembers.length > 0 && (
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginBottom: '8px' }}>
+                                {selectedMembers.map((member: any) => (
+                                    <div key={member.id} style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', border: '1px solid var(--border-subtle)', borderRadius: '999px', padding: '6px 10px', background: 'var(--bg-primary)', fontSize: '12px' }}>
+                                        <span>{member.name}</span>
+                                        <button className="btn btn-ghost" type="button" style={{ fontSize: '11px', padding: 0, minWidth: 'auto' }} onClick={() => toggleMemberSelection(member)}>×</button>
                                     </div>
                                 ))}
                             </div>
                         )}
-                    </div>
-                )}
-                {!readOnly && adding && (
-                    <div style={{ border: '1px solid var(--accent-primary)', borderRadius: '8px', padding: '12px', background: 'var(--bg-elevated)' }}>
-                        <div style={{ fontWeight: 600, fontSize: '14px', marginBottom: '8px' }}>
-                            {t('agent.detail.addRelationship')}: {adding.name}
-                            <span style={{ fontSize: '12px', fontWeight: 400, color: 'var(--text-tertiary)', marginLeft: '8px' }}>
-                                ({adding.provider_name ? `[${adding.provider_name}] ` : ''}{adding.department_path} · {adding.email})
-                            </span>
-                        </div>
                         <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
-                            <select className="input" value={relation} onChange={e => setRelation(e.target.value)} style={{ width: '140px', fontSize: '12px' }}>
+                            <select className="input" value={relation} onChange={e => setRelation(e.target.value)} style={{ width: '160px', fontSize: '12px' }}>
                                 {getRelationOptions(t).map((o: any) => <option key={o.value} value={o.value}>{o.label}</option>)}
                             </select>
                         </div>
                         <textarea className="input" placeholder="" value={description} onChange={e => setDescription(e.target.value)} rows={2} style={{ fontSize: '12px', resize: 'vertical', marginBottom: '8px' }} />
                         <div style={{ display: 'flex', gap: '8px' }}>
-                            <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={addRelationship}>{t('common.confirm')}</button>
-                            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => { setAdding(null); setDescription(''); }}>{t('common.cancel')}</button>
+                            <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={addRelationship} disabled={selectedMembers.length === 0}>
+                                {t('common.confirm')} {selectedMembers.length > 0 ? `(${selectedMembers.length})` : ''}
+                            </button>
+                            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={resetHumanDraft}>
+                                {t('common.cancel')}
+                            </button>
                         </div>
                     </div>
                 )}
@@ -1304,24 +1397,64 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
                         ))}
                     </div>
                 )}
-                {!readOnly && !addingAgent && (
-                    <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => setAddingAgent(true)}>+ {t('agent.detail.addRelationship')}</button>
-                )}
-                {!readOnly && addingAgent && (
-                    <div style={{ border: '1px solid rgba(16,185,129,0.5)', borderRadius: '8px', padding: '12px', background: 'var(--bg-elevated)' }}>
+                {!readOnly && (
+                    <div style={{ border: '1px solid rgba(16,185,129,0.3)', borderRadius: '8px', padding: '12px', background: 'var(--bg-elevated)' }}>
+                        <div style={{ position: 'relative', marginBottom: '8px' }}>
+                            <input
+                                className="input"
+                                placeholder={t('agent.detail.searchAgents', '搜索可见数字员工...')}
+                                value={agentSearch}
+                                onChange={e => setAgentSearch(e.target.value)}
+                                style={{ fontSize: '13px' }}
+                            />
+                            {visibleAgentResults.length > 0 && (
+                                <div style={{ position: 'absolute', top: '100%', left: 0, right: 0, background: 'var(--bg-primary)', border: '1px solid var(--border-subtle)', borderRadius: '6px', marginTop: '4px', maxHeight: '200px', overflowY: 'auto', zIndex: 10, boxShadow: '0 4px 12px rgba(0,0,0,0.15)' }}>
+                                    {visibleAgentResults.map((agent: any) => {
+                                        const checked = selectedAgentIds.has(agent.id);
+                                        return (
+                                            <div key={agent.id} style={{ padding: '8px 12px', cursor: 'pointer', fontSize: '13px', borderBottom: '1px solid var(--border-subtle)', display: 'flex', alignItems: 'flex-start', gap: '8px' }}
+                                                onClick={() => toggleAgentSelection(agent)}
+                                                onMouseEnter={e => (e.currentTarget.style.background = 'var(--bg-elevated)')}
+                                                onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}>
+                                                <input type="checkbox" checked={checked} readOnly style={{ marginTop: '2px' }} />
+                                                <div style={{ minWidth: 0, flex: 1 }}>
+                                                    <div style={{ fontWeight: 500 }}>{agent.name}</div>
+                                                    <div style={{ fontSize: '11px', color: 'var(--text-tertiary)' }}>{agent.role_description || 'Agent'}</div>
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                        {agentSearch && visibleAgentResults.length === 0 && (
+                            <div style={{ fontSize: '12px', color: 'var(--text-tertiary)', marginBottom: '8px' }}>
+                                {t('agent.detail.noSearchResults', 'No available results')}
+                            </div>
+                        )}
+                        {selectedAgents.length > 0 && (
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px', marginBottom: '8px' }}>
+                                {selectedAgents.map((agent: any) => (
+                                    <div key={agent.id} style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', border: '1px solid rgba(16,185,129,0.3)', borderRadius: '999px', padding: '6px 10px', background: 'var(--bg-primary)', fontSize: '12px' }}>
+                                        <span>{agent.name}</span>
+                                        <button className="btn btn-ghost" type="button" style={{ fontSize: '11px', padding: 0, minWidth: 'auto' }} onClick={() => toggleAgentSelection(agent)}>×</button>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
                         <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
-                            <select className="input" value={selectedAgentId} onChange={e => setSelectedAgentId(e.target.value)} style={{ flex: 1, minWidth: 0, fontSize: '12px' }}>
-                                <option value="">— Select Agent —</option>
-                                {availableAgents.map((a: any) => <option key={a.id} value={a.id}>{a.name} — {a.role_description || 'Agent'}</option>)}
-                            </select>
-                            <select className="input" value={agentRelation} onChange={e => setAgentRelation(e.target.value)} style={{ width: '150px', flexShrink: 0, fontSize: '12px' }}>
+                            <select className="input" value={agentRelation} onChange={e => setAgentRelation(e.target.value)} style={{ width: '160px', flexShrink: 0, fontSize: '12px' }}>
                                 {getAgentRelationOptions(t).map((o: any) => <option key={o.value} value={o.value}>{o.label}</option>)}
                             </select>
                         </div>
                         <textarea className="input" placeholder="" value={agentDescription} onChange={e => setAgentDescription(e.target.value)} rows={2} style={{ fontSize: '12px', resize: 'vertical', marginBottom: '8px' }} />
                         <div style={{ display: 'flex', gap: '8px' }}>
-                            <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={addAgentRelationship} disabled={!selectedAgentId}>{t('common.confirm')}</button>
-                            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={() => { setAddingAgent(false); setAgentDescription(''); setSelectedAgentId(''); }}>{t('common.cancel')}</button>
+                            <button className="btn btn-primary" style={{ fontSize: '12px' }} onClick={addAgentRelationship} disabled={selectedAgents.length === 0}>
+                                {t('common.confirm')} {selectedAgents.length > 0 ? `(${selectedAgents.length})` : ''}
+                            </button>
+                            <button className="btn btn-secondary" style={{ fontSize: '12px' }} onClick={resetAgentDraft}>
+                                {t('common.cancel')}
+                            </button>
                         </div>
                     </div>
                 )}

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -314,10 +314,13 @@ export default function Layout() {
         const data = await res.json();
         if (data.redirect_url) {
             localStorage.setItem('token', data.access_token);
-            window.location.href = data.redirect_url;
+            const targetUrl = new URL(data.redirect_url, window.location.origin);
+            targetUrl.pathname = '/';
+            targetUrl.hash = '';
+            window.location.href = targetUrl.toString();
         } else if (data.access_token) {
             localStorage.setItem('token', data.access_token);
-            window.location.reload();
+            window.location.href = '/';
         }
     };
 


### PR DESCRIPTION
## Summary
- support multi-select human and agent relationship management with searchable candidate lists
- centralize agent visibility rules and restrict visibility to same-tenant accessible agents only
- rebuild org department/member paths from department hierarchy and add backfill support
- redirect tenant switching to the homepage instead of preserving the current route

## Validation
- PYTHONPATH=backend pytest backend/tests/test_agent_visibility.py -q
- PYTHONPATH=backend pytest backend/tests/test_org_sync_adapter.py -q
- python3 -m py_compile backend/app/core/permissions.py backend/app/api/agents.py backend/app/api/relationships.py backend/app/services/org_sync_adapter.py backend/app/api/enterprise.py backend/app/scripts/backfill_department_paths.py
- npm run build