### PR TITLE
docs: update system email configuration guide to match UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,20 +158,12 @@ The first user to register automatically becomes the **platform admin**. Open th
 
 ### System Email and Password Reset
 
-Clawith can send platform-owned emails for password reset and optional broadcast delivery. Configure SMTP in `.env`:
+Clawith can send platform-owned emails for password reset, email verification, and optional broadcast delivery.
 
-```bash
-PUBLIC_BASE_URL=http://localhost:3008
-SYSTEM_EMAIL_FROM_ADDRESS=bot@example.com
-SYSTEM_EMAIL_FROM_NAME=Clawith
-SYSTEM_SMTP_HOST=smtp.example.com
-SYSTEM_SMTP_PORT=465
-SYSTEM_SMTP_USERNAME=bot@example.com
-SYSTEM_SMTP_PASSWORD=your-app-password
-SYSTEM_SMTP_SSL=true
-SYSTEM_SMTP_TIMEOUT_SECONDS=15
-PASSWORD_RESET_TOKEN_EXPIRE_MINUTES=30
-```
+You can configure the SMTP server settings directly from the web interface:
+1. Log in as a platform administrator.
+2. Navigate to **Admin -> Platform Settings**.
+3. Under the **Platform** tab, locate the **System Email Configuration** section and enter your SMTP details.
 
 `PUBLIC_BASE_URL` must point to the user-facing frontend because reset links are generated as `/reset-password?token=...`.
 In production, set it to your public HTTPS domain (for example `https://app.example.com`), not a localhost address.

--- a/backend/app/services/system_email_service.py
+++ b/backend/app/services/system_email_service.py
@@ -54,7 +54,6 @@ class BroadcastEmailRecipient:
 async def resolve_email_config_async(db) -> SystemEmailConfig | None:
     """Resolve email configuration by searching in order:
     1. Platform-level settings in DB ('system_email_platform')
-    2. Environment variables (Settings class)
     """
     from sqlalchemy import select
     from app.models.system_settings import SystemSetting


### PR DESCRIPTION
Fixes #440 by updating the README to point users to the Platform Settings UI for configuring system email instead of instructing them to use the `.env` file. Also removed the outdated docstring referencing environment variables in `system_email_service.py`.