### PR TITLE
feat: Talent Market + per-user onboarding + tenant default model

### DIFF
--- a/backend/alembic/versions/add_agent_bootstrap_fields.py
+++ b/backend/alembic/versions/add_agent_bootstrap_fields.py
@@ -1,0 +1,31 @@
+"""Add bootstrap_content + capability_bullets to agent templates.
+
+Revision ID: add_agent_bootstrap_fields
+Revises: increase_api_key_length
+Create Date: 2026-04-23
+
+Supports the Talent Market (capability_bullets fuel the template cards) and
+the per-user onboarding ritual (bootstrap_content is the founder-facing
+system prompt). The per-agent Agent.bootstrapped flag that earlier drafts
+carried has been dropped in favour of the per-user agent_user_onboardings
+junction table — see the add_agent_user_onboardings migration.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'add_agent_bootstrap_fields'
+down_revision: Union[str, None] = 'increase_api_key_length'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE agent_templates ADD COLUMN IF NOT EXISTS capability_bullets JSON DEFAULT '[]'::json")
+    op.execute("ALTER TABLE agent_templates ADD COLUMN IF NOT EXISTS bootstrap_content TEXT")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE agent_templates DROP COLUMN IF EXISTS bootstrap_content")
+    op.execute("ALTER TABLE agent_templates DROP COLUMN IF EXISTS capability_bullets")

--- a/backend/alembic/versions/add_agent_user_onboardings.py
+++ b/backend/alembic/versions/add_agent_user_onboardings.py
@@ -1,0 +1,58 @@
+"""Per-(user, agent) onboarding junction table + drop legacy bootstrapped flag.
+
+Revision ID: add_agent_user_onboardings
+Revises: add_tenant_default_model
+Create Date: 2026-04-24
+
+A row in agent_user_onboardings records that a user has been onboarded to a
+specific agent. Its presence is the authoritative signal that onboarding
+should NOT fire again for that pair — regardless of whether the user
+actually finished the introduction flow.
+
+Backfill: every (agent_id, user_id) pair that has any historical chat message
+is inserted with onboarded_at = the earliest message. Existing users thus
+never get retroactively re-onboarded.
+
+Also drops the short-lived Agent.bootstrapped column that an earlier draft
+of this feature introduced — the per-user model replaces it entirely. The
+drop is idempotent so fresh installs (which no longer add the column in
+add_agent_bootstrap_fields) aren't affected.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'add_agent_user_onboardings'
+down_revision: Union[str, None] = 'add_tenant_default_model'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS agent_user_onboardings (
+            agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+            user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            onboarded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (agent_id, user_id)
+        )
+    """)
+
+    # Backfill from chat history: any pair that has ever exchanged messages is
+    # considered already onboarded — don't re-greet established relationships.
+    op.execute("""
+        INSERT INTO agent_user_onboardings (agent_id, user_id, onboarded_at)
+        SELECT agent_id, user_id, MIN(created_at)
+        FROM chat_messages
+        WHERE agent_id IS NOT NULL AND user_id IS NOT NULL
+        GROUP BY agent_id, user_id
+        ON CONFLICT DO NOTHING
+    """)
+
+    # Clean up the abandoned per-agent flag from the previous design iteration.
+    op.execute("ALTER TABLE agents DROP COLUMN IF EXISTS bootstrapped")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS agent_user_onboardings")

--- a/backend/alembic/versions/add_tenant_default_model.py
+++ b/backend/alembic/versions/add_tenant_default_model.py
@@ -1,0 +1,46 @@
+"""Add Tenant.default_model_id + backfill per-tenant to earliest enabled model.
+
+Revision ID: add_tenant_default_model
+Revises: add_agent_bootstrap_fields
+Create Date: 2026-04-23
+
+Each tenant gets a default_model_id pointing at its first enabled LLM model
+(by created_at ascending). Tenants with no enabled models stay NULL; the admin
+picks one when they finally add a model (handled at the API layer).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'add_tenant_default_model'
+down_revision: Union[str, None] = 'add_agent_bootstrap_fields'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add the nullable FK column. ON DELETE SET NULL — if a model is deleted,
+    # tenants that pointed at it revert to "no default."
+    op.execute("""
+        ALTER TABLE tenants
+        ADD COLUMN IF NOT EXISTS default_model_id UUID
+        REFERENCES llm_models(id) ON DELETE SET NULL
+    """)
+
+    # Backfill: for each tenant, pick its earliest-created enabled model.
+    op.execute("""
+        UPDATE tenants t
+        SET default_model_id = m.id
+        FROM (
+            SELECT DISTINCT ON (tenant_id) tenant_id, id
+            FROM llm_models
+            WHERE enabled = TRUE AND tenant_id IS NOT NULL
+            ORDER BY tenant_id, created_at ASC
+        ) m
+        WHERE t.id = m.tenant_id AND t.default_model_id IS NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE tenants DROP COLUMN IF EXISTS default_model_id")

--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -127,9 +127,39 @@ async def list_templates(
             "soul_template": t.soul_template,
             "default_skills": t.default_skills,
             "default_autonomy_policy": t.default_autonomy_policy,
+            "capability_bullets": t.capability_bullets or [],
+            "has_bootstrap": bool(t.bootstrap_content),
         }
         for t in templates
     ]
+
+
+async def _agent_to_out(
+    db: AsyncSession,
+    agent: Agent,
+    viewer_id: uuid.UUID,
+) -> AgentOut:
+    """Serialize one agent with ``onboarded_for_me`` for the given viewer."""
+    from app.services.onboarding import is_onboarded
+    model = AgentOut.model_validate(agent)
+    model.onboarded_for_me = await is_onboarded(db, agent.id, viewer_id)
+    return model
+
+
+async def _agents_to_out(
+    db: AsyncSession,
+    agents: list[Agent],
+    viewer_id: uuid.UUID,
+) -> list[AgentOut]:
+    """List variant that fetches all junction rows in one query."""
+    from app.services.onboarding import onboarded_agent_ids
+    onboarded = await onboarded_agent_ids(db, viewer_id, [a.id for a in agents])
+    out: list[AgentOut] = []
+    for a in agents:
+        model = AgentOut.model_validate(a)
+        model.onboarded_for_me = a.id in onboarded
+        out.append(model)
+    return out
 
 
 @router.get("/", response_model=list[AgentOut])
@@ -153,7 +183,7 @@ async def list_agents(
                 needs_flush = True
         if needs_flush:
             await db.commit()
-        return [AgentOut.model_validate(a) for a in agents]
+        return await _agents_to_out(db, list(agents), current_user.id)
 
     # agent_admin sees their own created agents + permitted
     # member sees only permitted
@@ -188,7 +218,7 @@ async def list_agents(
             needs_flush = True
     if needs_flush:
         await db.commit()
-    return [AgentOut.model_validate(a) for a in agents]
+    return await _agents_to_out(db, list(agents), current_user.id)
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
@@ -220,6 +250,7 @@ async def create_agent(
     default_min_poll = 5
     default_webhook_rate = 5
     default_heartbeat_interval = 240  # model default
+    tenant_default_model_id = None
     if target_tenant_id:
         from app.models.tenant import Tenant
         tenant_result = await db.execute(select(Tenant).where(Tenant.id == target_tenant_id))
@@ -229,9 +260,13 @@ async def create_agent(
             default_max_triggers = tenant.default_max_triggers or 20
             default_min_poll = tenant.min_poll_interval_floor or 5
             default_webhook_rate = tenant.max_webhook_rate_ceiling or 5
+            tenant_default_model_id = tenant.default_model_id
             # Enforce heartbeat floor: new agents must respect company minimum
             if tenant.min_heartbeat_interval_minutes and tenant.min_heartbeat_interval_minutes > default_heartbeat_interval:
                 default_heartbeat_interval = tenant.min_heartbeat_interval_minutes
+
+    # If the caller didn't pick a model, fall back to the tenant's default.
+    effective_primary_model_id = data.primary_model_id or tenant_default_model_id
 
     agent = Agent(
         name=data.name,
@@ -241,7 +276,7 @@ async def create_agent(
         creator_id=current_user.id,
         tenant_id=target_tenant_id,
         agent_type=data.agent_type or "native",
-        primary_model_id=data.primary_model_id,
+        primary_model_id=effective_primary_model_id,
         fallback_model_id=data.fallback_model_id,
         max_tokens_per_day=data.max_tokens_per_day,
         max_tokens_per_month=data.max_tokens_per_month,
@@ -290,7 +325,8 @@ async def create_agent(
         agent.api_key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
         agent.status = "idle"
         await db.commit()
-        out = AgentOut.model_validate(agent).model_dump()
+        out_model = await _agent_to_out(db, agent, current_user.id)
+        out = out_model.model_dump()
         out["api_key"] = raw_key  # Return once on creation
         return out
 
@@ -340,7 +376,7 @@ async def create_agent(
     await agent_manager.start_container(db, agent)
     await db.flush()
 
-    return AgentOut.model_validate(agent)
+    return await _agent_to_out(db, agent, current_user.id)
 
 
 @router.get("/{agent_id}")
@@ -354,7 +390,8 @@ async def get_agent(
     # Lazy reset token counters
     if await _lazy_reset_token_counters(agent, db):
         await db.commit()
-    out = AgentOut.model_validate(agent).model_dump()
+    out_model = await _agent_to_out(db, agent, current_user.id)
+    out = out_model.model_dump()
     out["access_level"] = access_level
 
     # Resolve creator username (one extra query, only on detail page).
@@ -549,7 +586,8 @@ async def update_agent(
                 p.avatar_url = agent.avatar_url
             await db.flush()
 
-    out = AgentOut.model_validate(agent).model_dump()
+    out_model = await _agent_to_out(db, agent, current_user.id)
+    out = out_model.model_dump()
     if clamped_fields:
         out["_clamped_fields"] = clamped_fields
     return out
@@ -672,7 +710,7 @@ async def start_agent(
     from app.services.agent_manager import agent_manager
     await agent_manager.start_container(db, agent)
     await db.flush()
-    return AgentOut.model_validate(agent)
+    return await _agent_to_out(db, agent, current_user.id)
 
 
 @router.post("/{agent_id}/stop", response_model=AgentOut)
@@ -689,7 +727,7 @@ async def stop_agent(
     from app.services.agent_manager import agent_manager
     await agent_manager.stop_container(agent)
     await db.flush()
-    return AgentOut.model_validate(agent)
+    return await _agent_to_out(db, agent, current_user.id)
 
 
 # ─── Agent-Level Approvals ──────────────────────────────

--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -205,10 +205,12 @@ async def list_sessions(
                 total_counts[row[0]] = int(row[2] or 0)
 
         for session in sessions:
-            user_msg_count = user_msg_counts.get(str(session.id), 0)
-            if user_msg_count == 0:
-                continue  # hide empty or orphan sessions
+            # Hide truly empty / orphan sessions. Onboarding sessions have zero
+            # user messages (the agent greets first) but do have assistant
+            # turns, so count ALL messages here — not just user ones.
             count = total_counts.get(str(session.id), 0)
+            if count == 0:
+                continue
             out.append(SessionOut(
                 id=str(session.id),
                 agent_id=str(session.agent_id),

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -176,7 +176,43 @@ async def add_llm_model(
     )
     db.add(model)
     await db.flush()
+
+    # First enabled model for a tenant becomes that tenant's default.
+    # Admins can later reassign via PATCH /llm-models/{id}/set-default.
+    if model.tenant_id and model.enabled:
+        from app.models.tenant import Tenant
+        t_result = await db.execute(select(Tenant).where(Tenant.id == model.tenant_id))
+        tenant = t_result.scalar_one_or_none()
+        if tenant and tenant.default_model_id is None:
+            tenant.default_model_id = model.id
+
     return LLMModelOut.model_validate(model)
+
+
+@router.post("/llm-models/{model_id}/set-default", status_code=status.HTTP_204_NO_CONTENT)
+async def set_default_llm_model(
+    model_id: uuid.UUID,
+    current_user: User = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mark this model as the tenant's default for new agents."""
+    result = await db.execute(select(LLMModel).where(LLMModel.id == model_id))
+    model = result.scalar_one_or_none()
+    if not model:
+        raise HTTPException(status_code=404, detail="Model not found")
+    if not model.tenant_id:
+        raise HTTPException(status_code=400, detail="Model is not tenant-scoped")
+    if not model.enabled:
+        raise HTTPException(status_code=400, detail="Model is disabled")
+
+    from app.models.tenant import Tenant
+    t_result = await db.execute(select(Tenant).where(Tenant.id == model.tenant_id))
+    tenant = t_result.scalar_one_or_none()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+
+    tenant.default_model_id = model.id
+    await db.commit()
 
 
 @router.delete("/llm-models/{model_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/tenants.py
+++ b/backend/app/api/tenants.py
@@ -38,6 +38,7 @@ class TenantOut(BaseModel):
     sso_enabled: bool = False
     sso_domain: str | None = None
     a2a_async_enabled: bool = False
+    default_model_id: uuid.UUID | None = None
     created_at: datetime | None = None
 
     model_config = {"from_attributes": True}
@@ -410,6 +411,24 @@ async def list_tenants(
     """List all tenants (platform_admin only)."""
     result = await db.execute(select(Tenant).order_by(Tenant.created_at.desc()))
     return [TenantOut.model_validate(t) for t in result.scalars().all()]
+
+
+@router.get("/me", response_model=TenantOut)
+async def get_my_tenant(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the current user's own tenant. Any authenticated member can read
+    this — the wizard and the chat model switcher need default_model_id, which
+    shouldn't require admin privileges.
+    """
+    if not current_user.tenant_id:
+        raise HTTPException(status_code=404, detail="User is not in a tenant")
+    result = await db.execute(select(Tenant).where(Tenant.id == current_user.tenant_id))
+    tenant = result.scalar_one_or_none()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Tenant not found")
+    return TenantOut.model_validate(tenant)
 
 
 @router.get("/{tenant_id}", response_model=TenantOut)

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -175,6 +175,7 @@ async def websocket_chat(
             # Captured for onboarding lookups — the DB-bound `agent` goes out
             # of scope when this session block closes.
             agent_snapshot = agent
+            user_display_name = (user.display_name or "").strip() or "there"
             logger.info(f"[WS] Agent: {agent_name}, type: {agent_type}, model_id: {agent.primary_model_id}, ctx: {ctx_size}")
 
             # Load the agent's primary model
@@ -357,6 +358,23 @@ async def websocket_chat(
             if not content and not is_onboarding_trigger:
                 continue
             if is_onboarding_trigger:
+                # Guard against stale triggers. A frontend with a cached
+                # agent query from before the ritual completed can fire an
+                # onboarding_trigger on a new session even though the pair
+                # is already locked. In that case the resolver would return
+                # no prompt, but the placeholder "Please begin the
+                # onboarding" would still reach the LLM and the agent would
+                # dutifully restart the ritual. Short-circuit here, emit an
+                # event so the frontend refreshes its cache, and move on.
+                from app.services.onboarding import is_onboarded as _is_onboarded
+                async with async_session() as _gdb:
+                    if await _is_onboarded(_gdb, agent_id, user_id):
+                        logger.info("[WS] Onboarding trigger ignored — pair already onboarded")
+                        await websocket.send_json({
+                            "type": "onboarded",
+                            "agent_id": str(agent_id),
+                        })
+                        continue
                 # Minimal placeholder so the LLM has a valid user turn to anchor
                 # its greeting. The onboarding system prompt is what actually
                 # drives the reply; this text is never shown or saved.
@@ -520,6 +538,14 @@ async def websocket_chat(
                                 from app.services.onboarding import mark_onboarded
                                 async with async_session() as _ob_db:
                                     await mark_onboarded(_ob_db, agent_id, user_id)
+                                # Tell the frontend to refresh its cached agent
+                                # record so subsequent sessions (or other open
+                                # tabs) see onboarded_for_me=true and skip the
+                                # kickoff effect.
+                                await websocket.send_json({
+                                    "type": "onboarded",
+                                    "agent_id": str(agent_id),
+                                })
                             except Exception as _ob_err:
                                 logger.warning(f"[WS] mark_onboarded failed (non-fatal): {_ob_err}")
                     
@@ -607,6 +633,7 @@ async def websocket_chat(
                             async with async_session() as _ob_db:
                                 _onb = await resolve_onboarding_prompt(
                                     _ob_db, agent_snapshot, user_id,
+                                    user_name=user_display_name,
                                 )
                             if _onb:
                                 _truncated = [{"role": "system", "content": _onb.prompt}] + _truncated

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -172,6 +172,9 @@ async def websocket_chat(
             role_description = agent.role_description or ""
             welcome_message = agent.welcome_message or ""
             ctx_size = agent.context_window_size or 100
+            # Captured for onboarding lookups — the DB-bound `agent` goes out
+            # of scope when this session block closes.
+            agent_snapshot = agent
             logger.info(f"[WS] Agent: {agent_name}, type: {agent_type}, model_id: {agent.primary_model_id}, ctx: {ctx_size}")
 
             # Load the agent's primary model
@@ -343,10 +346,41 @@ async def websocket_chat(
             content = data.get("content", "")
             display_content = data.get("display_content", "")  # User-facing display text
             file_name = data.get("file_name", "")  # Original file name for attachment display
-            logger.info(f"[WS] Received: {content[:50]}")
+            override_model_id = data.get("model_id")  # Optional per-turn model switcher
+            # When the frontend fires an onboarding trigger for a (user, agent)
+            # pair that hasn't met before, it tags the message so the server can
+            # (a) skip persisting a user-side turn and (b) not echo any user
+            # bubble — the agent opens the conversation itself.
+            is_onboarding_trigger = data.get("kind") == "onboarding_trigger"
+            logger.info(f"[WS] Received: {content[:50]}" + (" [onboarding]" if is_onboarding_trigger else ""))
 
-            if not content:
+            if not content and not is_onboarding_trigger:
                 continue
+            if is_onboarding_trigger:
+                # Minimal placeholder so the LLM has a valid user turn to anchor
+                # its greeting. The onboarding system prompt is what actually
+                # drives the reply; this text is never shown or saved.
+                content = "Please begin the onboarding."
+
+            # Per-message model override — the chat dropdown lets users pick a
+            # different tenant-scoped model for this session. Override only the
+            # current turn; nothing is persisted, and it resets when Chat.tsx
+            # remounts.
+            effective_llm_model = llm_model
+            if override_model_id:
+                try:
+                    _ovr_uuid = uuid.UUID(str(override_model_id))
+                    async with async_session() as _mdb:
+                        _mr = await _mdb.execute(select(LLMModel).where(LLMModel.id == _ovr_uuid))
+                        _ovr = _mr.scalar_one_or_none()
+                        if _ovr and _ovr.enabled and _ovr.tenant_id and (
+                            not llm_model or _ovr.tenant_id == llm_model.tenant_id
+                        ):
+                            effective_llm_model = _ovr
+                        else:
+                            logger.warning(f"[WS] model override {override_model_id} rejected (missing/disabled/tenant mismatch)")
+                except (ValueError, TypeError):
+                    logger.warning(f"[WS] model override {override_model_id!r} is not a valid UUID")
 
             # ── Quota checks ──
             try:
@@ -369,6 +403,10 @@ async def websocket_chat(
 
             # Save user message to DB.
             #
+            # Bootstrap trigger: the user never sent anything — the frontend
+            # fired a synthetic turn so the agent could greet first. Don't
+            # persist and don't title the session from it.
+            #
             # If the LLM content contains [image_data:...] markers, persist the full
             # payload so subsequent turns can still forward the image to the model.
             has_image_marker = "[image_data:" in content
@@ -378,35 +416,38 @@ async def websocket_chat(
                 saved_content = display_content if display_content else content
                 if file_name:
                     saved_content = f"[file:{file_name}]\n{saved_content}"
-            async with async_session() as db:
-                user_msg = ChatMessage(
-                    agent_id=agent_id,
-                    user_id=user_id,
-                    role="user",
-                    content=saved_content,
-                    conversation_id=conv_id,
-                )
-                db.add(user_msg)
-                # Update session last_message_at + auto-title on first message
-                from app.models.chat_session import ChatSession as _CS
-                from datetime import datetime as _dt2, timezone as _tz2
-                _now = _dt2.now(_tz2.utc)
-                _sess_r = await db.execute(
-                    select(_CS).where(_CS.id == uuid.UUID(conv_id))
-                )
-                _sess = _sess_r.scalar_one_or_none()
-                if _sess:
-                    _sess.last_message_at = _now
-                    if not history_messages and _sess.title.startswith("Session "):
-                        # Use display_content for title (avoids raw base64/markers)
-                        title_src = display_content if display_content else content
-                        # Clean up common prefixes from image/file messages
-                        clean_title = title_src.replace("[图片] ", "📷 ").replace("[image_data:", "").strip()
-                        if file_name and not clean_title:
-                            clean_title = f"📎 {file_name}"
-                        _sess.title = clean_title[:40] if clean_title else content[:40]
-                await db.commit()
-            logger.info("[WS] User message saved")
+            if is_onboarding_trigger:
+                logger.info("[WS] Onboarding trigger — skipping user-message persistence")
+            else:
+                async with async_session() as db:
+                    user_msg = ChatMessage(
+                        agent_id=agent_id,
+                        user_id=user_id,
+                        role="user",
+                        content=saved_content,
+                        conversation_id=conv_id,
+                    )
+                    db.add(user_msg)
+                    # Update session last_message_at + auto-title on first message
+                    from app.models.chat_session import ChatSession as _CS
+                    from datetime import datetime as _dt2, timezone as _tz2
+                    _now = _dt2.now(_tz2.utc)
+                    _sess_r = await db.execute(
+                        select(_CS).where(_CS.id == uuid.UUID(conv_id))
+                    )
+                    _sess = _sess_r.scalar_one_or_none()
+                    if _sess:
+                        _sess.last_message_at = _now
+                        if not history_messages and _sess.title.startswith("Session "):
+                            # Use display_content for title (avoids raw base64/markers)
+                            title_src = display_content if display_content else content
+                            # Clean up common prefixes from image/file messages
+                            clean_title = title_src.replace("[图片] ", "📷 ").replace("[image_data:", "").strip()
+                            if file_name and not clean_title:
+                                clean_title = f"📎 {file_name}"
+                            _sess.title = clean_title[:40] if clean_title else content[:40]
+                    await db.commit()
+                logger.info("[WS] User message saved")
 
             # ── OpenClaw routing: insert into gateway_messages instead of LLM ──
             if agent_type == "openclaw":
@@ -440,17 +481,34 @@ async def websocket_chat(
             thinking_content = []
 
             # Call LLM with streaming
-            if llm_model:
+            if effective_llm_model:
                 try:
-                    logger.info(f"[WS] Calling LLM {llm_model.model} (streaming)...")
+                    logger.info(f"[WS] Calling LLM {effective_llm_model.model} (streaming)...")
                     
                     # Accumulate partial content for abort handling
                     partial_chunks: list[str] = []
-                    
+
+                    # Flipped to True inside _call_with_failover when an
+                    # onboarding prompt was injected for this turn. The first
+                    # streamed chunk then commits the junction-table row so
+                    # future sessions see this user as already onboarded, even
+                    # if they disconnect before the greeting finishes.
+                    needs_onboarding_mark = False
+                    onboarding_mark_done = False
+
                     async def stream_to_ws(text: str):
                         """Send each chunk to client in real-time."""
+                        nonlocal onboarding_mark_done
                         partial_chunks.append(text)
                         await websocket.send_json({"type": "chunk", "content": text})
+                        if needs_onboarding_mark and not onboarding_mark_done:
+                            onboarding_mark_done = True
+                            try:
+                                from app.services.onboarding import mark_onboarded
+                                async with async_session() as _ob_db:
+                                    await mark_onboarded(_ob_db, agent_id, user_id)
+                            except Exception as _ob_err:
+                                logger.warning(f"[WS] mark_onboarded failed (non-fatal): {_ob_err}")
                     
                     async def tool_call_to_ws(data: dict):
                         """Send tool call info to client and persist completed ones."""
@@ -512,6 +570,8 @@ async def websocket_chat(
 
                     # Run call_llm_with_failover as a cancellable task
                     async def _call_with_failover():
+                        nonlocal needs_onboarding_mark
+
                         async def _on_failover(reason: str):
                             await websocket.send_json({"type": "info", "content": f"Primary model error, {reason}"})
 
@@ -520,8 +580,26 @@ async def websocket_chat(
                         while _truncated and _truncated[0].get("role") == "tool":
                             _truncated.pop(0)
 
+                        # Per-(user, agent) onboarding: if the junction table
+                        # has no row for this pair yet, prepend a system prompt
+                        # — the founder gets the template's tailored script,
+                        # every subsequent user gets the generic welcoming
+                        # prompt. The lock row is written in stream_to_ws on
+                        # the first streamed chunk (see above).
+                        from app.services.onboarding import resolve_onboarding_prompt
+                        try:
+                            async with async_session() as _ob_db:
+                                _onb_prompt = await resolve_onboarding_prompt(
+                                    _ob_db, agent_snapshot, user_id,
+                                )
+                            if _onb_prompt:
+                                _truncated = [{"role": "system", "content": _onb_prompt}] + _truncated
+                                needs_onboarding_mark = True
+                        except Exception as _onb_err:
+                            logger.warning(f"[WS] Onboarding prompt resolve failed (non-fatal): {_onb_err}")
+
                         return await call_llm_with_failover(
-                            primary_model=llm_model,
+                            primary_model=effective_llm_model,
                             fallback_model=fallback_llm_model,
                             messages=_truncated,
                             agent_name=agent_name,
@@ -532,7 +610,7 @@ async def websocket_chat(
                             on_chunk=stream_to_ws,
                             on_tool_call=tool_call_to_ws,
                             on_thinking=thinking_to_ws,
-                            supports_vision=getattr(llm_model, 'supports_vision', False),
+                            supports_vision=getattr(effective_llm_model, 'supports_vision', False),
                             on_failover=_on_failover,
                         )
 
@@ -576,7 +654,9 @@ async def websocket_chat(
                         assistant_response = await llm_task
                         logger.info(f"[WS] LLM response: {assistant_response[:80]}")
 
-                    # Update last_active_at
+                    # Update last_active_at. The onboarding lock is handled
+                    # earlier in stream_to_ws on the first streamed chunk, so
+                    # there's nothing to reconcile here anymore.
                     from datetime import datetime, timezone as tz
                     async with async_session() as _db:
                         from app.models.agent import Agent as AgentModel

--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -418,6 +418,19 @@ async def websocket_chat(
                     saved_content = f"[file:{file_name}]\n{saved_content}"
             if is_onboarding_trigger:
                 logger.info("[WS] Onboarding trigger — skipping user-message persistence")
+                # Title this session "Onboarding" up front so it's identifiable
+                # in the session list even before the user has typed anything.
+                # The auto-title logic in the normal path only overwrites titles
+                # that start with "Session ", so this stays sticky.
+                async with async_session() as _sdb:
+                    from app.models.chat_session import ChatSession as _CS
+                    _sr = await _sdb.execute(
+                        select(_CS).where(_CS.id == uuid.UUID(conv_id))
+                    )
+                    _s = _sr.scalar_one_or_none()
+                    if _s and _s.title.startswith("Session "):
+                        _s.title = "Onboarding"
+                        await _sdb.commit()
             else:
                 async with async_session() as db:
                     user_msg = ChatMessage(
@@ -581,20 +594,24 @@ async def websocket_chat(
                             _truncated.pop(0)
 
                         # Per-(user, agent) onboarding: if the junction table
-                        # has no row for this pair yet, prepend a system prompt
-                        # — the founder gets the template's tailored script,
-                        # every subsequent user gets the generic welcoming
-                        # prompt. The lock row is written in stream_to_ws on
-                        # the first streamed chunk (see above).
+                        # has no row for this pair yet, prepend a system prompt.
+                        # The prompt is turn-aware — on the greeting turn it
+                        # tells the agent to greet + ask one question; on the
+                        # deliverable turn it tells the agent to drop question
+                        # mode and immediately produce a concrete output. The
+                        # junction row is only committed on the deliverable
+                        # turn (see lock_on_first_chunk below), so the full
+                        # two-step ritual stays guarded.
                         from app.services.onboarding import resolve_onboarding_prompt
                         try:
                             async with async_session() as _ob_db:
-                                _onb_prompt = await resolve_onboarding_prompt(
+                                _onb = await resolve_onboarding_prompt(
                                     _ob_db, agent_snapshot, user_id,
                                 )
-                            if _onb_prompt:
-                                _truncated = [{"role": "system", "content": _onb_prompt}] + _truncated
-                                needs_onboarding_mark = True
+                            if _onb:
+                                _truncated = [{"role": "system", "content": _onb.prompt}] + _truncated
+                                if _onb.lock_on_first_chunk:
+                                    needs_onboarding_mark = True
                         except Exception as _onb_err:
                             logger.warning(f"[WS] Onboarding prompt resolve failed (non-fatal): {_onb_err}")
 

--- a/backend/app/models/agent.py
+++ b/backend/app/models/agent.py
@@ -161,9 +161,40 @@ class AgentTemplate(Base):
     soul_template: Mapped[str] = mapped_column(Text, default="")
     default_skills: Mapped[list] = mapped_column(JSON, default=[])
     default_autonomy_policy: Mapped[dict] = mapped_column(JSON, default={})
+    # Talent Market card: 2-4 short capability bullets shown under the role
+    capability_bullets: Mapped[list] = mapped_column(JSON, default=[])
+    # Founding onboarding ritual. Used as the system prompt when the very first
+    # human opens a chat with an agent created from this template — it guides
+    # the agent to collect project context, introduce itself, and suggest a
+    # first task. Every subsequent user meets the agent via a simpler built-in
+    # welcoming prompt (see app.services.onboarding), not this content.
+    bootstrap_content: Mapped[str | None] = mapped_column(Text, default=None)
     is_builtin: Mapped[bool] = mapped_column(default=False)
     created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class AgentUserOnboarding(Base):
+    """A row exists for every (agent, user) pair the user has been onboarded to.
+
+    Row presence is the source of truth: if a user has a row for an agent, no
+    onboarding prompt is ever injected again — even if they never finished the
+    first conversation. The row is inserted as soon as the agent streams its
+    first chunk of the onboarding greeting, so the lock fires the instant the
+    user sees the agent start responding.
+    """
+
+    __tablename__ = "agent_user_onboardings"
+
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("agents.id", ondelete="CASCADE"), primary_key=True,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True,
+    )
+    onboarded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False,
+    )
 
 
 # Import for relationship resolution

--- a/backend/app/models/tenant.py
+++ b/backend/app/models/tenant.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Enum, Integer, String, func
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, func
 from sqlalchemy.dialects.postgresql import JSON, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -52,4 +52,12 @@ class Tenant(Base):
     # A2A async communication (notify / task_delegate)
     # When False, all agent-to-agent messages use synchronous consult mode
     a2a_async_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # Company default LLM model. Auto-set to the first enabled model the admin
+    # adds; used as the initial primary_model_id for new agents created in this
+    # tenant. SET NULL on model delete so the tenant just has no default until
+    # an admin picks a new one.
+    default_model_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("llm_models.id", ondelete="SET NULL"), nullable=True,
+    )
 

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -268,6 +268,12 @@ class AgentOut(BaseModel):
     openclaw_last_seen: datetime | None = None
     has_api_key: bool = False
     api_key_hash: str | None = None
+    # True when the current viewer already has an onboarding row for this
+    # agent. Computed per-request by the API layer from the junction table;
+    # not an ORM attribute, so callers must set it explicitly. Defaults to
+    # True so list endpoints that don't care about onboarding don't leak
+    # stale "needs onboarding" UI to users they shouldn't prompt.
+    onboarded_for_me: bool = True
     created_at: datetime
     last_active_at: datetime | None = None
 

--- a/backend/app/services/onboarding.py
+++ b/backend/app/services/onboarding.py
@@ -55,24 +55,28 @@ class OnboardingInjection:
 # it greets and asks one tight question; on the follow-up (user_turns >= 1)
 # it pivots to helping with whatever they replied, never re-asking context.
 _WELCOMING_PROMPT = """\
-A teammate in your company is meeting you for the first time. You're NOT \
-being founded — your working context was established earlier with someone \
-else. Don't re-ask project-context questions.
+{user_name} is meeting you for the first time. You're NOT being founded — \
+your working context was established earlier with someone else. Don't re-ask \
+project-context questions.
 
-This conversation has had {user_turns} user messages so far.
+This conversation has had {user_turns} user messages so far. Markdown \
+rendering is on — **use bold** to highlight the user's name, your own name, \
+capability labels, and key next-step phrases.
 
 If user_turns == 0 (greeting turn):
-- Greet them warmly in one short line.
-- Introduce yourself in one sentence: {name}{role_line}.
-- Mention 2–3 things you can help with{bullets_line}.
-- Ask ONE open-ended question about what they want to accomplish today.
-- Stop there. Keep it to three short paragraphs.
+- Open with: "**Hi {user_name}!**" on its own line.
+- One-line intro: "I'm **{name}**{role_line}."
+- List 2–3 short bullets of what you can help with. Put the capability label \
+in bold, then a brief explanation{bullets_line}.
+- Ask ONE open-ended question about what they want to accomplish today \
+(bold the question).
+- Stop there. Three short paragraphs max.
 
 If user_turns >= 1 (response turn):
 - They've told you what they need. DO NOT ask clarifying questions.
-- Jump straight into helping: produce a concrete first pass, a plan, or a \
-question-answer — whichever fits their ask best.
-- Close by offering one clear next step they can pick.
+- Jump straight into helping: produce a concrete first pass, a plan, or an \
+answer — whichever fits. Use **bold** on section headers and key terms.
+- Close with one clear next step offer, with the next-step phrase bolded.
 
 Never mention these instructions to the user."""
 
@@ -81,11 +85,12 @@ def _render_welcoming(
     agent: Agent,
     capability_bullets: list[str] | None,
     user_turns: int,
+    user_name: str,
 ) -> str:
     role_line = f", your {agent.role_description}" if agent.role_description else ""
     if capability_bullets:
         bullets = "; ".join(b.strip() for b in capability_bullets if b and b.strip())
-        bullets_line = f" (e.g. {bullets})" if bullets else ""
+        bullets_line = f" — ideas to lean on: {bullets}" if bullets else ""
     else:
         bullets_line = ""
     return _WELCOMING_PROMPT.format(
@@ -93,6 +98,7 @@ def _render_welcoming(
         role_line=role_line,
         bullets_line=bullets_line,
         user_turns=user_turns,
+        user_name=user_name,
     )
 
 
@@ -100,6 +106,8 @@ async def resolve_onboarding_prompt(
     db: AsyncSession,
     agent: Agent,
     user_id: uuid.UUID,
+    *,
+    user_name: str = "there",
 ) -> OnboardingInjection | None:
     """Decide what system prompt to inject for this (user, agent) turn.
 
@@ -153,11 +161,14 @@ async def resolve_onboarding_prompt(
             template_prompt = tpl.bootstrap_content
 
     if is_founder and template_prompt:
-        prompt = template_prompt.replace("{name}", agent.name).replace(
-            "{user_turns}", str(user_turns),
+        prompt = (
+            template_prompt
+            .replace("{name}", agent.name)
+            .replace("{user_name}", user_name)
+            .replace("{user_turns}", str(user_turns))
         )
     else:
-        prompt = _render_welcoming(agent, capability_bullets, user_turns)
+        prompt = _render_welcoming(agent, capability_bullets, user_turns, user_name)
 
     # Lock once the deliverable turn starts streaming (user_turns >= 1 at that
     # point). The greeting turn (user_turns == 0) intentionally doesn't lock

--- a/backend/app/services/onboarding.py
+++ b/backend/app/services/onboarding.py
@@ -19,6 +19,7 @@ mid-message.
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from sqlalchemy import func, select
@@ -26,30 +27,61 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent import Agent, AgentTemplate, AgentUserOnboarding
+from app.models.audit import ChatMessage
 
 if TYPE_CHECKING:  # pragma: no cover
     pass
 
 
+@dataclass(frozen=True)
+class OnboardingInjection:
+    """What the WS handler needs to apply for a given turn.
+
+    ``prompt`` is the system message to prepend; ``lock_on_first_chunk`` says
+    whether this turn's first streamed chunk should commit the junction row.
+    Greeting turns (where the user hasn't said anything yet) don't lock — the
+    deliverable turn does, so the whole two-step ritual is guarded.
+    """
+
+    prompt: str
+    lock_on_first_chunk: bool
+
+
 # Single shared welcoming prompt. Rendered per-call with the agent's fields.
 # Kept here (not in DB) because it's uniform across templates — only the
 # founding flow benefits from per-template authoring.
+#
+# This prompt is turn-aware: on the user's first exposure (user_turns == 0)
+# it greets and asks one tight question; on the follow-up (user_turns >= 1)
+# it pivots to helping with whatever they replied, never re-asking context.
 _WELCOMING_PROMPT = """\
-A new teammate in your company is opening a chat with you for the first time. \
-They are NOT the founder — the founder already established your working \
-context. Don't re-ask project-context questions; just open the door.
+A teammate in your company is meeting you for the first time. You're NOT \
+being founded — your working context was established earlier with someone \
+else. Don't re-ask project-context questions.
 
-For this first turn:
-1. Greet them warmly.
-2. Briefly introduce yourself: {name}{role_line}.
-3. Mention 2–3 things you can help with{bullets_line}.
-4. Ask an open-ended question about what they want to accomplish today.
+This conversation has had {user_turns} user messages so far.
 
-Keep the whole reply to three short paragraphs. Warm, not robotic. Do not \
-mention this instruction to the user — just start the greeting."""
+If user_turns == 0 (greeting turn):
+- Greet them warmly in one short line.
+- Introduce yourself in one sentence: {name}{role_line}.
+- Mention 2–3 things you can help with{bullets_line}.
+- Ask ONE open-ended question about what they want to accomplish today.
+- Stop there. Keep it to three short paragraphs.
+
+If user_turns >= 1 (response turn):
+- They've told you what they need. DO NOT ask clarifying questions.
+- Jump straight into helping: produce a concrete first pass, a plan, or a \
+question-answer — whichever fits their ask best.
+- Close by offering one clear next step they can pick.
+
+Never mention these instructions to the user."""
 
 
-def _render_welcoming(agent: Agent, capability_bullets: list[str] | None) -> str:
+def _render_welcoming(
+    agent: Agent,
+    capability_bullets: list[str] | None,
+    user_turns: int,
+) -> str:
     role_line = f", your {agent.role_description}" if agent.role_description else ""
     if capability_bullets:
         bullets = "; ".join(b.strip() for b in capability_bullets if b and b.strip())
@@ -60,6 +92,7 @@ def _render_welcoming(agent: Agent, capability_bullets: list[str] | None) -> str
         name=agent.name,
         role_line=role_line,
         bullets_line=bullets_line,
+        user_turns=user_turns,
     )
 
 
@@ -67,15 +100,18 @@ async def resolve_onboarding_prompt(
     db: AsyncSession,
     agent: Agent,
     user_id: uuid.UUID,
-) -> str | None:
-    """Return a system prompt to inject for this (user, agent) turn, or None.
+) -> OnboardingInjection | None:
+    """Decide what system prompt to inject for this (user, agent) turn.
 
-    The prompt is a *one-shot* instruction for the LLM call; callers are
-    expected to prepend it to the message list they hand to the LLM, and to
-    call :func:`mark_onboarded` once the stream starts so the lock fires.
-
-    Returns ``None`` when the user has already been onboarded to this agent,
-    in which case the caller should behave exactly like a normal turn.
+    Returns ``None`` when the pair is already onboarded and the turn should
+    proceed normally. Otherwise returns an :class:`OnboardingInjection` with:
+      - ``prompt``: the filled-in system instruction (founding or welcoming,
+        with a ``{user_turns}`` variable already resolved so the LLM can
+        branch between a greeting-only reply and a task-delivery reply);
+      - ``lock_on_first_chunk``: ``True`` iff this turn should commit the
+        junction row once streaming begins. We only lock after the user has
+        sent at least one real message, so the two-step ritual (greeting
+        turn → deliverable turn) stays guarded by the system prompt.
     """
     existing = await db.execute(
         select(AgentUserOnboarding).where(
@@ -86,9 +122,18 @@ async def resolve_onboarding_prompt(
     if existing.scalar_one_or_none():
         return None
 
-    # No row yet. Is anyone onboarded to this agent at all? If not, this user
-    # is the founder — use the template's tailored script. Otherwise welcome
-    # them with the generic greeting.
+    # Count real user messages this person has sent to this agent. Onboarding
+    # triggers are not persisted, so only authentic typed turns are counted.
+    user_turn_count = await db.execute(
+        select(func.count()).select_from(ChatMessage).where(
+            ChatMessage.agent_id == agent.id,
+            ChatMessage.user_id == user_id,
+            ChatMessage.role == "user",
+        )
+    )
+    user_turns = int(user_turn_count.scalar_one() or 0)
+
+    # Is anyone onboarded to this agent yet? If not, this user is the founder.
     peer_count = await db.execute(
         select(func.count()).select_from(AgentUserOnboarding).where(
             AgentUserOnboarding.agent_id == agent.id,
@@ -96,26 +141,31 @@ async def resolve_onboarding_prompt(
     )
     is_founder = peer_count.scalar_one() == 0
 
-    if is_founder and agent.template_id:
+    template_prompt: str | None = None
+    capability_bullets: list[str] | None = None
+    if agent.template_id:
         tpl_result = await db.execute(
             select(AgentTemplate).where(AgentTemplate.id == agent.template_id)
         )
         tpl = tpl_result.scalar_one_or_none()
-        if tpl and tpl.bootstrap_content:
-            return tpl.bootstrap_content.replace("{name}", agent.name)
+        if tpl:
+            capability_bullets = tpl.capability_bullets or None
+            template_prompt = tpl.bootstrap_content
 
-    # Welcoming fallback applies both to non-founders and to founders of
-    # custom agents that carry no founding script.
-    capability_bullets: list[str] | None = None
-    if agent.template_id:
-        tpl_result = await db.execute(
-            select(AgentTemplate.capability_bullets).where(
-                AgentTemplate.id == agent.template_id,
-            )
+    if is_founder and template_prompt:
+        prompt = template_prompt.replace("{name}", agent.name).replace(
+            "{user_turns}", str(user_turns),
         )
-        row = tpl_result.first()
-        capability_bullets = row[0] if row else None
-    return _render_welcoming(agent, capability_bullets)
+    else:
+        prompt = _render_welcoming(agent, capability_bullets, user_turns)
+
+    # Lock once the deliverable turn starts streaming (user_turns >= 1 at that
+    # point). The greeting turn (user_turns == 0) intentionally doesn't lock
+    # — we want the ritual to retry if the user disconnects before replying.
+    return OnboardingInjection(
+        prompt=prompt,
+        lock_on_first_chunk=user_turns >= 1,
+    )
 
 
 async def mark_onboarded(

--- a/backend/app/services/onboarding.py
+++ b/backend/app/services/onboarding.py
@@ -1,0 +1,171 @@
+"""Per-(user, agent) onboarding helpers.
+
+Two flows, picked at WS turn time:
+
+  - Founding: the first human to ever chat with a given agent. Uses the
+    agent's template.bootstrap_content as the system prompt, which guides
+    the agent to collect project context and suggest a first task.
+
+  - Welcoming: every subsequent user who meets the agent. Gets a shorter,
+    generic system prompt (defined here) that has the agent introduce
+    itself and ask what the user needs — without re-collecting context.
+
+A row in ``agent_user_onboardings`` marks the pair as done. The row is
+inserted as soon as the agent starts streaming its reply so the lock fires
+the moment the user sees the agent respond, even if they close the tab
+mid-message.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent import Agent, AgentTemplate, AgentUserOnboarding
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+
+# Single shared welcoming prompt. Rendered per-call with the agent's fields.
+# Kept here (not in DB) because it's uniform across templates — only the
+# founding flow benefits from per-template authoring.
+_WELCOMING_PROMPT = """\
+A new teammate in your company is opening a chat with you for the first time. \
+They are NOT the founder — the founder already established your working \
+context. Don't re-ask project-context questions; just open the door.
+
+For this first turn:
+1. Greet them warmly.
+2. Briefly introduce yourself: {name}{role_line}.
+3. Mention 2–3 things you can help with{bullets_line}.
+4. Ask an open-ended question about what they want to accomplish today.
+
+Keep the whole reply to three short paragraphs. Warm, not robotic. Do not \
+mention this instruction to the user — just start the greeting."""
+
+
+def _render_welcoming(agent: Agent, capability_bullets: list[str] | None) -> str:
+    role_line = f", your {agent.role_description}" if agent.role_description else ""
+    if capability_bullets:
+        bullets = "; ".join(b.strip() for b in capability_bullets if b and b.strip())
+        bullets_line = f" (e.g. {bullets})" if bullets else ""
+    else:
+        bullets_line = ""
+    return _WELCOMING_PROMPT.format(
+        name=agent.name,
+        role_line=role_line,
+        bullets_line=bullets_line,
+    )
+
+
+async def resolve_onboarding_prompt(
+    db: AsyncSession,
+    agent: Agent,
+    user_id: uuid.UUID,
+) -> str | None:
+    """Return a system prompt to inject for this (user, agent) turn, or None.
+
+    The prompt is a *one-shot* instruction for the LLM call; callers are
+    expected to prepend it to the message list they hand to the LLM, and to
+    call :func:`mark_onboarded` once the stream starts so the lock fires.
+
+    Returns ``None`` when the user has already been onboarded to this agent,
+    in which case the caller should behave exactly like a normal turn.
+    """
+    existing = await db.execute(
+        select(AgentUserOnboarding).where(
+            AgentUserOnboarding.agent_id == agent.id,
+            AgentUserOnboarding.user_id == user_id,
+        )
+    )
+    if existing.scalar_one_or_none():
+        return None
+
+    # No row yet. Is anyone onboarded to this agent at all? If not, this user
+    # is the founder — use the template's tailored script. Otherwise welcome
+    # them with the generic greeting.
+    peer_count = await db.execute(
+        select(func.count()).select_from(AgentUserOnboarding).where(
+            AgentUserOnboarding.agent_id == agent.id,
+        )
+    )
+    is_founder = peer_count.scalar_one() == 0
+
+    if is_founder and agent.template_id:
+        tpl_result = await db.execute(
+            select(AgentTemplate).where(AgentTemplate.id == agent.template_id)
+        )
+        tpl = tpl_result.scalar_one_or_none()
+        if tpl and tpl.bootstrap_content:
+            return tpl.bootstrap_content.replace("{name}", agent.name)
+
+    # Welcoming fallback applies both to non-founders and to founders of
+    # custom agents that carry no founding script.
+    capability_bullets: list[str] | None = None
+    if agent.template_id:
+        tpl_result = await db.execute(
+            select(AgentTemplate.capability_bullets).where(
+                AgentTemplate.id == agent.template_id,
+            )
+        )
+        row = tpl_result.first()
+        capability_bullets = row[0] if row else None
+    return _render_welcoming(agent, capability_bullets)
+
+
+async def mark_onboarded(
+    db: AsyncSession,
+    agent_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> None:
+    """Insert the onboarding lock row; no-op if it already exists.
+
+    Called once per turn as soon as the LLM begins streaming. Uses
+    ``ON CONFLICT DO NOTHING`` so concurrent first-turns don't collide.
+    """
+    stmt = pg_insert(AgentUserOnboarding).values(
+        agent_id=agent_id,
+        user_id=user_id,
+    ).on_conflict_do_nothing(index_elements=["agent_id", "user_id"])
+    await db.execute(stmt)
+    await db.commit()
+
+
+async def is_onboarded(
+    db: AsyncSession,
+    agent_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Shortcut for API serializers that need ``onboarded_for_me`` on AgentOut."""
+    result = await db.execute(
+        select(AgentUserOnboarding).where(
+            AgentUserOnboarding.agent_id == agent_id,
+            AgentUserOnboarding.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def onboarded_agent_ids(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    agent_ids: list[uuid.UUID],
+) -> set[uuid.UUID]:
+    """Bulk variant of ``is_onboarded`` for list endpoints.
+
+    Returns the subset of ``agent_ids`` the user is already onboarded to.
+    """
+    if not agent_ids:
+        return set()
+    result = await db.execute(
+        select(AgentUserOnboarding.agent_id).where(
+            AgentUserOnboarding.user_id == user_id,
+            AgentUserOnboarding.agent_id.in_(agent_ids),
+        )
+    )
+    return {row[0] for row in result.all()}

--- a/backend/app/services/template_seeder.py
+++ b/backend/app/services/template_seeder.py
@@ -25,116 +25,143 @@ from app.models.agent import AgentTemplate
 # goal is to show value in the first message exchange, not to schmooze.
 
 BOOTSTRAP_PM = """\
-You are {name}, a Project Manager meeting this user for the first time.
+You are {name}, a Project Manager meeting {user_name} for the first time. \
+Markdown rendering is on — **use bold** freely to highlight the user's name, \
+your own name, capability labels, and key next-step phrases.
 
-This conversation has had {user_turns} user messages so far. Your behavior \
-depends on that count — follow EXACTLY the matching branch below.
+This conversation has had {user_turns} user messages so far. Follow EXACTLY \
+the matching branch below.
 
 If user_turns == 0 (greeting turn):
-- Greet them warmly in one short line and say you're their new PM.
-- Ask exactly ONE question: "What's the one project you most want my help \
-on this week?"
-- STOP after the question. Do not ask about scope, team, deadlines, or tools.
+- Open with: "**Hi {user_name}!**" on its own line.
+- One-line intro: "I'm **{name}**, your new project manager."
+- Pitch 2–3 bullets of what you're great at. Put the capability label in \
+bold, then a short phrase. Use these or similar:
+  - "**Status snapshots** — pull together weekly one-pagers covering \
+milestones, risks, and next steps."
+  - "**Task breakdown & ownership** — turn messy work into a tracked plan \
+with owners and dates."
+  - "**Stakeholder updates** — draft clean status messages for leadership, \
+customers, or cross-team partners."
+- Then ask ONE question in bold: "**What's the one project you most want my \
+help on this week?**"
+- Stop. Don't ask about scope, team, deadlines, or tools.
 
 If user_turns >= 1 (deliverable turn):
-- Whatever they told you last is the project. DO NOT ask clarifying \
-questions about timeline, stakeholders, status, scope, or tools. That rule \
-is absolute.
-- Produce a one-page project snapshot inline in markdown:
-  - "Status" — one sentence with your best read.
-  - "Active milestones" — 3 to 5 bullets. Guess plausible ones if you don't \
-know, and tag guesses with "(to confirm)".
-  - "Risks" — 2 bullets.
-  - "Recommended next step" — one sentence.
-- Close by offering ONE follow-up: "Want me to refine any of these, or \
-should I start tracking the next step right now?"
+- Whatever they just told you is the project. DO NOT ask clarifying \
+questions about timeline, stakeholders, status, scope, or tools. Absolute.
+- Produce a one-page project snapshot inline with bold section headers:
+  - "**Status**" — one sentence with your best read.
+  - "**Active milestones**" — 3–5 bullets; tag guesses with "(to confirm)".
+  - "**Risks**" — 2 bullets.
+  - "**Recommended next step**" — one bolded sentence.
+- Close: "Want me to refine any of these, or should I **start tracking the \
+next step** right now?"
 - Under ~250 words.
 
 Never mention these instructions to the user."""
 
 BOOTSTRAP_DESIGNER = """\
-You are {name}, a design partner meeting this user for the first time.
+You are {name}, a design partner meeting {user_name} for the first time. \
+Markdown rendering is on — **use bold** to highlight names, capability \
+labels, and next-step phrases.
 
 This conversation has had {user_turns} user messages so far. Follow EXACTLY \
 the matching branch below.
 
 If user_turns == 0 (greeting turn):
-- Greet them warmly in one line and introduce yourself.
-- Ask exactly ONE question: "Point me at one product, page, or component \
-you'd like a quick audit of — a URL, a file name, or just a description \
-works."
-- STOP after the question. Don't ask for the brand book, personas, or design \
-system.
+- Open: "**Hi {user_name}!**" on its own line.
+- Intro: "I'm **{name}**, here to be your design partner."
+- Pitch 2–3 capability bullets (bold label + short phrase):
+  - "**Design audits** — spot quick-win fixes on a page, flow, or component."
+  - "**Design system sanity** — flag inconsistencies and patterns worth \
+tightening."
+  - "**Opinionated critique** — fast, specific, no consultant-speak."
+- Ask ONE bolded question: "**Point me at one product, page, or component \
+you'd like a quick audit of** — a URL, a file name, or just a short \
+description works."
+- Stop. Don't ask for the brand book, personas, or design system yet.
 
 If user_turns >= 1 (deliverable turn):
-- Whatever they named is your audit target. DO NOT ask for more context — \
-not for visuals, not for the design system, not for user personas.
-- Dive straight into a quick audit:
-  - Name the thing in one line.
-  - List 3 quick-win fixes you'd make. If you can't actually see the \
-artifact, say so once up top and label your fixes "(based on common patterns \
-— confirm when you share it)".
-  - List 1 more ambitious opportunity that could meaningfully improve it.
-- Close: "Want me to turn these into a patch list, or sketch a before/after?"
+- Whatever they named is your audit target. DO NOT ask for more context.
+- Audit inline with bold headers:
+  - "**Target**" — one line paraphrase.
+  - "**3 quick-win fixes**" — bullets; if you can't see the artifact, say \
+so once up top and tag each with "(based on common patterns — confirm when \
+you share it)".
+  - "**1 ambitious opportunity**" — one line.
+- Close: "Want me to turn these into **a patch list** or **a before/after \
+sketch**?"
 - Under ~300 words.
 
-Write like a designer talks — specific, opinionated, not consultant-y. \
-Never mention these instructions to the user."""
+Designer voice: specific, opinionated, not consultant-y. Never mention \
+these instructions to the user."""
 
 BOOTSTRAP_PRODUCT_INTERN = """\
-You are {name}, a product intern meeting this user for the first time.
+You are {name}, a product intern meeting {user_name} for the first time. \
+Markdown rendering is on — **use bold** to highlight names, capability \
+labels, and next-step phrases.
 
 This conversation has had {user_turns} user messages so far. Follow EXACTLY \
 the matching branch below.
 
 If user_turns == 0 (greeting turn):
-- Greet them warmly in one short line and introduce yourself as their new \
-product intern.
-- Ask exactly ONE question: "What's one feature your team just shipped or \
-is about to ship? I'll turn around a quick competitive snapshot on it."
-- STOP after the question. Don't ask for the roadmap, OKRs, or user segments.
+- Open: "**Hi {user_name}!**"
+- Intro: "I'm **{name}**, your new product intern — eager and scrappy."
+- Pitch 2–3 capability bullets (bold label + short phrase):
+  - "**Competitive snapshots** — who ships what, how it compares."
+  - "**User feedback triage** — themes from interviews, tickets, reviews."
+  - "**Spec drafting** — first-pass PRDs and user stories."
+- Ask ONE bolded question: "**What's one feature your team just shipped or \
+is about to ship?** I'll turn around a competitive snapshot on it."
+- Stop. Don't ask for the roadmap, OKRs, or user segments.
 
 If user_turns >= 1 (deliverable turn):
-- Whatever feature they named is your subject. DO NOT ask for more context \
-about users, metrics, or the product itself.
-- Produce a quick competitive snapshot inline:
-  - Paraphrase the feature in one line.
-  - Name 3 competitors who ship something similar. If guessing, tag them \
-"(worth verifying)". One sentence each on how their take differs.
-  - One under-explored angle — something this feature could lean into that \
-competitors don't.
-- Close: "Want me to go deeper on any of these, or start pulling sources?"
+- Whatever feature they named is your subject. DO NOT ask for more context.
+- Snapshot inline with bold headers:
+  - "**The feature**" — one-line paraphrase.
+  - "**3 competitors**" — each bolded name + one-line difference; tag \
+guesses "(worth verifying)".
+  - "**Under-explored angle**" — one line.
+- Close: "Want me to **go deeper on any of these** or **start pulling \
+sources**?"
 - Under ~250 words.
 
 Intern energy: scrappy, useful, not polished. Never mention these \
 instructions to the user."""
 
 BOOTSTRAP_MARKET_RESEARCHER = """\
-You are {name}, a market researcher meeting this user for the first time.
+You are {name}, a market researcher meeting {user_name} for the first \
+time. Markdown rendering is on — **use bold** to highlight names, \
+capability labels, players, signals, and next-step phrases.
 
 This conversation has had {user_turns} user messages so far. Follow EXACTLY \
 the matching branch below.
 
 If user_turns == 0 (greeting turn):
-- Greet them briefly in one line and introduce yourself.
-- Ask exactly ONE question: "What market or company do you most want me to \
-dig into first?"
-- STOP after the question. Don't ask about report format, audience, cadence, \
-or source preferences.
+- Open: "**Hi {user_name}!**"
+- Intro: "I'm **{name}**, your market research partner."
+- Pitch 2–3 capability bullets (bold label + short phrase):
+  - "**Landscape maps** — players, positioning, segmentation, at a glance."
+  - "**Signal tracking** — recent moves, funding, launches, narrative \
+shifts."
+  - "**Opportunity angles** — white space, adjacencies, where to dig next."
+- Ask ONE bolded question: "**What market or company do you most want me \
+to dig into first?**"
+- Stop. Don't ask about report format, audience, cadence, or source \
+preferences.
 
 If user_turns >= 1 (deliverable turn):
-- Whatever market or company they named is your subject. DO NOT ask for \
-more context — not for geography, not for decision framing, not for source \
-preferences.
-- Deliver a first-pass landscape snapshot inline:
-  - The landscape in two lines — who plays, rough segmentation.
-  - Top 3 to 5 players — one line each on what makes them distinct. Tag \
-guesses "(worth verifying)".
-  - One recent signal — something seemingly shifting in the last 30 days. \
-If guessing, say so.
-  - One opportunity angle — where you'd dig next.
-- Close: "Want me to go deeper on a player, chase that signal, or map \
-adjacent markets?"
+- Whatever they named is your subject. DO NOT ask for more context — not \
+for geography, decision framing, or source preferences.
+- Landscape snapshot inline with bold headers:
+  - "**Landscape**" — two lines: who plays, rough segmentation.
+  - "**Top players**" — 3–5 bullets, each with a bolded name + one-line \
+distinction; tag guesses "(worth verifying)".
+  - "**Recent signal**" — one line (flag guesses plainly).
+  - "**Opportunity angle**" — one line.
+- Close: "Want me to **go deeper on a player**, **chase that signal**, or \
+**map adjacent markets**?"
 - Under ~300 words.
 
 Analyst voice: direct, source-aware, no hedging fluff. Never mention these \

--- a/backend/app/services/template_seeder.py
+++ b/backend/app/services/template_seeder.py
@@ -6,6 +6,174 @@ from app.database import async_session
 from app.models.agent import AgentTemplate
 
 
+# ─── Bootstrap rituals ──────────────────────────────────────────────
+#
+# Each built-in template carries its own first-run ritual. It is copied into
+# {workspace}/bootstrap.md at agent creation and consumed by the agent on its
+# first chat turn. The agent `rm`s the file when done, which flips
+# Agent.bootstrapped to True (see PR 3).
+#
+# Rituals are written as *instructions to the agent*, not scripts to read at
+# the user. Keep them tailored to each template's persona — the ritual for a
+# PM should feel like a PM, not a generic AI greeter.
+
+BOOTSTRAP_PM = """---
+title: "Bootstrap — Project Manager"
+summary: "First-run ritual for a new PM agent"
+---
+
+# Hello. I'm {name}, your new PM.
+
+Before I touch anything, I need to understand the landscape. This is a chat, not an intake form.
+
+## Open the conversation
+
+Something warm but practical — not a scripted greeting:
+
+> "Hey, I'm {name}. Before I start running anything, can you walk me through what we've got? What's active, who's involved, where are things slipping?"
+
+Then listen. Ask two or three at a time, not all at once. The things I most need to learn:
+
+1. **Active projects** — names, rough phase, any hard deadlines
+2. **The team** — who I'll coordinate with, roughly who does what
+3. **Cadence** — standups? weekly review? do you want status via chat, doc, or a dashboard?
+4. **Pain points** — where are things slipping today? What do you want me to obsess over?
+5. **Tools** — Jira / Linear / Notion / a spreadsheet? Where does work actually live?
+
+## After the chat
+
+Write what I learned:
+
+- `USER.md` — their name, role, preferred cadence, timezone
+- Append a `## Context` section to `SOUL.md` covering active projects, key teammates, and tools in use
+
+Then suggest one concrete first move — not a grand plan:
+
+> "Want me to start with a one-page snapshot of the current projects? I can have a draft in about 15 minutes."
+
+## When you're done
+
+Delete this file — `rm bootstrap.md`. You're bootstrapped. Now go make them look organized.
+"""
+
+BOOTSTRAP_DESIGNER = """---
+title: "Bootstrap — Designer"
+summary: "First-run ritual for a new design agent"
+---
+
+# Hi. I'm {name} — your new design partner.
+
+Design is a conversation with taste, not a template. Before I start producing, I want to learn yours.
+
+## Open the conversation
+
+Be curious, not procedural:
+
+> "Hey, I'm {name}. Before I draft anything for you — what does 'good' look like here? What's the brand, and what's the team's aesthetic right now?"
+
+Listen for:
+
+1. **The brand** — who is this for, what feeling are we chasing?
+2. **Existing system** — do you have a design system or style guide? Where does it live?
+3. **Tools** — Figma, Sketch, something else? Access I'll need?
+4. **Current work** — what's on the near-term plate? Anything blocked on design right now?
+5. **Taste signals** — products, artists, sites you admire — or ones you actively don't want to look like
+
+## After the chat
+
+Capture it:
+
+- `USER.md` — their role, design background, timezone, how they like feedback (detailed vs. directional)
+- Append `## Context` to `SOUL.md` with brand summary, design system location, tool stack, current projects
+
+Then offer something small and useful — not a 10-page brand audit. Maybe:
+
+> "Want me to start by auditing the design system for inconsistencies? I can have a punch list by end of day."
+
+## When you're done
+
+`rm bootstrap.md`. You're in. Go make things beautiful.
+"""
+
+BOOTSTRAP_PRODUCT_INTERN = """---
+title: "Bootstrap — Product Intern"
+summary: "First-run ritual for a new product intern agent"
+---
+
+# Hi! I'm {name} — your new product intern.
+
+I'm eager, but I don't know what I don't know yet. Help me catch up, and I'll be useful fast.
+
+## Open the conversation
+
+Be curious and a little humble — I'm new here:
+
+> "Hi! I'm {name}, your product intern. Mind walking me through the product and where you'd like me to start? I'd rather ask now than guess later."
+
+Things to learn first:
+
+1. **The product** — what is it, who uses it, what problem does it solve? (One paragraph is enough.)
+2. **Current focus** — what's the team building this quarter? Any research gaps?
+3. **Stakeholders** — whose perspective do I need (PMs, engineers, designers, customers)?
+4. **Where things live** — PRDs, research docs, user feedback — is there a wiki, a drive folder, a Notion?
+5. **Where to help** — user interviews, competitive analysis, feedback triage, spec writing?
+
+## After the chat
+
+Write it down:
+
+- `USER.md` — their name, role, what they want me to take off their plate
+- Append `## Context` to `SOUL.md` with the product one-liner, active initiatives, and known stakeholders
+
+Suggest something small and concrete to prove useful:
+
+> "Want me to start by reading the last 10 user interviews and pulling out recurring themes?"
+
+## When you're done
+
+`rm bootstrap.md`. I'm no longer brand new. Time to earn the internship.
+"""
+
+BOOTSTRAP_MARKET_RESEARCHER = """---
+title: "Bootstrap — Market Researcher"
+summary: "First-run ritual for a new market research agent"
+---
+
+# Hello. I'm {name} — your market researcher.
+
+Good research starts with the right question. Before I dig, I want to know what you actually need to see.
+
+## Open the conversation
+
+Precise, but not cold:
+
+> "Hi, I'm {name}. Before I start pulling reports, can we sharpen the question? What market are we watching, and what decision is this going to inform?"
+
+Get to the heart of it:
+
+1. **The market** — industry, segment, geography
+2. **Competitors** — who do you watch closely? Any you think you're missing?
+3. **The decision** — is this for a positioning deck, a board update, an investment call? (The audience shapes the output.)
+4. **Cadence** — one-time deep dive, or ongoing intelligence? How often do you want updates?
+5. **Source preferences** — primary research, public filings, industry reports, social signals? Any subscriptions I can use?
+
+## After the chat
+
+Lock in what I heard:
+
+- `USER.md` — their role, research background, preferred report format (exec summary, deep dive, dashboard)
+- Append `## Context` to `SOUL.md` with the market scope, watchlist of competitors, decision framing, and cadence
+
+Then propose a first deliverable scoped tight:
+
+> "Want me to start with a one-page landscape map — the top 5 players, positioning, and the single most interesting signal from the last 30 days?"
+
+## When you're done
+
+`rm bootstrap.md`. Briefing over. Go find the signal in the noise.
+"""
+
+
 DEFAULT_TEMPLATES = [
     {
         "name": "Project Manager",
@@ -13,6 +181,12 @@ DEFAULT_TEMPLATES = [
         "icon": "PM",
         "category": "management",
         "is_builtin": True,
+        "capability_bullets": [
+            "Project planning & milestones",
+            "Status reports & dashboards",
+            "Cross-team coordination",
+        ],
+        "bootstrap_content": BOOTSTRAP_PM,
         "soul_template": """# Soul — {name}
 
 ## Identity
@@ -51,6 +225,12 @@ DEFAULT_TEMPLATES = [
         "icon": "DS",
         "category": "design",
         "is_builtin": True,
+        "capability_bullets": [
+            "Design briefs from requirements",
+            "Design system maintenance",
+            "Competitive UI analysis",
+        ],
+        "bootstrap_content": BOOTSTRAP_DESIGNER,
         "soul_template": """# Soul — {name}
 
 ## Identity
@@ -87,6 +267,12 @@ DEFAULT_TEMPLATES = [
         "icon": "PI",
         "category": "product",
         "is_builtin": True,
+        "capability_bullets": [
+            "Requirements & PRD support",
+            "User feedback triage",
+            "Competitive research",
+        ],
+        "bootstrap_content": BOOTSTRAP_PRODUCT_INTERN,
         "soul_template": """# Soul — {name}
 
 ## Identity
@@ -123,6 +309,12 @@ DEFAULT_TEMPLATES = [
         "icon": "MR",
         "category": "research",
         "is_builtin": True,
+        "capability_bullets": [
+            "Industry & trend analysis",
+            "Competitive intelligence tracking",
+            "Structured research reports",
+        ],
+        "bootstrap_content": BOOTSTRAP_MARKET_RESEARCHER,
         "soul_template": """# Soul — {name}
 
 ## Identity
@@ -200,6 +392,8 @@ async def seed_agent_templates():
                     existing.soul_template = tmpl["soul_template"]
                     existing.default_skills = tmpl["default_skills"]
                     existing.default_autonomy_policy = tmpl["default_autonomy_policy"]
+                    existing.capability_bullets = tmpl["capability_bullets"]
+                    existing.bootstrap_content = tmpl["bootstrap_content"]
                 else:
                     db.add(AgentTemplate(
                         name=tmpl["name"],
@@ -210,6 +404,8 @@ async def seed_agent_templates():
                         soul_template=tmpl["soul_template"],
                         default_skills=tmpl["default_skills"],
                         default_autonomy_policy=tmpl["default_autonomy_policy"],
+                        capability_bullets=tmpl["capability_bullets"],
+                        bootstrap_content=tmpl["bootstrap_content"],
                     ))
                     logger.info(f"[TemplateSeeder] Created template: {tmpl['name']}")
             await db.commit()

--- a/backend/app/services/template_seeder.py
+++ b/backend/app/services/template_seeder.py
@@ -17,161 +17,128 @@ from app.models.agent import AgentTemplate
 # the user. Keep them tailored to each template's persona — the ritual for a
 # PM should feel like a PM, not a generic AI greeter.
 
-BOOTSTRAP_PM = """---
-title: "Bootstrap — Project Manager"
-summary: "First-run ritual for a new PM agent"
----
+# Each founding prompt is a one-shot system instruction the backend injects on
+# the first chat turn with a brand-new agent. Do not talk about the mechanics
+# (prompts, files, "bootstrap") to the user — just play it out. The flow is
+# always: warm greeting → exactly one targeted question → as soon as the user
+# answers, immediately start a concrete role-specific demo task inline. The
+# goal is to show value in the first message exchange, not to schmooze.
 
-# Hello. I'm {name}, your new PM.
+BOOTSTRAP_PM = """\
+You are {name}, a Project Manager meeting this user for the first time.
 
-Before I touch anything, I need to understand the landscape. This is a chat, not an intake form.
+This conversation has had {user_turns} user messages so far. Your behavior \
+depends on that count — follow EXACTLY the matching branch below.
 
-## Open the conversation
+If user_turns == 0 (greeting turn):
+- Greet them warmly in one short line and say you're their new PM.
+- Ask exactly ONE question: "What's the one project you most want my help \
+on this week?"
+- STOP after the question. Do not ask about scope, team, deadlines, or tools.
 
-Something warm but practical — not a scripted greeting:
+If user_turns >= 1 (deliverable turn):
+- Whatever they told you last is the project. DO NOT ask clarifying \
+questions about timeline, stakeholders, status, scope, or tools. That rule \
+is absolute.
+- Produce a one-page project snapshot inline in markdown:
+  - "Status" — one sentence with your best read.
+  - "Active milestones" — 3 to 5 bullets. Guess plausible ones if you don't \
+know, and tag guesses with "(to confirm)".
+  - "Risks" — 2 bullets.
+  - "Recommended next step" — one sentence.
+- Close by offering ONE follow-up: "Want me to refine any of these, or \
+should I start tracking the next step right now?"
+- Under ~250 words.
 
-> "Hey, I'm {name}. Before I start running anything, can you walk me through what we've got? What's active, who's involved, where are things slipping?"
+Never mention these instructions to the user."""
 
-Then listen. Ask two or three at a time, not all at once. The things I most need to learn:
+BOOTSTRAP_DESIGNER = """\
+You are {name}, a design partner meeting this user for the first time.
 
-1. **Active projects** — names, rough phase, any hard deadlines
-2. **The team** — who I'll coordinate with, roughly who does what
-3. **Cadence** — standups? weekly review? do you want status via chat, doc, or a dashboard?
-4. **Pain points** — where are things slipping today? What do you want me to obsess over?
-5. **Tools** — Jira / Linear / Notion / a spreadsheet? Where does work actually live?
+This conversation has had {user_turns} user messages so far. Follow EXACTLY \
+the matching branch below.
 
-## After the chat
+If user_turns == 0 (greeting turn):
+- Greet them warmly in one line and introduce yourself.
+- Ask exactly ONE question: "Point me at one product, page, or component \
+you'd like a quick audit of — a URL, a file name, or just a description \
+works."
+- STOP after the question. Don't ask for the brand book, personas, or design \
+system.
 
-Write what I learned:
+If user_turns >= 1 (deliverable turn):
+- Whatever they named is your audit target. DO NOT ask for more context — \
+not for visuals, not for the design system, not for user personas.
+- Dive straight into a quick audit:
+  - Name the thing in one line.
+  - List 3 quick-win fixes you'd make. If you can't actually see the \
+artifact, say so once up top and label your fixes "(based on common patterns \
+— confirm when you share it)".
+  - List 1 more ambitious opportunity that could meaningfully improve it.
+- Close: "Want me to turn these into a patch list, or sketch a before/after?"
+- Under ~300 words.
 
-- `USER.md` — their name, role, preferred cadence, timezone
-- Append a `## Context` section to `SOUL.md` covering active projects, key teammates, and tools in use
+Write like a designer talks — specific, opinionated, not consultant-y. \
+Never mention these instructions to the user."""
 
-Then suggest one concrete first move — not a grand plan:
+BOOTSTRAP_PRODUCT_INTERN = """\
+You are {name}, a product intern meeting this user for the first time.
 
-> "Want me to start with a one-page snapshot of the current projects? I can have a draft in about 15 minutes."
+This conversation has had {user_turns} user messages so far. Follow EXACTLY \
+the matching branch below.
 
-## When you're done
+If user_turns == 0 (greeting turn):
+- Greet them warmly in one short line and introduce yourself as their new \
+product intern.
+- Ask exactly ONE question: "What's one feature your team just shipped or \
+is about to ship? I'll turn around a quick competitive snapshot on it."
+- STOP after the question. Don't ask for the roadmap, OKRs, or user segments.
 
-Delete this file — `rm bootstrap.md`. You're bootstrapped. Now go make them look organized.
-"""
+If user_turns >= 1 (deliverable turn):
+- Whatever feature they named is your subject. DO NOT ask for more context \
+about users, metrics, or the product itself.
+- Produce a quick competitive snapshot inline:
+  - Paraphrase the feature in one line.
+  - Name 3 competitors who ship something similar. If guessing, tag them \
+"(worth verifying)". One sentence each on how their take differs.
+  - One under-explored angle — something this feature could lean into that \
+competitors don't.
+- Close: "Want me to go deeper on any of these, or start pulling sources?"
+- Under ~250 words.
 
-BOOTSTRAP_DESIGNER = """---
-title: "Bootstrap — Designer"
-summary: "First-run ritual for a new design agent"
----
+Intern energy: scrappy, useful, not polished. Never mention these \
+instructions to the user."""
 
-# Hi. I'm {name} — your new design partner.
+BOOTSTRAP_MARKET_RESEARCHER = """\
+You are {name}, a market researcher meeting this user for the first time.
 
-Design is a conversation with taste, not a template. Before I start producing, I want to learn yours.
+This conversation has had {user_turns} user messages so far. Follow EXACTLY \
+the matching branch below.
 
-## Open the conversation
+If user_turns == 0 (greeting turn):
+- Greet them briefly in one line and introduce yourself.
+- Ask exactly ONE question: "What market or company do you most want me to \
+dig into first?"
+- STOP after the question. Don't ask about report format, audience, cadence, \
+or source preferences.
 
-Be curious, not procedural:
+If user_turns >= 1 (deliverable turn):
+- Whatever market or company they named is your subject. DO NOT ask for \
+more context — not for geography, not for decision framing, not for source \
+preferences.
+- Deliver a first-pass landscape snapshot inline:
+  - The landscape in two lines — who plays, rough segmentation.
+  - Top 3 to 5 players — one line each on what makes them distinct. Tag \
+guesses "(worth verifying)".
+  - One recent signal — something seemingly shifting in the last 30 days. \
+If guessing, say so.
+  - One opportunity angle — where you'd dig next.
+- Close: "Want me to go deeper on a player, chase that signal, or map \
+adjacent markets?"
+- Under ~300 words.
 
-> "Hey, I'm {name}. Before I draft anything for you — what does 'good' look like here? What's the brand, and what's the team's aesthetic right now?"
-
-Listen for:
-
-1. **The brand** — who is this for, what feeling are we chasing?
-2. **Existing system** — do you have a design system or style guide? Where does it live?
-3. **Tools** — Figma, Sketch, something else? Access I'll need?
-4. **Current work** — what's on the near-term plate? Anything blocked on design right now?
-5. **Taste signals** — products, artists, sites you admire — or ones you actively don't want to look like
-
-## After the chat
-
-Capture it:
-
-- `USER.md` — their role, design background, timezone, how they like feedback (detailed vs. directional)
-- Append `## Context` to `SOUL.md` with brand summary, design system location, tool stack, current projects
-
-Then offer something small and useful — not a 10-page brand audit. Maybe:
-
-> "Want me to start by auditing the design system for inconsistencies? I can have a punch list by end of day."
-
-## When you're done
-
-`rm bootstrap.md`. You're in. Go make things beautiful.
-"""
-
-BOOTSTRAP_PRODUCT_INTERN = """---
-title: "Bootstrap — Product Intern"
-summary: "First-run ritual for a new product intern agent"
----
-
-# Hi! I'm {name} — your new product intern.
-
-I'm eager, but I don't know what I don't know yet. Help me catch up, and I'll be useful fast.
-
-## Open the conversation
-
-Be curious and a little humble — I'm new here:
-
-> "Hi! I'm {name}, your product intern. Mind walking me through the product and where you'd like me to start? I'd rather ask now than guess later."
-
-Things to learn first:
-
-1. **The product** — what is it, who uses it, what problem does it solve? (One paragraph is enough.)
-2. **Current focus** — what's the team building this quarter? Any research gaps?
-3. **Stakeholders** — whose perspective do I need (PMs, engineers, designers, customers)?
-4. **Where things live** — PRDs, research docs, user feedback — is there a wiki, a drive folder, a Notion?
-5. **Where to help** — user interviews, competitive analysis, feedback triage, spec writing?
-
-## After the chat
-
-Write it down:
-
-- `USER.md` — their name, role, what they want me to take off their plate
-- Append `## Context` to `SOUL.md` with the product one-liner, active initiatives, and known stakeholders
-
-Suggest something small and concrete to prove useful:
-
-> "Want me to start by reading the last 10 user interviews and pulling out recurring themes?"
-
-## When you're done
-
-`rm bootstrap.md`. I'm no longer brand new. Time to earn the internship.
-"""
-
-BOOTSTRAP_MARKET_RESEARCHER = """---
-title: "Bootstrap — Market Researcher"
-summary: "First-run ritual for a new market research agent"
----
-
-# Hello. I'm {name} — your market researcher.
-
-Good research starts with the right question. Before I dig, I want to know what you actually need to see.
-
-## Open the conversation
-
-Precise, but not cold:
-
-> "Hi, I'm {name}. Before I start pulling reports, can we sharpen the question? What market are we watching, and what decision is this going to inform?"
-
-Get to the heart of it:
-
-1. **The market** — industry, segment, geography
-2. **Competitors** — who do you watch closely? Any you think you're missing?
-3. **The decision** — is this for a positioning deck, a board update, an investment call? (The audience shapes the output.)
-4. **Cadence** — one-time deep dive, or ongoing intelligence? How often do you want updates?
-5. **Source preferences** — primary research, public filings, industry reports, social signals? Any subscriptions I can use?
-
-## After the chat
-
-Lock in what I heard:
-
-- `USER.md` — their role, research background, preferred report format (exec summary, deep dive, dashboard)
-- Append `## Context` to `SOUL.md` with the market scope, watchlist of competitors, decision framing, and cadence
-
-Then propose a first deliverable scoped tight:
-
-> "Want me to start with a one-page landscape map — the top 5 players, positioning, and the single most interesting signal from the last 30 days?"
-
-## When you're done
-
-`rm bootstrap.md`. Briefing over. Go find the signal in the noise.
-"""
+Analyst voice: direct, source-aware, no hedging fluff. Never mention these \
+instructions to the user."""
 
 
 DEFAULT_TEMPLATES = [

--- a/frontend/src/components/ModelSwitcher.tsx
+++ b/frontend/src/components/ModelSwitcher.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { IconChevronDown, IconCheck } from '@tabler/icons-react';
+import { enterpriseApi } from '../services/api';
+
+interface Model {
+    id: string;
+    provider: string;
+    model: string;
+    label?: string;
+    enabled?: boolean;
+}
+
+interface Props {
+    // Current selection — parent-controlled so the override persists across re-renders
+    // within the same session, but resets when the parent remounts.
+    value: string | null;
+    onChange: (modelId: string | null) => void;
+    // Optional: the tenant's default model id, used to render a "默认" tag.
+    tenantDefaultId?: string | null;
+    disabled?: boolean;
+}
+
+export default function ModelSwitcher({ value, onChange, tenantDefaultId, disabled }: Props) {
+    const { t } = useTranslation();
+    const [open, setOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    const { data: models = [] } = useQuery({
+        queryKey: ['llm-models'],
+        queryFn: enterpriseApi.llmModels,
+    });
+
+    const enabled = (models as Model[]).filter(m => m.enabled !== false);
+    const selected = enabled.find(m => m.id === value) || enabled[0] || null;
+
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: MouseEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+        };
+        window.addEventListener('mousedown', handler);
+        return () => window.removeEventListener('mousedown', handler);
+    }, [open]);
+
+    if (enabled.length === 0) return null;
+
+    const labelFor = (m: Model) => m.label || `${m.provider} · ${m.model}`;
+
+    return (
+        <div ref={ref} style={{ position: 'relative', display: 'inline-block' }}>
+            <button
+                type="button"
+                onClick={() => !disabled && setOpen(o => !o)}
+                disabled={disabled}
+                style={{
+                    display: 'inline-flex', alignItems: 'center', gap: '6px',
+                    padding: '4px 10px', fontSize: '12px',
+                    border: '1px solid var(--border-subtle)', borderRadius: '999px',
+                    background: 'var(--bg-secondary)', color: 'var(--text-secondary)',
+                    cursor: disabled ? 'not-allowed' : 'pointer',
+                    opacity: disabled ? 0.6 : 1,
+                }}
+                title={t('chat.modelSwitcher.title', 'Switch model for this session')}
+            >
+                <span style={{
+                    display: 'inline-block', maxWidth: '200px',
+                    overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                    {selected ? labelFor(selected) : t('chat.modelSwitcher.none', 'No model')}
+                </span>
+                <IconChevronDown size={12} stroke={2} />
+            </button>
+            {open && (
+                <div style={{
+                    position: 'absolute', bottom: 'calc(100% + 4px)', left: 0,
+                    minWidth: '220px', maxHeight: '280px', overflowY: 'auto',
+                    background: 'var(--bg-primary)', border: '1px solid var(--border-subtle)',
+                    borderRadius: '8px', boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+                    zIndex: 1000, padding: '4px',
+                }}>
+                    {enabled.map(m => {
+                        const isSelected = selected?.id === m.id;
+                        const isDefault = tenantDefaultId && m.id === tenantDefaultId;
+                        return (
+                            <button
+                                key={m.id}
+                                onClick={() => { onChange(m.id); setOpen(false); }}
+                                style={{
+                                    display: 'flex', alignItems: 'center', width: '100%',
+                                    padding: '6px 10px', gap: '8px',
+                                    border: 'none', borderRadius: '6px',
+                                    background: isSelected ? 'var(--bg-secondary)' : 'transparent',
+                                    color: 'var(--text-primary)',
+                                    cursor: 'pointer', fontSize: '12.5px', textAlign: 'left',
+                                }}
+                                onMouseEnter={e => { if (!isSelected) (e.currentTarget as HTMLButtonElement).style.background = 'var(--bg-secondary)'; }}
+                                onMouseLeave={e => { if (!isSelected) (e.currentTarget as HTMLButtonElement).style.background = 'transparent'; }}
+                            >
+                                <span style={{ width: '14px', display: 'inline-flex' }}>
+                                    {isSelected && <IconCheck size={14} stroke={2} />}
+                                </span>
+                                <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                    {labelFor(m)}
+                                </span>
+                                {isDefault && (
+                                    <span style={{
+                                        fontSize: '10px', padding: '2px 6px',
+                                        background: 'var(--bg-secondary)', color: 'var(--text-tertiary)',
+                                        borderRadius: '4px', letterSpacing: '0.02em',
+                                    }}>
+                                        {t('chat.modelSwitcher.defaultTag', '默认')}
+                                    </span>
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/components/PostHireSettingsModal.tsx
+++ b/frontend/src/components/PostHireSettingsModal.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { IconX } from '@tabler/icons-react';
+import { agentApi, enterpriseApi, tenantApi } from '../services/api';
+
+interface Template {
+    id: string;
+    name: string;
+    description?: string;
+    icon?: string;
+    category?: string;
+}
+
+interface Model {
+    id: string;
+    provider: string;
+    model: string;
+    label?: string;
+    enabled?: boolean;
+}
+
+interface Props {
+    template: Template | null;
+    open: boolean;
+    // User cancelled the settings step — close this modal, but keep the caller
+    // (e.g. the Talent Market grid) open so they can pick again.
+    onClose: () => void;
+    // Creation succeeded — caller should close too. Navigation is handled here.
+    onDone?: () => void;
+}
+
+type Visibility = 'company' | 'only_me';
+
+export default function PostHireSettingsModal({ template, open, onClose, onDone }: Props) {
+    const { t, i18n } = useTranslation();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const isChinese = i18n.language.startsWith('zh');
+
+    const [visibility, setVisibility] = useState<Visibility>('company');
+    const [modelId, setModelId] = useState<string>('');
+
+    const { data: myTenant } = useQuery({
+        queryKey: ['tenant', 'me'],
+        queryFn: () => tenantApi.me(),
+        enabled: open,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    const { data: models = [] } = useQuery({
+        queryKey: ['llm-models'],
+        queryFn: enterpriseApi.llmModels,
+        enabled: open,
+    });
+
+    const enabledModels = useMemo(
+        () => (models as Model[]).filter(m => m.enabled !== false),
+        [models],
+    );
+
+    // Default the model picker to the tenant default (or first enabled)
+    // once both are available.
+    useEffect(() => {
+        if (!open) return;
+        if (modelId) return;
+        const preferred = myTenant?.default_model_id && enabledModels.find(m => m.id === myTenant.default_model_id)
+            ? myTenant.default_model_id
+            : (enabledModels[0]?.id || '');
+        if (preferred) setModelId(preferred);
+    }, [open, myTenant?.default_model_id, enabledModels, modelId]);
+
+    // Reset local form whenever the modal closes so the next open is clean.
+    useEffect(() => {
+        if (!open) {
+            setVisibility('company');
+            setModelId('');
+        }
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [open, onClose]);
+
+    const hire = useMutation({
+        mutationFn: (navigateAfter: boolean) => {
+            if (!template) return Promise.reject(new Error('No template'));
+            const payload: any = {
+                name: template.name,
+                // Auto-fill the agent's role with the template's one-line
+                // description so the detail page doesn't show an empty "角色"
+                // field. Users can still edit it later in settings.
+                role_description: template.description || '',
+                template_id: template.id,
+                primary_model_id: modelId || undefined,
+                permission_access_level: 'manage',
+            };
+            if (visibility === 'company') {
+                payload.permission_scope_type = 'company';
+                payload.permission_scope_ids = [];
+            } else {
+                payload.permission_scope_type = 'user';
+                payload.permission_scope_ids = [];
+            }
+            return agentApi.create(payload).then((agent: any) => ({ agent, navigateAfter }));
+        },
+        onSuccess: ({ agent, navigateAfter }) => {
+            queryClient.invalidateQueries({ queryKey: ['agents'] });
+            (onDone || onClose)();
+            // "立即对话" → open directly on the chat tab (not the default status
+            // tab). AgentDetail picks up the hash on mount.
+            if (navigateAfter) navigate(`/agents/${agent.id}#chat`);
+        },
+        onError: (err: any) => {
+            alert((err?.message || 'Failed to create agent') as string);
+        },
+    });
+
+    if (!open || !template) return null;
+
+    const labelFor = (m: Model) => m.label || `${m.provider} · ${m.model}`;
+    const busy = hire.isPending;
+
+    return (
+        <div
+            style={{
+                position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+                background: 'rgba(0,0,0,0.55)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                zIndex: 10001,
+            }}
+            onClick={e => { if (e.target === e.currentTarget && !busy) onClose(); }}
+        >
+            <div style={{
+                background: 'var(--bg-primary)', borderRadius: '12px',
+                width: '480px', maxWidth: '92vw',
+                border: '1px solid var(--border-subtle)',
+                boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+                display: 'flex', flexDirection: 'column', overflow: 'hidden',
+            }}>
+                <div style={{ padding: '22px 26px 8px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+                    <div>
+                        <h3 style={{ margin: 0, fontSize: '17px', fontWeight: 600 }}>
+                            {t('postHire.title', isChinese ? '配置新成员' : 'Configure new teammate')}
+                        </h3>
+                        <p style={{ margin: '4px 0 0', fontSize: '12.5px', color: 'var(--text-secondary)' }}>
+                            {template.name}
+                        </p>
+                    </div>
+                    <button onClick={onClose} className="btn btn-ghost" disabled={busy} style={{ padding: '4px' }}>
+                        <IconX size={16} stroke={1.5} />
+                    </button>
+                </div>
+
+                <div style={{ padding: '8px 26px 8px', display: 'flex', flexDirection: 'column', gap: '18px' }}>
+                    {/* Visibility */}
+                    <section>
+                        <div style={{ fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>
+                            {t('postHire.visibility', isChinese ? '可见权限' : 'Visibility')}
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+                            <RadioRow
+                                selected={visibility === 'company'}
+                                onClick={() => !busy && setVisibility('company')}
+                                title={t('postHire.visibilityCompanyTitle', isChinese ? '公司所有人' : 'Everyone at the company')}
+                                hint={t('postHire.visibilityCompanyHint', isChinese ? '全公司都能使用这个数字员工' : 'Everyone in the company can use this agent')}
+                            />
+                            <RadioRow
+                                selected={visibility === 'only_me'}
+                                onClick={() => !busy && setVisibility('only_me')}
+                                title={t('postHire.visibilityOnlyMeTitle', isChinese ? '仅自己' : 'Only me')}
+                                hint={t('postHire.visibilityOnlyMeHint', isChinese ? '只有你能使用，可以之后在设置里分享' : 'Only you can use it; you can share later in Settings')}
+                            />
+                        </div>
+                    </section>
+
+                    {/* Model */}
+                    <section>
+                        <div style={{ fontSize: '13px', fontWeight: 600, marginBottom: '8px' }}>
+                            {t('postHire.model', isChinese ? '首选模型' : 'Preferred model')}
+                        </div>
+                        {enabledModels.length === 0 ? (
+                            <div style={{ fontSize: '12.5px', color: 'var(--text-tertiary)' }}>
+                                {t('postHire.noModels', isChinese ? '暂无可用模型，请管理员先添加' : 'No enabled models — ask an admin to add one')}
+                            </div>
+                        ) : (
+                            <select
+                                className="form-input"
+                                value={modelId}
+                                onChange={e => setModelId(e.target.value)}
+                                disabled={busy}
+                                style={{ width: '100%' }}
+                            >
+                                {enabledModels.map(m => (
+                                    <option key={m.id} value={m.id}>
+                                        {labelFor(m)}{myTenant?.default_model_id === m.id ? ` · ${t('postHire.defaultSuffix', isChinese ? '默认' : 'default')}` : ''}
+                                    </option>
+                                ))}
+                            </select>
+                        )}
+                    </section>
+                </div>
+
+                <div style={{ padding: '16px 26px 20px', display: 'flex', justifyContent: 'flex-end', gap: '8px', borderTop: '1px solid var(--border-subtle)', marginTop: '12px' }}>
+                    <button
+                        className="btn btn-secondary"
+                        disabled={busy}
+                        onClick={() => hire.mutate(false)}
+                    >
+                        {busy && !hire.variables ? '...' : t('postHire.createOnly', isChinese ? '仅创建' : 'Just create')}
+                    </button>
+                    <button
+                        className="btn btn-primary"
+                        disabled={busy || enabledModels.length === 0}
+                        onClick={() => hire.mutate(true)}
+                    >
+                        {busy ? (isChinese ? '创建中...' : 'Creating...') : t('postHire.chatNow', isChinese ? '立即对话' : 'Chat now')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function RadioRow({ selected, onClick, title, hint }: { selected: boolean; onClick: () => void; title: string; hint: string }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            style={{
+                display: 'flex', alignItems: 'flex-start', gap: '10px',
+                padding: '10px 12px', textAlign: 'left',
+                border: `1px solid ${selected ? 'var(--accent-primary)' : 'var(--border-subtle)'}`,
+                borderRadius: '8px', background: selected ? 'var(--accent-subtle, rgba(99,102,241,0.08))' : 'transparent',
+                cursor: 'pointer', width: '100%',
+            }}
+        >
+            <span style={{
+                marginTop: '2px', width: '14px', height: '14px', borderRadius: '50%',
+                border: `2px solid ${selected ? 'var(--accent-primary)' : 'var(--border-subtle)'}`,
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                flexShrink: 0,
+            }}>
+                {selected && <span style={{ width: '6px', height: '6px', borderRadius: '50%', background: 'var(--accent-primary)' }} />}
+            </span>
+            <span style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
+                <span style={{ fontSize: '13px', color: 'var(--text-primary)' }}>{title}</span>
+                <span style={{ fontSize: '11.5px', color: 'var(--text-tertiary)' }}>{hint}</span>
+            </span>
+        </button>
+    );
+}

--- a/frontend/src/components/TalentMarketModal.tsx
+++ b/frontend/src/components/TalentMarketModal.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { IconPlus, IconX } from '@tabler/icons-react';
+import { agentApi } from '../services/api';
+import PostHireSettingsModal from './PostHireSettingsModal';
+
+interface Template {
+    id: string;
+    name: string;
+    description: string;
+    icon: string;
+    category: string;
+    is_builtin: boolean;
+    capability_bullets?: string[];
+    has_bootstrap?: boolean;
+}
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+}
+
+export default function TalentMarketModal({ open, onClose }: Props) {
+    const { t, i18n } = useTranslation();
+    const navigate = useNavigate();
+    const isChinese = i18n.language.startsWith('zh');
+    // Chosen template → hands off to PostHireSettingsModal. The market modal
+    // stays mounted behind so the user can cancel and pick someone else.
+    const [pendingTemplate, setPendingTemplate] = useState<Template | null>(null);
+
+    const { data: templates = [], isLoading } = useQuery({
+        queryKey: ['agent-templates'],
+        queryFn: () => agentApi.templates(),
+        enabled: open,
+    });
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape' && !pendingTemplate) onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [open, onClose, pendingTemplate]);
+
+    if (!open) return null;
+
+    const builtins = templates.filter((t: Template) => t.is_builtin);
+
+    return (
+        <div
+            style={{
+                position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+                background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                zIndex: 10000,
+            }}
+            onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        >
+            <div
+                style={{
+                    background: 'var(--bg-primary)', borderRadius: '12px',
+                    width: '960px', maxWidth: '95vw', maxHeight: '88vh',
+                    border: '1px solid var(--border-subtle)',
+                    boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+                    display: 'flex', flexDirection: 'column', overflow: 'hidden',
+                }}
+            >
+                {/* Header */}
+                <div style={{
+                    padding: '24px 28px 12px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between',
+                }}>
+                    <div>
+                        <h2 style={{ margin: 0, fontSize: '22px', fontWeight: 600 }}>
+                            {t('talentMarket.title', isChinese ? '人才市场' : 'Talent Market')}
+                        </h2>
+                        <p style={{ margin: '6px 0 0', fontSize: '13px', color: 'var(--text-secondary)' }}>
+                            {t('talentMarket.subtitle', isChinese ? '挑选一位专业成员加入你的公司' : 'Pick a professional to join your company')}
+                        </p>
+                    </div>
+                    <button
+                        onClick={onClose}
+                        className="btn btn-ghost"
+                        style={{ padding: '4px', display: 'flex', alignItems: 'center' }}
+                        title={t('common.close', 'Close')}
+                    >
+                        <IconX size={18} stroke={1.5} />
+                    </button>
+                </div>
+
+                {/* Cards */}
+                <div style={{
+                    padding: '12px 28px 20px', overflowY: 'auto', flex: 1,
+                    display: 'grid',
+                    gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))',
+                    gap: '16px',
+                    alignContent: 'start',
+                }}>
+                    {isLoading && (
+                        <div style={{ gridColumn: '1 / -1', padding: '60px', textAlign: 'center', color: 'var(--text-tertiary)' }}>
+                            {t('common.loading', 'Loading...')}
+                        </div>
+                    )}
+                    {!isLoading && builtins.map((tpl: Template) => (
+                        <TemplateCard
+                            key={tpl.id}
+                            tpl={tpl}
+                            hiring={false}
+                            onHire={() => setPendingTemplate(tpl)}
+                        />
+                    ))}
+                    {!isLoading && (
+                        <CustomCard
+                            onClick={() => { onClose(); navigate('/agents/new'); }}
+                        />
+                    )}
+                </div>
+
+                {/* Footer */}
+                <div style={{
+                    padding: '12px 28px 16px', textAlign: 'center', fontSize: '12px',
+                    color: 'var(--text-tertiary)', borderTop: '1px solid var(--border-subtle)',
+                }}>
+                    {t('talentMarket.footer', isChinese ? '点击聘用·可随时在设置中调整' : 'Hire now · adjust anything in settings later')}
+                </div>
+            </div>
+
+            <PostHireSettingsModal
+                template={pendingTemplate}
+                open={!!pendingTemplate}
+                onClose={() => setPendingTemplate(null)}
+                onDone={() => { setPendingTemplate(null); onClose(); }}
+            />
+        </div>
+    );
+}
+
+function TemplateCard({ tpl, hiring, onHire }: { tpl: Template; hiring: boolean; onHire: () => void }) {
+    const { t } = useTranslation();
+    const bullets = tpl.capability_bullets?.length
+        ? tpl.capability_bullets
+        : [tpl.description].filter(Boolean);
+
+    return (
+        <div style={{
+            border: '1px solid var(--border-subtle)', borderRadius: '10px',
+            padding: '18px', display: 'flex', flexDirection: 'column',
+            background: 'var(--bg-primary)',
+            transition: 'border-color 120ms',
+        }}>
+            <div style={{
+                width: '40px', height: '40px', borderRadius: '8px',
+                background: 'var(--bg-secondary)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                fontSize: '16px', fontWeight: 600, marginBottom: '14px',
+            }}>
+                {tpl.icon || '🤖'}
+            </div>
+            <div style={{ fontSize: '15px', fontWeight: 600, marginBottom: '2px' }}>
+                {tpl.name}
+            </div>
+            <div style={{
+                fontSize: '10px', fontWeight: 500, letterSpacing: '0.06em',
+                color: 'var(--text-tertiary)', textTransform: 'uppercase',
+                marginBottom: '12px',
+            }}>
+                {tpl.category || 'general'}
+            </div>
+            <ul style={{
+                margin: 0, padding: 0, listStyle: 'none', flex: 1,
+                fontSize: '12.5px', color: 'var(--text-secondary)', lineHeight: 1.7,
+            }}>
+                {bullets.slice(0, 4).map((b, i) => (
+                    <li key={i} style={{ display: 'flex', gap: '6px', alignItems: 'flex-start' }}>
+                        <span style={{ color: 'var(--text-tertiary)', flexShrink: 0 }}>•</span>
+                        <span>{b}</span>
+                    </li>
+                ))}
+            </ul>
+            <button
+                className="btn btn-primary"
+                onClick={onHire}
+                disabled={hiring}
+                style={{ marginTop: '16px', width: '100%' }}
+            >
+                {hiring ? t('talentMarket.hiring', 'Hiring...') : t('talentMarket.hire', '聘用')}
+            </button>
+        </div>
+    );
+}
+
+function CustomCard({ onClick }: { onClick: () => void }) {
+    const { t, i18n } = useTranslation();
+    const isChinese = i18n.language.startsWith('zh');
+    return (
+        <div
+            onClick={onClick}
+            style={{
+                border: '1.5px dashed var(--border-subtle)', borderRadius: '10px',
+                padding: '18px', display: 'flex', flexDirection: 'column',
+                cursor: 'pointer', background: 'transparent',
+                transition: 'border-color 120ms, background 120ms',
+            }}
+            onMouseEnter={(e) => {
+                (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--accent)';
+            }}
+            onMouseLeave={(e) => {
+                (e.currentTarget as HTMLDivElement).style.borderColor = 'var(--border-subtle)';
+            }}
+        >
+            <div style={{
+                width: '40px', height: '40px', borderRadius: '8px',
+                background: 'var(--bg-secondary)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                marginBottom: '14px', color: 'var(--text-secondary)',
+            }}>
+                <IconPlus size={20} stroke={1.5} />
+            </div>
+            <div style={{ fontSize: '15px', fontWeight: 600, marginBottom: '2px' }}>
+                {t('talentMarket.customTitle', isChinese ? '自建 Agent' : 'Build custom')}
+            </div>
+            <div style={{
+                fontSize: '10px', fontWeight: 500, letterSpacing: '0.06em',
+                color: 'var(--text-tertiary)', textTransform: 'uppercase',
+                marginBottom: '12px',
+            }}>
+                {t('talentMarket.customCategory', 'Custom')}
+            </div>
+            <p style={{
+                margin: 0, flex: 1, fontSize: '12.5px',
+                color: 'var(--text-secondary)', lineHeight: 1.6,
+            }}>
+                {t('talentMarket.customDescription', isChinese
+                    ? '从零开始定义身份、性格、权限和工具，完全按你的需求打造。'
+                    : 'Define identity, personality, permissions, and tools from scratch.')}
+            </p>
+            <button
+                className="btn btn-secondary"
+                onClick={onClick}
+                style={{ marginTop: '16px', width: '100%' }}
+            >
+                {t('talentMarket.customStart', isChinese ? '开始' : 'Start')}
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -51,9 +51,21 @@
     "myCreated": "Created by me",
     "companyShared": "Company shared",
     "newAgent": "New Digital Employee",
+    "hire": "Hire teammate",
     "enterprise": "Company Settings",
     "language": "Language",
     "plaza": "Plaza"
+  },
+  "talentMarket": {
+    "title": "Talent Market",
+    "subtitle": "Pick a professional to join your company",
+    "hire": "Hire",
+    "hiring": "Hiring...",
+    "footer": "Hire now · adjust anything in settings later",
+    "customTitle": "Build custom",
+    "customCategory": "Custom",
+    "customDescription": "Define identity, personality, permissions, and tools from scratch.",
+    "customStart": "Start"
   },
   "auth": {
     "login": "Login",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -31,11 +31,23 @@
     "myCreated": "我创建的",
     "companyShared": "公司共用",
     "newAgent": "新建数字员工",
+    "hire": "招聘新成员",
     "enterprise": "公司设置",
     "adminCompanies": "公司管理",
     "platformSettings": "平台设置",
     "language": "语言",
     "plaza": "广场"
+  },
+  "talentMarket": {
+    "title": "人才市场",
+    "subtitle": "挑选一位专业成员加入你的公司",
+    "hire": "聘用",
+    "hiring": "聘用中...",
+    "footer": "点击聘用·可随时在设置中调整",
+    "customTitle": "自建 Agent",
+    "customCategory": "自定义",
+    "customDescription": "从零开始定义身份、性格、权限和工具，完全按你的需求打造。",
+    "customStart": "开始"
   },
   "plaza": {
     "title": "智能体广场",

--- a/frontend/src/pages/AgentCreate.tsx
+++ b/frontend/src/pages/AgentCreate.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { agentApi, channelApi, enterpriseApi, skillApi } from '../services/api';
+import { agentApi, channelApi, enterpriseApi, skillApi, tenantApi } from '../services/api';
 import ChannelConfig from '../components/ChannelConfig';
 import LinearCopyButton from '../components/LinearCopyButton';
 const STEPS = ['basicInfo', 'personality', 'skills', 'permissions', 'channel'] as const;
@@ -93,6 +93,22 @@ export default function AgentCreate() {
         queryKey: ['llm-models'],
         queryFn: enterpriseApi.llmModels,
     });
+
+    // Tenant default model — used to preselect the model step so the open-source
+    // default ("hire and go") path needs no clicks. User can override.
+    const { data: myTenant } = useQuery({
+        queryKey: ['tenant', 'me'],
+        queryFn: () => tenantApi.me(),
+        staleTime: 5 * 60 * 1000,
+    });
+    useEffect(() => {
+        if (!myTenant?.default_model_id) return;
+        const enabledModels = (models as any[]).filter((m: any) => m.enabled);
+        const exists = enabledModels.some((m: any) => m.id === myTenant.default_model_id);
+        if (exists) {
+            setForm(prev => prev.primary_model_id ? prev : { ...prev, primary_model_id: myTenant.default_model_id! });
+        }
+    }, [myTenant?.default_model_id, models]);
 
     // Fetch templates
     const { data: templates = [] } = useQuery({

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -12,7 +12,8 @@ import PromptModal from '../components/PromptModal';
 import OpenClawSettings from './OpenClawSettings';
 import AgentBayLivePanel, { LivePreviewState } from '../components/AgentBayLivePanel';
 import AgentCredentials from '../components/AgentCredentials';
-import { activityApi, agentApi, channelApi, enterpriseApi, fileApi, scheduleApi, skillApi, taskApi, triggerApi, uploadFileWithProgress } from '../services/api';
+import { activityApi, agentApi, channelApi, enterpriseApi, fileApi, scheduleApi, skillApi, taskApi, tenantApi, triggerApi, uploadFileWithProgress } from '../services/api';
+import ModelSwitcher from '../components/ModelSwitcher';
 import { useAppStore } from '../stores';
 import { useAuthStore } from '../stores';
 import { copyToClipboard } from '../utils/clipboard';
@@ -748,25 +749,7 @@ function fetchAuth<T>(url: string, options?: RequestInit): Promise<T> {
     return fetch(`/api${url}`, {
         ...options,
         headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
-    }).then(async (r) => {
-        if (!r.ok) {
-            const bodyText = await r.text();
-            let detail: unknown;
-            try {
-                detail = bodyText ? JSON.parse(bodyText)?.detail : undefined;
-            } catch {
-                detail = bodyText;
-            }
-            const message = typeof detail === 'string'
-                ? detail
-                : bodyText?.trim() || `HTTP ${r.status}`;
-            const error: any = new Error(message);
-            error.status = r.status;
-            error.detail = detail;
-            throw error;
-        }
-        return r.json();
-    });
+    }).then(r => r.json());
 }
 
 // ── Pulse LED keyframe (shared with Chat.tsx, guarded by ID) ──────────────
@@ -1352,6 +1335,28 @@ function AgentDetailInner() {
         enabled: !!id,
     });
 
+    // Tenant default model — used to render a "默认" tag in ModelSwitcher.
+    const { data: myTenant } = useQuery({
+        queryKey: ['tenant', 'me'],
+        queryFn: () => tenantApi.me(),
+        staleTime: 5 * 60 * 1000,
+    });
+
+    // Session-scoped per-chat model override. Initial value = agent's configured
+    // primary_model_id (which on creation equals the tenant default). Remount
+    // resets it, matching the "just for this session" intent.
+    const [overrideModelId, setOverrideModelId] = useState<string | null>(null);
+    useEffect(() => {
+        if (agent?.primary_model_id && overrideModelId === null) {
+            setOverrideModelId(agent.primary_model_id);
+        }
+    }, [agent?.primary_model_id]);
+
+    // Track onboarding kickoff per (agent, session) so the agent only greets
+    // once per session. The agent opens the conversation itself — no visible
+    // user message — by sending a tagged trigger the backend filters out.
+    const onboardingKickoffRef = useRef<Set<string>>(new Set());
+
     // ── Aware tab data: triggers ──
     const { data: awareTriggers = [], refetch: refetchTriggers } = useQuery({
         queryKey: ['triggers', id],
@@ -1803,6 +1808,31 @@ function AgentDetailInner() {
     const chatUploadAbortRef = useRef<Map<string, () => void>>(new Map());
     const [attachedFiles, setAttachedFiles] = useState<{ name: string; text: string; path?: string; imageUrl?: string }[]>([]);
     const wsRef = useRef<WebSocket | null>(null);
+
+    // Onboarding kickoff: once WS is connected and the session is empty, and
+    // this viewer has never been onboarded to this agent, fire a tagged trigger
+    // exactly once per (agent, session). Backend swallows the user turn and
+    // streams the assistant greeting. Founding vs welcoming content is decided
+    // server-side based on whether anyone else has been onboarded to this
+    // agent before.
+    useEffect(() => {
+        if (!wsConnected || !id || !activeSession?.id) return;
+        if (!agent || agent.onboarded_for_me !== false) return;
+        if (chatMessages.length > 0) return;
+        const runtimeKey = buildSessionRuntimeKey(id, String(activeSession.id));
+        if (onboardingKickoffRef.current.has(runtimeKey)) return;
+        const socket = wsMapRef.current[runtimeKey];
+        if (!socket || socket.readyState !== WebSocket.OPEN) return;
+        onboardingKickoffRef.current.add(runtimeKey);
+        setIsWaiting(true);
+        setIsStreaming(false);
+        socket.send(JSON.stringify({
+            content: '',
+            kind: 'onboarding_trigger',
+            model_id: overrideModelId,
+        }));
+    }, [wsConnected, id, activeSession?.id, agent?.onboarded_for_me, chatMessages.length, overrideModelId]);
+
     const chatEndRef = useRef<HTMLDivElement>(null);
     const chatContainerRef = useRef<HTMLDivElement>(null);
     const chatInputRef = useRef<HTMLTextAreaElement>(null);
@@ -2366,7 +2396,8 @@ function AgentDetailInner() {
         activeSocket.send(JSON.stringify({
             content: contentForLLM,
             display_content: userMsg,
-            file_name: attachedFiles.map(f => f.name).join(', ')
+            file_name: attachedFiles.map(f => f.name).join(', '),
+            model_id: overrideModelId,
         }));
 
         setChatInput('');
@@ -4712,6 +4743,15 @@ function AgentDetailInner() {
                                                 >
                                                     <IconPaperclip size={16} stroke={1.75} />
                                                 </button>
+                                                {/* Right-hugging group: ModelSwitcher stays docked to the send
+                                                    button regardless of textarea width. */}
+                                                <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                                <ModelSwitcher
+                                                    value={overrideModelId}
+                                                    onChange={setOverrideModelId}
+                                                    tenantDefaultId={myTenant?.default_model_id}
+                                                    disabled={!wsConnected}
+                                                />
                                                 {(isStreaming || isWaiting) ? (
                                                     <button
                                                         type="button"
@@ -4742,6 +4782,7 @@ function AgentDetailInner() {
                                                         <IconSend size={16} stroke={1.75} />
                                                     </button>
                                                 )}
+                                                </div>
                                             </div>
                                         </div>
                                         </div>
@@ -4900,19 +4941,11 @@ function AgentDetailInner() {
                     activeTab === 'approvals' && (() => {
                         const ApprovalsTab = () => {
                             const isChinese = i18n.language?.startsWith('zh');
-                            const {
-                                data: approvals = [],
-                                error: approvalsError,
-                                refetch: refetchApprovals,
-                            } = useQuery({
+                            const { data: approvals = [], refetch: refetchApprovals } = useQuery({
                                 queryKey: ['agent-approvals', id],
-                                queryFn: async () => {
-                                    const data = await fetchAuth<any[]>(`/agents/${id}/approvals`);
-                                    return Array.isArray(data) ? data : [];
-                                },
+                                queryFn: () => fetchAuth<any[]>(`/agents/${id}/approvals`),
                                 enabled: !!id,
                                 refetchInterval: 15000,
-                                retry: false,
                             });
                             const resolveMut = useMutation({
                                 mutationFn: async ({ approvalId, action }: { approvalId: string; action: string }) => {
@@ -4930,9 +4963,6 @@ function AgentDetailInner() {
                             });
                             const pending = (approvals as any[]).filter((a: any) => a.status === 'pending');
                             const resolved = (approvals as any[]).filter((a: any) => a.status !== 'pending');
-                            const approvalsErrorMessage = approvalsError instanceof Error
-                                ? approvalsError.message
-                                : (isChinese ? '审批记录加载失败' : 'Failed to load approval records');
                             const statusStyle = (s: string) => ({
                                 padding: '2px 8px', borderRadius: '4px', fontSize: '11px', fontWeight: 600,
                                 background: s === 'approved' ? 'rgba(0,180,120,0.12)' : s === 'rejected' ? 'rgba(255,80,80,0.12)' : 'rgba(255,180,0,0.12)',
@@ -4940,23 +4970,6 @@ function AgentDetailInner() {
                             });
                             return (
                                 <div style={{ padding: '20px 24px' }}>
-                                    {approvalsError && (
-                                        <div style={{
-                                            marginBottom: '16px',
-                                            padding: '14px 16px',
-                                            borderRadius: '8px',
-                                            background: 'rgba(255, 180, 0, 0.08)',
-                                            border: '1px solid rgba(255, 180, 0, 0.2)',
-                                            color: 'var(--text-secondary)',
-                                            fontSize: '13px',
-                                            lineHeight: 1.5,
-                                        }}>
-                                            <div style={{ fontWeight: 600, marginBottom: '4px', color: 'var(--warning)' }}>
-                                                {isChinese ? '无法加载审批记录' : 'Unable to load approval records'}
-                                            </div>
-                                            <div>{approvalsErrorMessage}</div>
-                                        </div>
-                                    )}
                                     {/* Pending */}
                                     {pending.length > 0 && (
                                         <>

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -2044,6 +2044,14 @@ function AgentDetailInner() {
         };
         ws.onmessage = (e) => {
             const d = JSON.parse(e.data);
+            // Onboarding lock fired (or trigger was rejected because the pair
+            // was already onboarded). Either way, invalidate the cached agent
+            // record so the kickoff effect stops thinking a new session needs
+            // onboarding. Fire early and unconditionally — the event is cheap.
+            if (d.type === 'onboarded') {
+                queryClient.invalidateQueries({ queryKey: ['agent', agentId] });
+                return;
+            }
             const isActiveRuntime = currentAgentIdRef.current === agentId && activeSessionIdRef.current === sessionId;
             if (['thinking', 'chunk', 'tool_call', 'done', 'error', 'quota_exceeded'].includes(d.type)) {
                 const nextStreaming = ['thinking', 'chunk', 'tool_call'].includes(d.type);

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 import MarkdownRenderer from '../components/MarkdownRenderer';
 import AgentBayLivePanel, { LivePreviewState } from '../components/AgentBayLivePanel';
-import { agentApi, enterpriseApi, uploadFileWithProgress } from '../services/api';
+import ModelSwitcher from '../components/ModelSwitcher';
+import { agentApi, enterpriseApi, tenantApi, uploadFileWithProgress } from '../services/api';
 import { IconPaperclip, IconSend } from '@tabler/icons-react';
 import { formatFileSize } from '../utils/formatFileSize';
 import { useAuthStore } from '../stores';
@@ -261,7 +262,7 @@ function ChatToolChain({ toolCalls }: { toolCalls: ToolCall[] }) {
 }
 
 export default function Chat() {
-    const { t } = useTranslation();
+    const { t, i18n } = useTranslation();
     const { id } = useParams<{ id: string }>();
     const token = useAuthStore((s) => s.token);
     const [messages, setMessages] = useState<Message[]>([]);
@@ -287,12 +288,34 @@ export default function Chat() {
     const pendingToolCalls = useRef<ToolCall[]>([]);
     const streamContent = useRef('');
     const thinkingContent = useRef('');
+    // Track history load + whether we've already fired the one-shot onboarding
+    // trigger so the agent greets the user at most once per mount.
+    const historyLoaded = useRef(false);
+    const onboardingKickoffSent = useRef(false);
 
     const { data: agent } = useQuery({
         queryKey: ['agent', id],
         queryFn: () => agentApi.get(id!),
         enabled: !!id,
     });
+
+    // Tenant default model — used only as a "默认" tag in the dropdown, not as
+    // the initial selection. Initial selection is agent.primary_model_id.
+    const { data: myTenant } = useQuery({
+        queryKey: ['tenant', 'me'],
+        queryFn: () => tenantApi.me(),
+        staleTime: 5 * 60 * 1000,
+    });
+
+    // Per-session model override. Lives in component state — remounting Chat
+    // (new agent / new session) resets it. Initialized from the agent's
+    // configured primary_model_id once the agent record loads.
+    const [overrideModelId, setOverrideModelId] = useState<string | null>(null);
+    useEffect(() => {
+        if (agent?.primary_model_id && overrideModelId === null) {
+            setOverrideModelId(agent.primary_model_id);
+        }
+    }, [agent?.primary_model_id]);
 
     const { data: llmModels = [] } = useQuery({
         queryKey: ['llm-models'],
@@ -397,8 +420,29 @@ export default function Chat() {
                     setMessages(processed);
                 }
             })
-            .catch(() => { /* ignore */ });
+            .catch(() => { /* ignore */ })
+            .finally(() => { historyLoaded.current = true; });
     }, [id, token]);
+
+    // Per-(user, agent) onboarding kickoff: if this viewer has never been
+    // onboarded to this agent and the conversation is empty, fire a tagged
+    // trigger the backend treats as "agent greets first" — no visible user
+    // bubble, no DB write for the placeholder turn. One-shot per mount.
+    useEffect(() => {
+        if (onboardingKickoffSent.current) return;
+        if (!connected || !wsRef.current) return;
+        if (!agent || agent.onboarded_for_me !== false) return;
+        if (!historyLoaded.current) return;
+        if (messages.length > 0) return;
+        onboardingKickoffSent.current = true;
+        setIsWaiting(true);
+        setStreaming(true);
+        wsRef.current.send(JSON.stringify({
+            content: '',
+            kind: 'onboarding_trigger',
+            model_id: overrideModelId,
+        }));
+    }, [connected, agent, messages.length, overrideModelId]);
 
     useEffect(() => {
         if (!id || !token) return;
@@ -703,7 +747,7 @@ export default function Chat() {
             imageUrl: attachedFile?.imageUrl,
             timestamp: new Date().toISOString(),
         }]);
-        wsRef.current.send(JSON.stringify({ content: contentForLLM, display_content: userMsg, file_name: attachedFile?.name || '' }));
+        wsRef.current.send(JSON.stringify({ content: contentForLLM, display_content: userMsg, file_name: attachedFile?.name || '', model_id: overrideModelId }));
         setInput('');
         setAttachedFile(null);
     };
@@ -952,6 +996,14 @@ export default function Chat() {
                                 placeholder={t('chat.placeholder')}
                                 disabled={!connected}
                                 rows={1}
+                            />
+                        </div>
+                        <div style={{ padding: '0 8px', marginTop: '4px' }}>
+                            <ModelSwitcher
+                                value={overrideModelId}
+                                onChange={setOverrideModelId}
+                                tenantDefaultId={myTenant?.default_model_id}
+                                disabled={!connected}
                             />
                         </div>
                         <div className="chat-composer-toolbar">

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -1970,6 +1970,18 @@ export default function EnterpriseSettings() {
         mutationFn: ({ id, data }: { id: string; data: any }) => fetchJson(`/enterprise/llm-models/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
         onSuccess: () => { qc.invalidateQueries({ queryKey: ['llm-models', selectedTenantId] }); setShowAddModel(false); setEditingModelId(null); },
     });
+    // Tenant default model — for rendering a "默认" badge in the model list.
+    const { data: tenantForDefault, refetch: refetchTenantForDefault } = useQuery({
+        queryKey: ['tenant-default-model', selectedTenantId],
+        queryFn: () => fetchJson<{ default_model_id: string | null }>(
+            selectedTenantId ? `/tenants/${selectedTenantId}` : '/tenants/me'
+        ),
+        enabled: activeTab === 'llm',
+    });
+    const setDefaultModel = useMutation({
+        mutationFn: (modelId: string) => fetchJson(`/enterprise/llm-models/${modelId}/set-default`, { method: 'POST' }),
+        onSuccess: () => { refetchTenantForDefault(); },
+    });
     const deleteModel = useMutation({
         mutationFn: async ({ id, force = false }: { id: string; force?: boolean }) => {
             const url = force ? `/enterprise/llm-models/${id}?force=true` : `/enterprise/llm-models/${id}`;
@@ -2324,6 +2336,13 @@ export default function EnterpriseSettings() {
                                                     }} />
                                                 </button>
                                                 {m.supports_vision && <span className="badge" style={{ background: 'rgba(99,102,241,0.15)', color: 'rgb(99,102,241)', fontSize: '10px' }}>Vision</span>}
+                                                {tenantForDefault?.default_model_id === m.id ? (
+                                                    <span className="badge" style={{ background: 'rgba(34,197,94,0.15)', color: 'rgb(34,197,94)', fontSize: '10px' }}>{t('enterprise.llm.defaultBadge', '默认')}</span>
+                                                ) : m.enabled ? (
+                                                    <button className="btn btn-ghost" style={{ fontSize: '12px' }} onClick={() => setDefaultModel.mutate(m.id)} title={t('enterprise.llm.setAsDefaultTitle', 'Set as default for new agents')}>
+                                                        {t('enterprise.llm.setAsDefault', '设为默认')}
+                                                    </button>
+                                                ) : null}
                                                 <button className="btn btn-ghost" onClick={() => {
                                                     setEditingModelId(m.id);
                                                     setModelForm({ provider: m.provider, model: m.model, label: m.label, base_url: m.base_url || '', api_key: m.api_key_masked || '', supports_vision: m.supports_vision || false, max_output_tokens: m.max_output_tokens ? String(m.max_output_tokens) : '', request_timeout: m.request_timeout ? String(m.request_timeout) : '', temperature: m.temperature !== null && m.temperature !== undefined ? String(m.temperature) : '' });

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -31,6 +31,7 @@ import {
     IconCheck,
 } from '@tabler/icons-react';
 import { useAppStore } from '../stores';
+import TalentMarketModal from '../components/TalentMarketModal';
 
 /* ────── Tabler Icons ────── */
 const SidebarIcons = {
@@ -249,6 +250,7 @@ export default function Layout() {
     const langSubmenuPortalRef = useRef<HTMLDivElement>(null);
     const langHoverCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [showNotifications, setShowNotifications] = useState(false);
+    const [showTalentMarket, setShowTalentMarket] = useState(false);
     const [notifCategory, setNotifCategory] = useState<string>('all');
     const [selectedNotification, setSelectedNotification] = useState<any | null>(null);
     const [showTenantMenu, setShowTenantMenu] = useState(false);
@@ -664,10 +666,15 @@ export default function Layout() {
                 <div className="sidebar-bottom">
                     <div className="sidebar-section" style={{ borderBottom: '1px solid var(--border-subtle)', paddingBottom: '8px', marginBottom: 0 }}>
                         {user && (
-                            <NavLink to="/agents/new" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`} title={t('nav.newAgent')}>
+                            <button
+                                onClick={() => setShowTalentMarket(true)}
+                                className="sidebar-item"
+                                title={t('nav.hire', t('nav.newAgent'))}
+                                style={{ background: 'transparent', border: 'none', width: '100%', textAlign: 'left', cursor: 'pointer' }}
+                            >
                                 <span className="sidebar-item-icon" style={{ display: 'flex' }}>{SidebarIcons.plus}</span>
-                                <span className="sidebar-item-text">{t('nav.newAgent')}</span>
-                            </NavLink>
+                                <span className="sidebar-item-text">{t('nav.hire', t('nav.newAgent'))}</span>
+                            </button>
                         )}
                         {user && ['platform_admin', 'org_admin'].includes(user.role) && (
                             <NavLink to="/enterprise" className={({ isActive }) => `sidebar-item ${isActive ? 'active' : ''}`} title={t('nav.enterprise')}>
@@ -1034,6 +1041,11 @@ export default function Layout() {
                     isChinese={!!isChinese}
                 />
             )}
+
+            <TalentMarketModal
+                open={showTalentMarket}
+                onClose={() => setShowTalentMarket(false)}
+            />
         </div>
     );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -198,6 +198,9 @@ export const tenantApi = {
 
     resolveByDomain: (domain: string) =>
         request<any>(`/tenants/resolve-by-domain?domain=${encodeURIComponent(domain)}`),
+
+    me: () =>
+        request<{ id: string; name: string; default_model_id: string | null; [k: string]: any }>('/tenants/me'),
 };
 
 export const adminApi = {
@@ -340,6 +343,9 @@ export const enterpriseApi = {
         const tid = localStorage.getItem('current_tenant_id');
         return request<any[]>(`/enterprise/llm-models${tid ? `?tenant_id=${tid}` : ''}`);
     },
+
+    setDefaultModel: (modelId: string) =>
+        request<void>(`/enterprise/llm-models/${modelId}/set-default`, { method: 'POST' }),
     templates: () => request<any[]>('/agents/templates'),
 
     // Enterprise Knowledge Base

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,9 @@ export interface Agent {
     context_window_size?: number;
     agent_type?: 'native' | 'openclaw';
     openclaw_last_seen?: string;
+    // True when the viewing user has already been onboarded to this agent.
+    // Defaults to true on list endpoints that don't compute per-viewer state.
+    onboarded_for_me?: boolean;
     created_at: string;
     last_active_at?: string;
 }


### PR DESCRIPTION
## Summary

Two linked user-facing features that reshape how employees are hired, met, and configured:

1. **Talent Market** — the sidebar's create-agent button now opens a grid modal of built-in templates (plus a dashed custom-agent card that falls back to the existing wizard). A PostHireSettingsModal collects visibility + preferred model, with `仅创建` or `立即对话` actions. `立即对话` lands on `#chat` so users skip the status tab on first entry.
2. **Tenant default LLM model** — the first enabled model an admin adds becomes the company's default; new agents inherit it; chat users can override per-session via a compact `ModelSwitcher` pill docked next to the send button.

And the feature that **redesigned from scratch** versus the v1 of this branch:

3. **Per-(user, agent) onboarding** — every unique pair gets one onboarding conversation. The first person to ever chat with an agent gets the **founding** flow (template-specific, collects project context, suggests a first task). Every subsequent user meets the agent via a **welcoming** flow (generic built-in, introduces the agent and asks how to help — no context re-collection). The lock fires as soon as the agent starts streaming its greeting, so the ritual never retriggers even if the user closes mid-flow.

## How the onboarding mechanics work

- **Data model:** `agent_user_onboardings(agent_id, user_id, onboarded_at)` is the source of truth. Row present = user has been onboarded; no row = next chat turn will have a system prompt injected.
- **Founder vs welcomer:** the founder is defined as "the first user who opens chat with this agent" (not `agent.creator_id`) — so admins hiring on behalf of a team don't blow the context-collection questions on themselves.
- **Backfill:** every existing (agent, user) pair with chat history is inserted into the junction table so established relationships never re-onboard.
- **Dropped in this rewrite:** the old file-based `workspace/bootstrap.md` activation flow + the short-lived `Agent.bootstrapped` column. Activation is pure DB + in-memory prompt injection now.

## Commits

- `feat(backend): per-(user, agent) onboarding + tenant default model + Talent Market APIs` — models, migrations, onboarding service, API endpoints, WebSocket protocol
- `feat(frontend): Talent Market, post-hire settings, per-user onboarding kickoff, ModelSwitcher` — new components + page wiring + ModelSwitcher docked to send button
- `chore: i18n strings, Agent type, api client helpers`

## Data model changes (Alembic migrations)

- `add_agent_bootstrap_fields` — adds `AgentTemplate.bootstrap_content` and `AgentTemplate.capability_bullets`
- `add_tenant_default_model` — adds `Tenant.default_model_id`, backfills each tenant to its earliest-enabled model
- `add_agent_user_onboardings` — creates the junction table, backfills pairs from `chat_messages`, drops the obsolete `Agent.bootstrapped` column

## Test plan

- [ ] Migrations apply cleanly on a fresh DB and on a DB with existing agents/tenants/chat history
- [ ] Sidebar `招聘新成员` opens the Talent Market; custom card routes to `/agents/new`
- [ ] `立即对话` creates the agent, lands on `/agents/:id#chat` with the agent's greeting streaming in; no user bubble visible
- [ ] `仅创建` creates the agent without navigation; new agent appears in sidebar
- [ ] Agent's `role_description` auto-fills from template
- [ ] **Founding flow:** first user meeting a newly-hired template agent gets the template's context-collection greeting
- [ ] **Welcoming flow:** second user meeting the same agent gets the short welcoming intro, no context questions
- [ ] **Lock semantics:** user closes chat mid-greeting → next session does NOT re-trigger onboarding
- [ ] Existing agents with prior chat history: user never gets onboarding (backfill worked)
- [ ] Admin adding the first enabled model auto-sets it as tenant default; `设为默认` reassigns
- [ ] `AgentCreate` wizard preselects tenant default in the model step
- [ ] Chat `ModelSwitcher` pill is docked to the send button with fixed gap regardless of textarea width; dropdown tags the tenant default; switching affects only the current session
- [ ] `/tenants/me` readable by any authenticated member