### PR TITLE
fix: unified dialog/toast UI for all confirm and alert popups

### DIFF
--- a/frontend/src/components/Dialog/DialogProvider.tsx
+++ b/frontend/src/components/Dialog/DialogProvider.tsx
@@ -1,0 +1,189 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+
+type DialogType = 'info' | 'success' | 'warning' | 'error';
+
+interface AlertOptions {
+    title?: string;
+    type?: DialogType;
+    details?: string;
+    confirmLabel?: string;
+}
+
+interface ConfirmOptions {
+    title?: string;
+    danger?: boolean;
+    confirmLabel?: string;
+    cancelLabel?: string;
+}
+
+interface DialogContextValue {
+    alert: (message: string, options?: AlertOptions) => Promise<void>;
+    confirm: (message: string, options?: ConfirmOptions) => Promise<boolean>;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+type ModalState =
+    | { kind: 'alert'; message: string; options: AlertOptions; resolve: () => void }
+    | { kind: 'confirm'; message: string; options: ConfirmOptions; resolve: (ok: boolean) => void }
+    | null;
+
+const TYPE_META: Record<DialogType, { color: string; icon: string }> = {
+    info: { color: 'var(--info)', icon: 'ℹ' },
+    success: { color: 'var(--success)', icon: '✓' },
+    warning: { color: 'var(--warning)', icon: '⚠' },
+    error: { color: 'var(--error)', icon: '✕' },
+};
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+    const [state, setState] = useState<ModalState>(null);
+
+    const alert = useCallback(
+        (message: string, options: AlertOptions = {}) =>
+            new Promise<void>((resolve) => setState({ kind: 'alert', message, options, resolve })),
+        [],
+    );
+
+    const confirm = useCallback(
+        (message: string, options: ConfirmOptions = {}) =>
+            new Promise<boolean>((resolve) => setState({ kind: 'confirm', message, options, resolve })),
+        [],
+    );
+
+    const close = useCallback((result?: boolean) => {
+        setState((s) => {
+            if (!s) return null;
+            if (s.kind === 'alert') s.resolve();
+            else s.resolve(!!result);
+            return null;
+        });
+    }, []);
+
+    return (
+        <DialogContext.Provider value={{ alert, confirm }}>
+            {children}
+            {state && <DialogModal state={state} onClose={close} />}
+        </DialogContext.Provider>
+    );
+}
+
+function DialogModal({ state, onClose }: { state: NonNullable<ModalState>; onClose: (result?: boolean) => void }) {
+    const btnRef = useRef<HTMLButtonElement>(null);
+    const [showDetails, setShowDetails] = useState(false);
+
+    useEffect(() => {
+        const timer = setTimeout(() => btnRef.current?.focus(), 50);
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose(false);
+            if (e.key === 'Enter' && state.kind === 'alert') onClose();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => { clearTimeout(timer); window.removeEventListener('keydown', onKey); };
+    }, [state, onClose]);
+
+    const isConfirm = state.kind === 'confirm';
+    const type: DialogType = isConfirm
+        ? (state.options.danger ? 'error' : 'info')
+        : (state.options.type ?? 'info');
+    const meta = TYPE_META[type];
+    const title = state.options.title
+        ?? (isConfirm ? '请确认' : type === 'error' ? '出错了' : type === 'success' ? '成功' : type === 'warning' ? '提示' : '提示');
+    const details = !isConfirm ? state.options.details : undefined;
+
+    return (
+        <div
+            style={{
+                position: 'fixed', inset: 0,
+                background: 'rgba(0,0,0,0.5)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                zIndex: 10000,
+            }}
+            onClick={(e) => { if (e.target === e.currentTarget) onClose(false); }}
+        >
+            <div
+                role="dialog"
+                aria-modal="true"
+                style={{
+                    background: 'var(--bg-primary)',
+                    borderRadius: '12px',
+                    padding: '24px',
+                    width: '420px',
+                    maxWidth: '90vw',
+                    maxHeight: '80vh',
+                    overflow: 'auto',
+                    border: '1px solid var(--border-subtle)',
+                    boxShadow: '0 20px 60px rgba(0,0,0,0.4)',
+                }}
+            >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '12px' }}>
+                    <span
+                        aria-hidden
+                        style={{
+                            width: '22px', height: '22px', borderRadius: '50%',
+                            background: meta.color, color: '#fff',
+                            display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                            fontSize: '13px', fontWeight: 700, flexShrink: 0,
+                        }}
+                    >{meta.icon}</span>
+                    <h4 style={{ margin: 0, fontSize: '15px', fontWeight: 600 }}>{title}</h4>
+                </div>
+                <div style={{ fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.6, marginBottom: details ? '12px' : '20px', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                    {state.message}
+                </div>
+                {details && (
+                    <div style={{ marginBottom: '20px' }}>
+                        <button
+                            type="button"
+                            onClick={() => setShowDetails((v) => !v)}
+                            style={{
+                                background: 'none', border: 'none', padding: 0,
+                                color: 'var(--text-tertiary)', fontSize: '12px',
+                                cursor: 'pointer', textDecoration: 'underline',
+                            }}
+                        >
+                            {showDetails ? '收起详细信息' : '查看详细信息'}
+                        </button>
+                        {showDetails && (
+                            <pre style={{
+                                marginTop: '8px',
+                                padding: '10px 12px',
+                                background: 'var(--bg-tertiary)',
+                                border: '1px solid var(--border-subtle)',
+                                borderRadius: '6px',
+                                fontSize: '11px',
+                                color: 'var(--text-secondary)',
+                                maxHeight: '240px',
+                                overflow: 'auto',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-all',
+                                fontFamily: 'var(--font-mono)',
+                            }}>{details}</pre>
+                        )}
+                    </div>
+                )}
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8px' }}>
+                    {isConfirm && (
+                        <button className="btn btn-secondary" onClick={() => onClose(false)}>
+                            {state.options.cancelLabel ?? '取消'}
+                        </button>
+                    )}
+                    <button
+                        ref={btnRef}
+                        className={isConfirm && state.options.danger ? 'btn btn-danger' : 'btn btn-primary'}
+                        onClick={() => onClose(true)}
+                    >
+                        {isConfirm
+                            ? (state.options.confirmLabel ?? '确定')
+                            : (state.options.confirmLabel ?? '确定')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function useDialog() {
+    const ctx = useContext(DialogContext);
+    if (!ctx) throw new Error('useDialog must be used within DialogProvider');
+    return ctx;
+}

--- a/frontend/src/components/Toast/ToastProvider.tsx
+++ b/frontend/src/components/Toast/ToastProvider.tsx
@@ -1,0 +1,182 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react';
+
+type ToastType = 'info' | 'success' | 'warning' | 'error';
+
+interface ToastOptions {
+    duration?: number;
+    details?: string;
+}
+
+interface ToastItem {
+    id: number;
+    type: ToastType;
+    message: string;
+    details?: string;
+    duration: number;
+}
+
+interface ToastContextValue {
+    show: (type: ToastType, message: string, options?: ToastOptions) => void;
+    info: (message: string, options?: ToastOptions) => void;
+    success: (message: string, options?: ToastOptions) => void;
+    warning: (message: string, options?: ToastOptions) => void;
+    error: (message: string, options?: ToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const TYPE_META: Record<ToastType, { color: string; icon: string }> = {
+    info: { color: 'var(--info)', icon: 'ℹ' },
+    success: { color: 'var(--success)', icon: '✓' },
+    warning: { color: 'var(--warning)', icon: '⚠' },
+    error: { color: 'var(--error)', icon: '✕' },
+};
+
+let idSeq = 0;
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+    const [items, setItems] = useState<ToastItem[]>([]);
+
+    const remove = useCallback((id: number) => {
+        setItems((list) => list.filter((t) => t.id !== id));
+    }, []);
+
+    const show = useCallback((type: ToastType, message: string, options: ToastOptions = {}) => {
+        const id = ++idSeq;
+        const duration = options.duration ?? (type === 'error' ? 6000 : 3500);
+        setItems((list) => [...list, { id, type, message, details: options.details, duration }]);
+    }, []);
+
+    const value: ToastContextValue = {
+        show,
+        info: (m, o) => show('info', m, o),
+        success: (m, o) => show('success', m, o),
+        warning: (m, o) => show('warning', m, o),
+        error: (m, o) => show('error', m, o),
+    };
+
+    return (
+        <ToastContext.Provider value={value}>
+            {children}
+            <div
+                style={{
+                    position: 'fixed',
+                    top: '20px',
+                    right: '20px',
+                    zIndex: 10001,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: '10px',
+                    pointerEvents: 'none',
+                    maxWidth: '380px',
+                }}
+            >
+                {items.map((t) => (
+                    <ToastCard key={t.id} item={t} onClose={() => remove(t.id)} />
+                ))}
+            </div>
+        </ToastContext.Provider>
+    );
+}
+
+function ToastCard({ item, onClose }: { item: ToastItem; onClose: () => void }) {
+    const [showDetails, setShowDetails] = useState(false);
+    const [leaving, setLeaving] = useState(false);
+    const timerRef = useRef<number | null>(null);
+    const meta = TYPE_META[item.type];
+
+    useEffect(() => {
+        timerRef.current = window.setTimeout(() => {
+            setLeaving(true);
+            window.setTimeout(onClose, 180);
+        }, item.duration);
+        return () => { if (timerRef.current) window.clearTimeout(timerRef.current); };
+    }, [item.duration, onClose]);
+
+    const pause = () => { if (timerRef.current) window.clearTimeout(timerRef.current); };
+
+    return (
+        <div
+            role="status"
+            onMouseEnter={pause}
+            style={{
+                pointerEvents: 'auto',
+                background: 'var(--bg-elevated)',
+                border: '1px solid var(--border-subtle)',
+                borderLeft: `3px solid ${meta.color}`,
+                borderRadius: '8px',
+                padding: '12px 14px',
+                boxShadow: '0 8px 24px rgba(0,0,0,0.3)',
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '10px',
+                fontSize: '13px',
+                color: 'var(--text-primary)',
+                opacity: leaving ? 0 : 1,
+                transform: leaving ? 'translateX(20px)' : 'translateX(0)',
+                transition: 'opacity 180ms ease, transform 180ms ease',
+                minWidth: '240px',
+            }}
+        >
+            <span
+                aria-hidden
+                style={{
+                    width: '18px', height: '18px', borderRadius: '50%',
+                    background: meta.color, color: '#fff',
+                    display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                    fontSize: '11px', fontWeight: 700, flexShrink: 0, marginTop: '1px',
+                }}
+            >{meta.icon}</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ lineHeight: 1.5, wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{item.message}</div>
+                {item.details && (
+                    <>
+                        <button
+                            type="button"
+                            onClick={() => setShowDetails((v) => !v)}
+                            style={{
+                                background: 'none', border: 'none', padding: 0,
+                                color: 'var(--text-tertiary)', fontSize: '11px',
+                                cursor: 'pointer', textDecoration: 'underline', marginTop: '4px',
+                            }}
+                        >
+                            {showDetails ? '收起详情' : '查看详情'}
+                        </button>
+                        {showDetails && (
+                            <pre style={{
+                                marginTop: '6px',
+                                padding: '8px',
+                                background: 'var(--bg-tertiary)',
+                                border: '1px solid var(--border-subtle)',
+                                borderRadius: '4px',
+                                fontSize: '11px',
+                                color: 'var(--text-secondary)',
+                                maxHeight: '160px',
+                                overflow: 'auto',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-all',
+                                fontFamily: 'var(--font-mono)',
+                            }}>{item.details}</pre>
+                        )}
+                    </>
+                )}
+            </div>
+            <button
+                type="button"
+                onClick={() => { setLeaving(true); window.setTimeout(onClose, 180); }}
+                aria-label="Close"
+                style={{
+                    background: 'none', border: 'none', padding: 0,
+                    color: 'var(--text-tertiary)', cursor: 'pointer',
+                    fontSize: '14px', lineHeight: 1, flexShrink: 0,
+                }}
+            >✕</button>
+        </div>
+    );
+}
+
+export function useToast() {
+    const ctx = useContext(ToastContext);
+    if (!ctx) throw new Error('useToast must be used within ToastProvider');
+    return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,8 @@ import './i18n';
 import './index.css';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
+import { DialogProvider } from './components/Dialog/DialogProvider';
+import { ToastProvider } from './components/Toast/ToastProvider';
 import { loadSavedAccentColor } from './utils/theme';
 
 // Apply saved theme color before first paint
@@ -22,7 +24,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <ErrorBoundary>
             <QueryClientProvider client={queryClient}>
                 <BrowserRouter>
-                    <App />
+                    <DialogProvider>
+                        <ToastProvider>
+                            <App />
+                        </ToastProvider>
+                    </DialogProvider>
                 </BrowserRouter>
             </QueryClientProvider>
         </ErrorBoundary>

--- a/frontend/src/pages/AdminCompanies.tsx
+++ b/frontend/src/pages/AdminCompanies.tsx
@@ -6,6 +6,7 @@ import { saveAccentColor, getSavedAccentColor } from '../utils/theme';
 import { IconFilter } from '@tabler/icons-react';
 import PlatformDashboard from './PlatformDashboard';
 import LinearCopyButton from '../components/LinearCopyButton';
+import { useDialog } from '../components/Dialog/DialogProvider';
 // Helper for authenticated JSON fetch
 async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
     const token = localStorage.getItem('token');
@@ -639,6 +640,7 @@ function PlatformTab() {
 // ─── Companies Tab ─────────────────────────────────
 function CompaniesTab() {
     const { t } = useTranslation();
+    const dialog = useDialog();
     const [companies, setCompanies] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
@@ -750,7 +752,10 @@ function CompaniesTab() {
 
     const handleToggle = async (id: string, currentlyActive: boolean) => {
         const action = currentlyActive ? 'disable' : 'enable';
-        if (currentlyActive && !confirm(t('admin.confirmDisable', 'Disable this company? All users and agents will be paused.'))) return;
+        if (currentlyActive) {
+            const ok = await dialog.confirm(t('admin.confirmDisable', 'Disable this company? All users and agents will be paused.'), { title: '禁用公司', danger: true, confirmLabel: '禁用' });
+            if (!ok) return;
+        }
         try {
             await adminApi.toggleCompany(id);
             loadCompanies();

--- a/frontend/src/pages/AgentCreate.tsx
+++ b/frontend/src/pages/AgentCreate.tsx
@@ -5,6 +5,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { agentApi, channelApi, enterpriseApi, skillApi } from '../services/api';
 import ChannelConfig from '../components/ChannelConfig';
 import LinearCopyButton from '../components/LinearCopyButton';
+import { useToast } from '../components/Toast/ToastProvider';
 const STEPS = ['basicInfo', 'personality', 'skills', 'permissions', 'channel'] as const;
 const OPENCLAW_STEPS = ['basicInfo', 'permissions'] as const;
 
@@ -60,6 +61,7 @@ function parseSoulTemplate(soulTemplate: string, sectionNames: string[] = []): R
 
 export default function AgentCreate() {
     const { t } = useTranslation();
+    const toast = useToast();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const [step, setStep] = useState(0);
@@ -609,7 +611,7 @@ For humans, the message is delivered via their available channel (e.g. Feishu).`
                                                         template_id: '',
                                                     }));
                                                 } catch {
-                                                    alert('Invalid JSON file');
+                                                    toast.error('JSON 文件格式无效');
                                                 }
                                             };
                                             reader.readAsText(file);

--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -4,6 +4,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import ConfirmModal from '../components/ConfirmModal';
+import { useDialog } from '../components/Dialog/DialogProvider';
+import { useToast } from '../components/Toast/ToastProvider';
 import type { FileBrowserApi } from '../components/FileBrowser';
 import FileBrowser from '../components/FileBrowser';
 import ChannelConfig from '../components/ChannelConfig';
@@ -48,6 +50,8 @@ const getCategoryLabels = (t: any): Record<string, string> => ({
 
 function ToolsManager({ agentId, canManage = false }: { agentId: string; canManage?: boolean }) {
     const { t } = useTranslation();
+    const dialog = useDialog();
+    const toast = useToast();
     const [tools, setTools] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [configTool, setConfigTool] = useState<any | null>(null);
@@ -215,7 +219,7 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                 setConfigTool(null);
             }
             loadTools();
-        } catch (e) { alert('Save failed: ' + e); }
+        } catch (e: any) { toast.error('保存失败', { details: String(e?.message || e) }); }
         setConfigSaving(false);
     };
 
@@ -316,7 +320,11 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                                     {canManage && tool.source === 'agent' && tool.agent_tool_id && (
                                         <button
                                             onClick={async () => {
-                                                if (!confirm(t('agent.tools.confirmDelete', `Remove "${tool.display_name}" from this agent?`))) return;
+                                                const ok = await dialog.confirm(
+                                                    t('agent.tools.confirmDelete', `Remove "${tool.display_name}" from this agent?`),
+                                                    { danger: true, confirmLabel: '移除' },
+                                                );
+                                                if (!ok) return;
                                                 setDeletingToolId(tool.id);
                                                 try {
                                                     const token = localStorage.getItem('token');
@@ -325,8 +333,8 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                                                         headers: { Authorization: `Bearer ${token}` },
                                                     });
                                                     if (res.ok) await loadTools();
-                                                    else alert('Delete failed');
-                                                } catch (e) { alert('Delete failed: ' + e); }
+                                                    else toast.error('删除失败');
+                                                } catch (e: any) { toast.error('删除失败', { details: String(e?.message || e) }); }
                                                 setDeletingToolId(null);
                                             }}
                                             disabled={deletingToolId === tool.id}
@@ -648,8 +656,12 @@ function ToolsManager({ agentId, canManage = false }: { agentId: string; canMana
                                                     headers: { Authorization: `Bearer ${token}` }
                                                 });
                                                 const data = await res.json();
-                                                alert(data.message || (data.ok ? '✅ Test successful' : '❌ Test failed: ' + data.error));
-                                            } catch (e: any) { alert('Test failed: ' + e.message); }
+                                                if (data.ok) {
+                                                    await dialog.alert(data.message || '测试成功', { type: 'success', title: '连通性测试' });
+                                                } else {
+                                                    await dialog.alert('测试失败', { type: 'error', title: '连通性测试', details: typeof data.error === 'string' ? data.error : JSON.stringify(data, null, 2) });
+                                                }
+                                            } catch (e: any) { await dialog.alert('测试失败', { type: 'error', title: '连通性测试', details: String(e?.message || e) }); }
                                             finally { if (btn) btn.textContent = 'Test Connection'; }
                                         }}
                                         id="cat-test-btn"
@@ -1332,6 +1344,8 @@ function RelationshipEditor({ agentId, readOnly = false }: { agentId: string; re
 
 function AgentDetailInner() {
     const { t, i18n } = useTranslation();
+    const dialog = useDialog();
+    const toast = useToast();
     const { id } = useParams<{ id: string }>();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
@@ -1716,16 +1730,20 @@ function AgentDetailInner() {
             } else {
                 const err = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
                 console.error('Failed to create session:', err);
-                alert(`Failed to create session: ${err.detail || res.status}`);
+                toast.error('创建会话失败', { details: String(err.detail || `HTTP ${res.status}`) });
             }
         } catch (err: any) {
             console.error('Failed to create session:', err);
-            alert(`Failed to create session: ${err.message || err}`);
+            toast.error('创建会话失败', { details: String(err.message || err) });
         }
     };
 
     const deleteSession = async (sessionId: string) => {
-        if (!confirm(t('chat.deleteConfirm', 'Delete this session and all its messages? This cannot be undone.'))) return;
+        const ok = await dialog.confirm(
+            t('chat.deleteConfirm', 'Delete this session and all its messages? This cannot be undone.'),
+            { title: '删除会话', danger: true, confirmLabel: '删除' },
+        );
+        if (!ok) return;
         const tkn = localStorage.getItem('token');
         try {
             await fetch(`/api/agents/${id}/sessions/${sessionId}`, { method: 'DELETE', headers: { Authorization: `Bearer ${tkn}` } });
@@ -1743,7 +1761,7 @@ function AgentDetailInner() {
             await fetchMySessions(false, id);
             if (canViewAllAgentChatSessions) await fetchAllSessions();
         } catch (e: any) {
-            alert(e.message || 'Delete failed');
+            toast.error('删除失败', { details: String(e?.message || e) });
         }
     };
 
@@ -1777,7 +1795,7 @@ function AgentDetailInner() {
             });
             queryClient.invalidateQueries({ queryKey: ['agent', id] });
             setShowExpiryModal(false);
-        } catch (e) { alert('Failed: ' + e); }
+        } catch (e: any) { toast.error('保存失败', { details: String(e?.message || e) }); }
         setExpirySaving(false);
     };
     interface ChatMsg { role: 'user' | 'assistant' | 'tool_call'; content: string; fileName?: string; toolName?: string; toolArgs?: any; toolStatus?: 'running' | 'done'; toolResult?: string; thinking?: string; imageUrl?: string; timestamp?: string; }
@@ -2382,7 +2400,7 @@ function AgentDetailInner() {
         if (!files.length) return;
         const allowedFiles = files.slice(0, 10 - attachedFiles.length);
         if (!allowedFiles.length) {
-            alert('Limit of 10 attached files reached.');
+            toast.warning('最多可附加 10 个文件');
             return;
         }
 
@@ -2425,7 +2443,7 @@ function AgentDetailInner() {
                 if (draft.previewUrl) URL.revokeObjectURL(draft.previewUrl);
                 setChatUploadDrafts((prev) => prev.filter((d) => d.id !== draft.id));
                 chatUploadAbortRef.current.delete(draft.id);
-                if (err?.message !== 'Upload cancelled') alert(t('agent.upload.failed'));
+                if (err?.message !== 'Upload cancelled') toast.error(t('agent.upload.failed'), { details: String(err?.message || err) });
             }
         };
 
@@ -2454,7 +2472,7 @@ function AgentDetailInner() {
         e.preventDefault();
         const allowedFiles = filesToUpload.slice(0, 10 - attachedFiles.length);
         if (!allowedFiles.length) {
-            alert('Limit of 10 attached files reached.');
+            toast.warning('最多可附加 10 个文件');
             return;
         }
 
@@ -2497,7 +2515,7 @@ function AgentDetailInner() {
                 if (draft.previewUrl) URL.revokeObjectURL(draft.previewUrl);
                 setChatUploadDrafts((prev) => prev.filter((d) => d.id !== draft.id));
                 chatUploadAbortRef.current.delete(draft.id);
-                if (err?.message !== 'Upload cancelled') alert(t('agent.upload.failed'));
+                if (err?.message !== 'Upload cancelled') toast.error(t('agent.upload.failed'), { details: String(err?.message || err) });
             }
         };
 
@@ -2528,7 +2546,7 @@ function AgentDetailInner() {
                 setAttachedFiles(prev => [...prev, { name: data.filename, text: data.extracted_text, path: data.workspace_path, imageUrl: data.image_data_url || undefined }]);
             } catch (err: any) {
                 if (err?.message !== 'Upload cancelled') {
-                    alert(err?.message || t('agent.upload.failed'));
+                    toast.error(t('agent.upload.failed'), { details: String(err?.message || '') });
                 }
             } finally {
                 if (previewUrl) URL.revokeObjectURL(previewUrl);
@@ -2588,7 +2606,7 @@ function AgentDetailInner() {
         },
         onError: (err: any) => {
             const msg = err?.detail || err?.message || String(err);
-            alert(`Failed to create schedule: ${msg}`);
+            toast.error('创建计划任务失败', { details: String(msg) });
         },
     });
 
@@ -3306,7 +3324,8 @@ function AgentDetailInner() {
                                                             <button className="btn btn-ghost" style={{ padding: '2px 6px', fontSize: '11px', color: 'var(--error)' }}
                                                                 onClick={async (e) => {
                                                                     e.stopPropagation();
-                                                                    if (confirm(t('agent.aware.deleteTriggerConfirm', { name: trig.name }))) {
+                                                                    const ok = await dialog.confirm(t('agent.aware.deleteTriggerConfirm', { name: trig.name }), { title: '删除触发器', danger: true, confirmLabel: '删除' });
+                                                                    if (ok) {
                                                                         await triggerApi.delete(id!, trig.id);
                                                                         refetchTriggers();
                                                                     }
@@ -3475,7 +3494,8 @@ function AgentDetailInner() {
                                                     </button>
                                                     <button className="btn btn-ghost" style={{ padding: '2px 6px', fontSize: '11px', color: 'var(--error)' }}
                                                         onClick={async () => {
-                                                            if (confirm(t('agent.aware.deleteTriggerConfirm', { name: trig.name }))) {
+                                                            const ok = await dialog.confirm(t('agent.aware.deleteTriggerConfirm', { name: trig.name }), { title: '删除触发器', danger: true, confirmLabel: '删除' });
+                                                            if (ok) {
                                                                 await triggerApi.delete(id!, trig.id);
                                                                 refetchTriggers();
                                                             }
@@ -3918,10 +3938,10 @@ function AgentDetailInner() {
                                                                 setAgentClawhubInstalling(r.slug);
                                                                 try {
                                                                     const res = await skillApi.agentImport.fromClawhub(id!, r.slug);
-                                                                    alert(`Installed "${r.displayName || r.slug}" (${res.files_written} files)`);
+                                                                    toast.success(`已安装 "${r.displayName || r.slug}"（${res.files_written} 个文件）`);
                                                                     queryClient.invalidateQueries({ queryKey: ['files', id, 'skills'] });
                                                                 } catch (err: any) {
-                                                                    alert(`Import failed: ${err?.message || err}`);
+                                                                    await dialog.alert('安装失败', { type: 'error', details: String(err?.message || err) });
                                                                 } finally {
                                                                     setAgentClawhubInstalling(null);
                                                                 }
@@ -3963,11 +3983,11 @@ function AgentDetailInner() {
                                                         setAgentUrlImporting(true);
                                                         try {
                                                             const res = await skillApi.agentImport.fromUrl(id!, agentUrlInput.trim());
-                                                            alert(`Imported ${res.files_written} files`);
+                                                            toast.success(`已导入 ${res.files_written} 个文件`);
                                                             queryClient.invalidateQueries({ queryKey: ['files', id, 'skills'] });
                                                             setShowAgentUrlImport(false);
                                                         } catch (err: any) {
-                                                            alert(`Import failed: ${err?.message || err}`);
+                                                            await dialog.alert('导入失败', { type: 'error', details: String(err?.message || err) });
                                                         } finally {
                                                             setAgentUrlImporting(false);
                                                         }
@@ -4030,11 +4050,11 @@ function AgentDetailInner() {
                                                                     setImportingSkillId(skill.id);
                                                                     try {
                                                                         const res = await fileApi.importSkill(id!, skill.id);
-                                                                        alert(`✅ Imported "${skill.name}" (${res.files_written} files)`);
+                                                                        toast.success(`已导入 "${skill.name}"（${res.files_written} 个文件）`);
                                                                         queryClient.invalidateQueries({ queryKey: ['files', id, 'skills'] });
                                                                         setShowImportSkillModal(false);
                                                                     } catch (err: any) {
-                                                                        alert(`❌ Import failed: ${err?.message || err}`);
+                                                                        await dialog.alert('导入失败', { type: 'error', details: String(err?.message || err) });
                                                                     } finally {
                                                                         setImportingSkillId(null);
                                                                     }
@@ -5727,7 +5747,7 @@ function AgentDetailInner() {
                                                         queryClient.invalidateQueries({ queryKey: ['agents'] });
                                                         navigate('/');
                                                     } catch (err: any) {
-                                                        alert(err?.message || 'Failed to delete agent');
+                                                        await dialog.alert('删除数字员工失败', { type: 'error', details: String(err?.message || err) });
                                                     }
                                                 }}>{t('agent.settings.danger.confirmDelete')}</button>
                                                 <button className="btn btn-secondary" onClick={() => setShowDeleteConfirm(false)}>{t('common.cancel')}</button>

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -9,6 +9,7 @@ import { IconPaperclip, IconSend } from '@tabler/icons-react';
 import { formatFileSize } from '../utils/formatFileSize';
 import { useAuthStore } from '../stores';
 import { useDropZone } from '../hooks/useDropZone';
+import { useToast } from '../components/Toast/ToastProvider';
 
 /* ── Inline SVG Icons ── */
 const Icons = {
@@ -262,6 +263,7 @@ function ChatToolChain({ toolCalls }: { toolCalls: ToolCall[] }) {
 
 export default function Chat() {
     const { t } = useTranslation();
+    const toast = useToast();
     const { id } = useParams<{ id: string }>();
     const token = useAuthStore((s) => s.token);
     const [messages, setMessages] = useState<Message[]>([]);
@@ -646,7 +648,7 @@ export default function Chat() {
             });
         } catch (err: any) {
             if (err?.message !== 'Upload cancelled') {
-                alert(t('agent.upload.failed') + (err?.message ? `: ${err.message}` : ''));
+                toast.error(t('agent.upload.failed'), { details: String(err?.message || '') });
             }
         } finally {
             if (previewUrl) URL.revokeObjectURL(previewUrl);
@@ -750,7 +752,7 @@ export default function Chat() {
             });
         } catch (err: any) {
             if (err?.message !== 'Upload cancelled') {
-                alert(t('agent.upload.failed') + (err?.message ? `: ${err.message}` : ''));
+                toast.error(t('agent.upload.failed'), { details: String(err?.message || '') });
             }
         } finally {
             if (previewUrl) URL.revokeObjectURL(previewUrl);

--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -10,6 +10,8 @@ import { saveAccentColor, getSavedAccentColor, resetAccentColor, PRESET_COLORS }
 import UserManagement from './UserManagement';
 import InvitationCodes from './InvitationCodes';
 import LinearCopyButton from '../components/LinearCopyButton';
+import { useDialog } from '../components/Dialog/DialogProvider';
+import { useToast } from '../components/Toast/ToastProvider';
 // API helpers for enterprise endpoints
 async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
     const token = localStorage.getItem('token');
@@ -131,6 +133,8 @@ function SsoChannelSection({ idpType, existingProvider, tenant, t }: {
     idpType: string; existingProvider: any; tenant: any; t: any;
 }) {
     const qc = useQueryClient();
+    const dialog = useDialog();
+    const toast = useToast();
     const [liveDomain, setLiveDomain] = useState<string>(existingProvider?.sso_domain || tenant?.sso_domain || '');
     const [ssoError, setSsoError] = useState<string>('');
     const [toggling, setToggling] = useState(false);
@@ -145,7 +149,7 @@ function SsoChannelSection({ idpType, existingProvider, tenant, t }: {
 
     const handleSsoToggle = async () => {
         if (!existingProvider) {
-            alert(t('enterprise.identity.saveFirst', 'Please save the configuration first to enable SSO.'));
+            toast.warning(t('enterprise.identity.saveFirst', 'Please save the configuration first to enable SSO.'));
             return;
         }
         const newVal = !ssoEnabled;
@@ -743,7 +747,7 @@ function OrgTab({ tenant }: { tenant: any }) {
                             <span style={{ fontSize: '12px', color: 'var(--success)' }}>Saved</span>
                         )}
                         {existingProvider && (
-                            <button className="btn btn-ghost btn-sm" style={{ color: 'var(--error)' }} onClick={() => confirm('Are you sure you want to delete this configuration?') && deleteProvider.mutate(existingProvider.id)}>
+                            <button className="btn btn-ghost btn-sm" style={{ color: 'var(--error)' }} onClick={async () => { const ok = await dialog.confirm('确定要删除此配置吗？', { title: '删除配置', danger: true, confirmLabel: '删除' }); if (ok) deleteProvider.mutate(existingProvider.id); }}>
                                 {t('common.delete', 'Delete')}
                             </button>
                         )}
@@ -1659,6 +1663,7 @@ function CompanyTimezoneEditor() {
 // ── Broadcast Section ──────────────────────────
 function BroadcastSection() {
     const { t } = useTranslation();
+    const toast = useToast();
     const [title, setTitle] = useState('');
     const [body, setBody] = useState('');
     const [sendEmail, setSendEmail] = useState(false);
@@ -1678,7 +1683,7 @@ function BroadcastSection() {
             });
             if (!res.ok) {
                 const err = await res.json().catch(() => ({}));
-                alert(err.detail || 'Failed to send broadcast');
+                toast.error('广播发送失败', { details: String(err.detail || `HTTP ${res.status}`) });
                 setSending(false);
                 return;
             }
@@ -1692,7 +1697,7 @@ function BroadcastSection() {
             setBody('');
             setSendEmail(false);
         } catch (e: any) {
-            alert(e.message || 'Failed');
+            toast.error('广播发送失败', { details: String(e?.message || e) });
         }
         setSending(false);
     };
@@ -1753,6 +1758,8 @@ function BroadcastSection() {
 
 export default function EnterpriseSettings() {
     const { t } = useTranslation();
+    const dialog = useDialog();
+    const toast = useToast();
     const qc = useQueryClient();
     const [activeTab, setActiveTab] = useState<'llm' | 'org' | 'info' | 'approvals' | 'audit' | 'tools' | 'skills' | 'quotas' | 'users' | 'invites'>('info');
 
@@ -1789,7 +1796,7 @@ export default function EnterpriseSettings() {
         try {
             await fetchJson('/enterprise/tenant-quotas', { method: 'PATCH', body: JSON.stringify(quotaForm) });
             setQuotaSaved(true); setTimeout(() => setQuotaSaved(false), 2000);
-        } catch (e) { alert('Failed to save'); }
+        } catch (e: any) { toast.error('保存失败', { details: String(e?.message || e) }); }
         setQuotaSaving(false);
     };
     const [companyIntro, setCompanyIntro] = useState('');
@@ -1980,8 +1987,8 @@ export default function EnterpriseSettings() {
             if (res.status === 409) {
                 const data = await res.json();
                 const agents = data.detail?.agents || [];
-                const msg = `This model is used by ${agents.length} agent(s):\n\n${agents.join(', ')}\n\nDelete anyway? (their model config will be cleared)`;
-                if (confirm(msg)) {
+                const msg = `该模型正在被 ${agents.length} 个数字员工使用：\n\n${agents.join(', ')}\n\n仍要删除吗？（对应的模型配置会被清空）`;
+                if (await dialog.confirm(msg, { title: '删除模型', danger: true, confirmLabel: '强制删除' })) {
                     // Retry with force
                     const r2 = await fetch(`/api/enterprise/llm-models/${id}?force=true`, {
                         method: 'DELETE',
@@ -2155,11 +2162,11 @@ export default function EnterpriseSettings() {
                                                 if (btn) { btn.textContent = t('enterprise.llm.testSuccess', { latency: result.latency_ms }); btn.style.color = 'var(--success)'; }
                                                 setTimeout(() => { if (btn) { btn.textContent = origText; btn.style.color = ''; } }, 3000);
                                             } else {
-                                                alert(t('enterprise.llm.testFailed', { error: result.error || 'Unknown error', latency: result.latency_ms }));
+                                                await dialog.alert(t('enterprise.llm.testFailedShort', '连通性测试失败'), { type: 'error', title: t('enterprise.llm.testTitle', '连通性测试'), details: String(result.error || 'Unknown error') });
                                                 if (btn) btn.textContent = origText;
                                             }
                                         } catch (e: any) {
-                                            alert(t('enterprise.llm.testError', { message: e.message }));
+                                            await dialog.alert(t('enterprise.llm.testErrorShort', '连通性测试出错'), { type: 'error', title: t('enterprise.llm.testTitle', '连通性测试'), details: String(e?.message || e) });
                                             if (btn) btn.textContent = origText;
                                         }
                                     }}>{t('enterprise.llm.test')}</button>
@@ -2265,11 +2272,11 @@ export default function EnterpriseSettings() {
                                                             if (btn) { btn.textContent = t('enterprise.llm.testSuccess', { latency: result.latency_ms }); btn.style.color = 'var(--success)'; }
                                                             setTimeout(() => { if (btn) { btn.textContent = origText; btn.style.color = ''; } }, 3000);
                                                         } else {
-                                                            alert(t('enterprise.llm.testFailed', { error: result.error || 'Unknown error', latency: result.latency_ms }));
+                                                            await dialog.alert(t('enterprise.llm.testFailedShort', '连通性测试失败'), { type: 'error', title: t('enterprise.llm.testTitle', '连通性测试'), details: String(result.error || 'Unknown error') });
                                                             if (btn) btn.textContent = origText;
                                                         }
                                                     } catch (e: any) {
-                                                        alert(t('enterprise.llm.testError', { message: e.message }));
+                                                        await dialog.alert(t('enterprise.llm.testErrorShort', '连通性测试出错'), { type: 'error', title: t('enterprise.llm.testTitle', '连通性测试'), details: String(e?.message || e) });
                                                         if (btn) btn.textContent = origText;
                                                     }
                                                 }}>{t('enterprise.llm.test')}</button>
@@ -2509,7 +2516,7 @@ export default function EnterpriseSettings() {
                                         onChange={async (e) => {
                                             const wantEnable = e.target.checked;
                                             if (wantEnable) {
-                                                const confirmed = window.confirm(
+                                                const confirmed = await dialog.confirm(
                                                     t('enterprise.a2aAsync.enableWarning',
                                                         [
                                                             '⚠️ You are about to enable the A2A Async Communication feature (Beta).',
@@ -2526,9 +2533,10 @@ export default function EnterpriseSettings() {
                                                             '',
                                                             'Are you sure you want to enable this feature?'
                                                         ].join('\n')
-                                                    )
+                                                    ),
+                                                    { title: '启用 A2A 异步通信（Beta）', confirmLabel: '启用' },
                                                 );
-                                                if (!confirmed) return;
+                                                if (!confirmed) { e.target.checked = false; return; }
                                             }
                                             try {
                                                 await fetchJson(`/tenants/${selectedTenantId}`, {
@@ -2537,7 +2545,7 @@ export default function EnterpriseSettings() {
                                                 });
                                                 qc.invalidateQueries({ queryKey: ['tenant', selectedTenantId] });
                                             } catch (err: any) {
-                                                alert(err.message || 'Update failed');
+                                                toast.error('更新失败', { details: String(err?.message || err) });
                                             }
                                         }}
                                         style={{ opacity: 0, width: 0, height: 0 }}
@@ -2581,8 +2589,11 @@ export default function EnterpriseSettings() {
                             <button
                                 className="btn"
                                 onClick={async () => {
-                                    const name = document.querySelector<HTMLInputElement>('.company-name-input')?.value || selectedTenantId;
-                                    if (!confirm(t('enterprise.deleteCompanyConfirm', 'Are you sure you want to delete this company and ALL its data? This cannot be undone.'))) return;
+                                    const ok = await dialog.confirm(
+                                        t('enterprise.deleteCompanyConfirm', 'Are you sure you want to delete this company and ALL its data? This cannot be undone.'),
+                                        { title: '删除公司', danger: true, confirmLabel: '永久删除' },
+                                    );
+                                    if (!ok) return;
                                     try {
                                         const res = await fetchJson<any>(`/tenants/${selectedTenantId}`, { method: 'DELETE' });
                                         // Switch to fallback tenant
@@ -2592,7 +2603,7 @@ export default function EnterpriseSettings() {
                                         window.dispatchEvent(new StorageEvent('storage', { key: 'current_tenant_id', newValue: fallbackId }));
                                         qc.invalidateQueries({ queryKey: ['tenants'] });
                                     } catch (e: any) {
-                                        alert(e.message || 'Delete failed');
+                                        await dialog.alert('删除失败', { type: 'error', details: String(e?.message || e) });
                                     }
                                 }}
                                 style={{
@@ -2749,7 +2760,8 @@ export default function EnterpriseSettings() {
                                                     </div>
                                                 </div>
                                                 <button className="btn btn-ghost" style={{ color: 'var(--error)', fontSize: '12px' }} onClick={async () => {
-                                                    if (!confirm(t('enterprise.tools.removeFromAgent', { name: row.tool_display_name }))) return;
+                                                    const ok = await dialog.confirm(t('enterprise.tools.removeFromAgent', { name: row.tool_display_name }), { title: '移除工具', danger: true, confirmLabel: '移除' });
+                                                    if (!ok) return;
                                                     try {
                                                         await fetchJson(`/tools/agent-tool/${row.agent_tool_id}`, { method: 'DELETE' });
                                                     } catch {
@@ -2879,7 +2891,7 @@ export default function EnterpriseSettings() {
                                                                         }
                                                                         await loadAllTools();
                                                                     } catch (e: any) {
-                                                                        alert(`${t('enterprise.tools.importFailed') || 'Import failed'}: ${e.message}`);
+                                                                        await dialog.alert(t('enterprise.tools.importFailed') || '导入失败', { type: 'error', details: String(e?.message || e) });
                                                                     }
                                                                 }}>{t('enterprise.tools.import') || 'Import'}</button>
                                                             </div>
@@ -2920,7 +2932,9 @@ export default function EnterpriseSettings() {
                                                                 await loadAllTools();
                                                                 setShowAddMCP(false); setMcpTestResult(null); setMcpForm({ server_url: '', server_name: '', api_key: '' }); setMcpRawInput('');
                                                                 if (errors.length > 0) {
-                                                                    alert(`Imported ${successCount}/${tools.length} tools.\nFailed:\n${errors.join('\n')}`);
+                                                                    await dialog.alert(`已导入 ${successCount}/${tools.length} 个工具`, { type: 'warning', title: '部分导入失败', details: errors.join('\n') });
+                                                                } else if (successCount > 0) {
+                                                                    toast.success(`已导入 ${successCount} 个工具`);
                                                                 }
                                                             }}>{t('enterprise.tools.importAll')}</button>
                                                         </div>
@@ -3027,7 +3041,8 @@ export default function EnterpriseSettings() {
                                                                                 </div>
                                                                                 <div style={{ display: 'flex', alignItems: 'center', gap: '8px', flexShrink: 0 }}>
                                                                                     <button className="btn btn-danger" style={{ padding: '3px 7px', fontSize: '10px' }} onClick={async () => {
-                                                                                        if (!confirm(`${t('common.delete')} ${tool.display_name}?`)) return;
+                                                                                        const ok = await dialog.confirm(`确定删除 ${tool.display_name}？`, { title: '删除工具', danger: true, confirmLabel: '删除' });
+                                                                                        if (!ok) return;
                                                                                         await fetchJson(`/tools/${tool.id}`, { method: 'DELETE' });
                                                                                         await loadAllTools();
                                                                                     }}>{t('common.delete')}</button>
@@ -3066,7 +3081,8 @@ export default function EnterpriseSettings() {
                                                                                             <button style={{ background: 'none', border: '1px solid var(--border-subtle)', borderRadius: '6px', padding: '3px 8px', fontSize: '11px', cursor: 'pointer', color: 'var(--text-secondary)' }} onClick={() => { setEditingToolId(tool.id); setEditingConfig({ ...tool.config }); }}>Configure</button>
                                                                                         )}
                                                                                         <button className="btn btn-danger" style={{ padding: '4px 8px', fontSize: '11px' }} onClick={async () => {
-                                                                                            if (!confirm(`${t('common.delete')} ${tool.display_name}?`)) return;
+                                                                                            const ok = await dialog.confirm(`确定删除 ${tool.display_name}？`, { title: '删除工具', danger: true, confirmLabel: '删除' });
+                                                                                            if (!ok) return;
                                                                                             await fetchJson(`/tools/${tool.id}`, { method: 'DELETE' });
                                                                                             loadAllTools();
                                                                                         }}>{t('common.delete')}</button>
@@ -3129,7 +3145,7 @@ export default function EnterpriseSettings() {
                                                                             await fetchJson('/tools/bulk', { method: 'PUT', body: JSON.stringify(payload) });
                                                                             loadAllTools();
                                                                         } catch (err: any) {
-                                                                            alert('Bulk update failed: ' + err.message);
+                                                                            toast.error('批量更新失败', { details: String(err?.message || err) });
                                                                         }
                                                                     }}
                                                                     style={{ opacity: 0, width: 0, height: 0 }} />
@@ -3197,7 +3213,8 @@ export default function EnterpriseSettings() {
                                                                             {/* Delete (non-builtin only) */}
                                                                             {tool.type !== 'builtin' && (
                                                                                 <button className="btn btn-danger" style={{ padding: '4px 8px', fontSize: '11px' }} onClick={async () => {
-                                                                                    if (!confirm(`${t('common.delete')} ${tool.display_name}?`)) return;
+                                                                                    const ok = await dialog.confirm(`确定删除 ${tool.display_name}？`, { title: '删除工具', danger: true, confirmLabel: '删除' });
+                                                                                    if (!ok) return;
                                                                                     await fetchJson(`/tools/${tool.id}`, { method: 'DELETE' });
                                                                                     loadAllTools();
                                                                                     loadAgentInstalledTools();
@@ -3296,7 +3313,7 @@ export default function EnterpriseSettings() {
                                                     await loadAllTools();
                                                     setEditingMcpServer(null);
                                                 } catch (e: any) {
-                                                    alert('Failed to update server: ' + e.message);
+                                                    toast.error('更新服务器失败', { details: String(e?.message || e) });
                                                 }
                                                 setMcpServerSaving(false);
                                             }}>{mcpServerSaving ? 'Saving...' : 'Save Changes'}</button>

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '../stores';
 import { agentApi, tenantApi, authApi } from '../services/api';
+import { useToast } from '../components/Toast/ToastProvider';
 
 import {
     IconHome,
@@ -233,6 +234,7 @@ function VersionDisplay() {
 
 export default function Layout() {
     const { t, i18n } = useTranslation();
+    const toast = useToast();
     const navigate = useNavigate();
     const { user, logout, setAuth } = useAuthStore();
     const queryClient = useQueryClient();
@@ -308,7 +310,7 @@ export default function Layout() {
         });
         if (!res.ok) {
             const err = await res.json().catch(() => ({ detail: 'Failed to switch tenant' }));
-            alert(err.detail || 'Failed to switch tenant');
+            toast.error('切换公司失败', { details: String(err.detail || `HTTP ${res.status}`) });
             return;
         }
         const data = await res.json();

--- a/frontend/src/pages/UserManagement.tsx
+++ b/frontend/src/pages/UserManagement.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../stores';
 import LinearCopyButton from '../components/LinearCopyButton';
+import { useDialog } from '../components/Dialog/DialogProvider';
 
 interface UserInfo {
     id: string;
@@ -49,6 +50,7 @@ export default function UserManagement() {
     const { t, i18n } = useTranslation();
     const isChinese = i18n.language?.startsWith('zh');
     const { user: currentUser, setUser } = useAuthStore();
+    const dialog = useDialog();
 
     const [users, setUsers] = useState<UserInfo[]>([]);
     const [loading, setLoading] = useState(true);
@@ -315,12 +317,13 @@ export default function UserManagement() {
                                             className="form-input"
                                             value={user.role}
                                             disabled={changingRoleUserId === user.id}
-                                            onChange={e => {
+                                            onChange={async e => {
                                                 const newRole = e.target.value;
                                                 const confirmMsg = isChinese
                                                     ? `确认将 ${user.display_name || user.username} 的角色更改为 ${newRole === 'org_admin' ? 'Admin' : 'Member'}？`
                                                     : `Change ${user.display_name || user.username}'s role to ${newRole === 'org_admin' ? 'Admin' : 'Member'}?`;
-                                                if (confirm(confirmMsg)) handleRoleChange(user.id, newRole);
+                                                const ok = await dialog.confirm(confirmMsg, { title: isChinese ? '更改角色' : 'Change role' });
+                                                if (ok) handleRoleChange(user.id, newRole);
                                             }}
                                             style={{ fontSize: '11px', padding: '2px 4px', width: '100%', minWidth: 0 }}
                                         >

--- a/frontend/src/pages/VerifyEmail.tsx
+++ b/frontend/src/pages/VerifyEmail.tsx
@@ -3,9 +3,11 @@ import { Link, useSearchParams, useNavigate, useLocation } from 'react-router-do
 import { useTranslation } from 'react-i18next';
 import { authApi } from '../services/api';
 import { useAuthStore } from '../stores';
+import { useToast } from '../components/Toast/ToastProvider';
 
 export default function VerifyEmail() {
     const { t, i18n } = useTranslation();
+    const toast = useToast();
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
     const location = useLocation();
@@ -79,9 +81,9 @@ export default function VerifyEmail() {
         setLoading(true);
         try {
             await authApi.resendVerification(email);
-            alert(isChinese ? '验证码已重发，请检查您的邮箱。' : 'Verification code resent. Please check your email.');
+            toast.success(isChinese ? '验证码已重发，请检查您的邮箱' : 'Verification code resent. Please check your email.');
         } catch (err: any) {
-            alert(err.message || 'Failed to resend verification');
+            toast.error(isChinese ? '重发失败' : 'Failed to resend verification', { details: String(err?.message || err) });
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
## Summary
- Users were seeing browser-default `confirm()` / `alert()` popups (session delete, model connectivity test, file upload errors, etc.) that broke visual consistency with the rest of the app.
- Introduces a unified dialog/toast system so every notification uses the Clawith UI, and migrates all 46 native call sites across 9 files.

## What changed
- **`DialogProvider` + `useDialog()`**: centered modal with Promise-based `confirm()` and `alert()` API. Supports `info / success / warning / error` types and **collapsible details** for long error payloads (e.g. the LLM connectivity test's raw 429 response).
- **`ToastProvider` + `useToast()`**: top-right, auto-dismissing notifications with the same type/details support for non-critical errors.
- **Migration rule**: destructive or must-acknowledge → dialog (session/tool/trigger/agent delete, connectivity test result, import failure); non-critical → toast (save failure, upload failure, file-count limit, etc.).

## Test plan
- [x] Verified in dev: session delete now opens the centered Clawith-styled modal with red 删除 button (was browser default).
- [x] Verified Toast renders at top-right with icon and collapsible details.
- [ ] Click through LLM connectivity test (enterprise settings → model pool → test) and confirm error payload is collapsible.
- [ ] Click through a destructive delete (trigger / tool / agent) and confirm danger variant renders.
- [ ] Trigger a toast-level error (upload failure, save failure) and confirm it auto-dismisses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)