### PR TITLE
fix(frontend): notification panel never fetches list on bell click

### DIFF
--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -269,7 +269,7 @@ export default function Layout() {
         refetchInterval: 30000,
         enabled: !!user,
     });
-    const { data: notifications = [], refetch: refetchNotifications } = useQuery({
+    const { data: notifications = [] } = useQuery({
         queryKey: ['notifications', notifCategory],
         queryFn: () => fetchJson<any[]>(`/notifications?limit=50${notifCategory !== 'all' ? `&category=${notifCategory}` : ''}`),
         enabled: !!user && showNotifications,
@@ -731,7 +731,7 @@ export default function Layout() {
                             }} title={theme === 'dark' ? t('common.lightMode') : t('common.darkMode')}>
                                 {theme === 'dark' ? SidebarIcons.sun : SidebarIcons.moon}
                             </button>
-                            <button className="btn btn-ghost" onClick={() => { setShowNotifications(v => !v); if (!showNotifications) refetchNotifications(); }} style={{
+                            <button className="btn btn-ghost" onClick={() => setShowNotifications(v => !v)} style={{
                                 padding: '4px 8px', display: 'flex', alignItems: 'center', justifyContent: 'center', position: 'relative',
                             }} title={isChinese ? '通知' : 'Notifications'}>
                                 {SidebarIcons.bell}


### PR DESCRIPTION
## Bug

Clicking the notification bell opens the panel but always shows "暂无通知 / No notifications" even when the unread badge displays a positive count. The unread number then stays stuck — closing and reopening doesn't help.

## Root cause

`Layout.tsx` calls `refetchNotifications()` synchronously inside the bell's onClick, right after `setShowNotifications(v => !v)`. At that moment the query is still `enabled: !!user && showNotifications` with `showNotifications === false` (state hasn't committed yet), so the manual refetch doesn't actually hit `/api/notifications`.

Empirical evidence from dev backend logs: 300+ hits on `GET /api/notifications/unread-count` (the polling badge), **zero** on `GET /api/notifications` (the list endpoint). With the list never fetched, `notifications` stays `[]` (the panel shows "暂无通知") and `markOneRead` / `markAllRead` are never reachable — that's why the badge can never decrement.

## Fix

Drop the manual refetch entirely. TanStack Query v5's `queryObserver.shouldFetchOptionally` already auto-fetches when `enabled` flips `false → true` (the `prevOptions.enabled === false` branch with stale data).

## Verified on dev

After the fix, every bell interaction now produces the expected backend call:

- Click bell → `GET /api/notifications?limit=50 → 200` (panel populates)
- Switch tabs → `?category=tool|approval|social → 200` each
- Click an item → `POST /api/notifications/{id}/read → 200` (badge -1)
- "全部已读" → `POST /api/notifications/read-all → 200` (badge → 0)