### PR TITLE
fix: to ensure Docker Compose starts without errors, you need to add …

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -31,6 +31,7 @@ from app.models.tenant import Tenant  # noqa: F401
 from app.models.tool import Tool  # noqa: F401
 from app.models.trigger import AgentTrigger  # noqa: F401
 from app.models.agent_credential import AgentCredential  # noqa: F401
+from app.models.notification import Notification  # noqa: F401
 
 config = context.config
 settings = get_settings()


### PR DESCRIPTION
## Summary

Register the `Notification` model in `backend/alembic/env.py` so that Alembic detects the `notifications` table during migrations.

## Problem

When running `docker compose up`, the application fails to start with an error indicating the `notifications` table cannot be found. This happens because the `Notification` model was not imported in the Alembic environment file, so SQLAlchemy's `Base.metadata` never registered it. As a result, Alembic is unaware of the table and cannot manage it through migrations.

## Solution

Add the `Notification` model import alongside the other model imports already present in `backend/alembic/env.py`:

```python
from app.models.notification import Notification  # noqa: F401
```

This follows the same pattern used for all other models in the file (e.g., `Agent`, `User`, `AuditLog`, etc.) and ensures `Base.metadata` includes the `notifications` table.

## Test Plan

- Run `docker compose up` and confirm the application starts without the missing table error
- Run `alembic revision --autogenerate -m "description"` and verify the `notifications` table is correctly detected
- Verify existing migrations continue to apply without issues