### PR TITLE
Fix channel user identity reuse and outbound routing

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -13,6 +13,17 @@ from uuid import uuid4
 trace_id_var: ContextVar[str] = ContextVar("trace_id", default=None)
 
 
+NOISY_CONNECTION_LOGGERS = {
+    # WebSocket accepted / HTTP access lines from uvicorn.
+    "uvicorn.access": logging.WARNING,
+    # "connection open" / "connection closed" emitted by websockets.
+    "websockets": logging.WARNING,
+    "websockets.server": logging.WARNING,
+    "websockets.client": logging.WARNING,
+    "uvicorn.protocols.websockets.websockets_impl": logging.WARNING,
+}
+
+
 def get_trace_id() -> str:
     """Get current trace ID from context."""
     return trace_id_var.get()
@@ -32,7 +43,7 @@ def configure_logging():
     logger.add(
         sys.stdout,
         level="INFO",
-        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{extra[trace_id]:-<12}</cyan> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level}</level> | <cyan>{extra[trace_id]:-<12}</cyan> | <cyan>{name}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
         enqueue=True,
         backtrace=True,
         diagnose=True,
@@ -40,6 +51,13 @@ def configure_logging():
     )
 
     return logger
+
+
+def quiet_noisy_connection_loggers() -> None:
+    """Reduce chatty transport-level logs while keeping warnings/errors visible."""
+    for logger_name, level in NOISY_CONNECTION_LOGGERS.items():
+        target = logging.getLogger(logger_name)
+        target.setLevel(level)
 
 
 def intercept_standard_logging():
@@ -77,6 +95,7 @@ def intercept_standard_logging():
     for name in logging.root.manager.loggerDict:
         logging.getLogger(name).handlers = [InterceptHandler()]
         logging.getLogger(name).propagate = False
+    quiet_noisy_connection_loggers()
 
 
 # Configure on import

--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -4836,7 +4836,7 @@ async def _send_feishu_message(agent_id: uuid.UUID, args: dict) -> str:
 
 
 async def _send_channel_message(agent_id: uuid.UUID, args: dict) -> str:
-    """Send message via the recipient's configured channel (Feishu/DingTalk/WeCom).
+    """Send message via the recipient's configured external channel.
 
     1. Find target user from relationships (AgentRelationship -> OrgMember)
     2. Determine user's provider type (via OrgMember.provider_id -> IdentityProvider)
@@ -4850,7 +4850,8 @@ async def _send_channel_message(agent_id: uuid.UUID, args: dict) -> str:
 
     member_name = (args.get("member_name") or "").strip()
     message_text = (args.get("message") or "").strip()
-    target_channel = (args.get("channel") or "").strip().lower()
+    raw_target_channel = (args.get("channel") or "").strip().lower()
+    target_channel = "teams" if raw_target_channel == "microsoft_teams" else raw_target_channel
 
     if not member_name:
         return "❌ Please provide member_name"
@@ -4875,25 +4876,30 @@ async def _send_channel_message(agent_id: uuid.UUID, args: dict) -> str:
             target_member = None
             provider_type = None
 
+            def _normalize_provider_type(value: str | None) -> str | None:
+                if not value:
+                    return None
+                return "teams" if value == "microsoft_teams" else value
+
             # Handle multiple matches across different providers
             if target_channel:
                 for rel, member, provider in rows:
-                    if provider and provider.provider_type == target_channel:
+                    if provider and _normalize_provider_type(provider.provider_type) == target_channel:
                         target_member = member
-                        provider_type = target_channel
+                        provider_type = _normalize_provider_type(provider.provider_type)
                         break
                 if not target_member:
-                    available = [p.provider_type for _, _, p in rows if p]
+                    available = sorted({_normalize_provider_type(p.provider_type) for _, _, p in rows if p})
                     return f"❌ {member_name} not found in {target_channel} channel. Available channels: {', '.join(available)}"
             else:
                 if len(rows) > 1:
-                    available = [p.provider_type for _, _, p in rows if p]
+                    available = [_normalize_provider_type(p.provider_type) for _, _, p in rows if p]
                     logger.warning(f"[ChannelMessage] Ambiguous member '{member_name}' found in multiple channels: {available}")
                     # Pick the first one as before, but mention others if possible
                 
                 rel, member, provider = rows[0]
                 target_member = member
-                provider_type = provider.provider_type if provider else None
+                provider_type = _normalize_provider_type(provider.provider_type) if provider else None
 
             # 2. Determine channel based on provider type
             if not provider_type:
@@ -4942,6 +4948,12 @@ async def _send_channel_message(agent_id: uuid.UUID, args: dict) -> str:
                 return await _send_dingtalk_message(agent_id, member_name, message_text, target_member)
             elif provider_type == "wecom":
                 return await _send_wecom_message(agent_id, member_name, message_text, target_member)
+            elif provider_type == "slack":
+                return await _send_slack_message(agent_id, member_name, message_text, target_member)
+            elif provider_type == "teams":
+                return await _send_teams_channel_message(agent_id, member_name, message_text, target_member)
+            elif provider_type == "wechat":
+                return await _send_wechat_channel_message(agent_id, member_name, message_text, target_member)
             else:
                 return f"❌ Unsupported channel type: {provider_type}"
 
@@ -5134,6 +5146,249 @@ async def _send_wecom_message(
     except Exception as e:
         logger.exception("[WeCom] Error")
         return f"❌ WeCom message error: {str(e)[:200]}"
+
+
+async def _send_slack_message(
+    agent_id: uuid.UUID,
+    member_name: str,
+    message_text: str,
+    target_member: "OrgMember",
+) -> str:
+    """Send proactive Slack DM via conversations.open + chat.postMessage."""
+    import httpx
+
+    from app.api.slack import _send_slack_messages
+
+    try:
+        async with async_session() as db:
+            config_result = await db.execute(
+                select(ChannelConfig).where(
+                    ChannelConfig.agent_id == agent_id,
+                    ChannelConfig.channel_type == "slack",
+                    ChannelConfig.is_configured == True,
+                )
+            )
+            config = config_result.scalar_one_or_none()
+            if not config:
+                return "❌ This agent has no Slack channel configured"
+
+            user_id = (target_member.external_id or "").strip()
+            if not user_id:
+                return f"❌ {member_name} has no Slack user_id"
+
+            bot_token = (config.app_secret or "").strip()
+            if not bot_token:
+                return "❌ Slack bot token is missing"
+
+            async with httpx.AsyncClient(timeout=10) as client:
+                open_resp = await client.post(
+                    "https://slack.com/api/conversations.open",
+                    headers={"Authorization": f"Bearer {bot_token}", "Content-Type": "application/json"},
+                    json={"users": user_id},
+                )
+                data = open_resp.json()
+                if open_resp.status_code >= 400 or not data.get("ok"):
+                    err = data.get("error") or open_resp.text[:200]
+                    return f"❌ Slack conversations.open failed: {err}"
+                channel_id = (((data.get("channel") or {})).get("id") or "").strip()
+
+            if not channel_id:
+                return f"❌ Slack DM channel unavailable for {member_name}"
+
+            await _send_slack_messages(bot_token, channel_id, message_text)
+
+            try:
+                agent_r = await db.execute(select(AgentModel).where(AgentModel.id == agent_id))
+                agent_obj = agent_r.scalar_one_or_none()
+                platform_user = await get_platform_user_by_org_member(
+                    db=db,
+                    org_member=target_member,
+                    agent_tenant_id=agent_obj.tenant_id if agent_obj else None,
+                )
+                conv_id = f"slack_{channel_id}"
+                sess = await find_or_create_channel_session(
+                    db=db,
+                    agent_id=agent_id,
+                    user_id=platform_user.id,
+                    external_conv_id=conv_id,
+                    source_channel="slack",
+                    first_message_title=message_text[:30],
+                )
+                db.add(ChatMessage(
+                    agent_id=agent_id,
+                    user_id=platform_user.id,
+                    role="assistant",
+                    content=message_text,
+                    conversation_id=str(sess.id),
+                ))
+                sess.last_message_at = datetime.now(timezone.utc)
+                await db.commit()
+                logger.info(f"[Slack] Proactive message saved to session {sess.id}")
+            except Exception as ex:
+                logger.error(f"[Slack] Failed to save proactive message to session: {ex}")
+
+            return f"✅ Message sent to {member_name} via Slack"
+    except Exception as e:
+        logger.exception("[Slack] Error")
+        return f"❌ Slack message error: {str(e)[:200]}"
+
+
+async def _send_teams_channel_message(
+    agent_id: uuid.UUID,
+    member_name: str,
+    message_text: str,
+    target_member: "OrgMember",
+) -> str:
+    """Send proactive Teams message using the latest known conversation context."""
+    from app.api.teams import _send_teams_message
+
+    try:
+        async with async_session() as db:
+            config_result = await db.execute(
+                select(ChannelConfig).where(
+                    ChannelConfig.agent_id == agent_id,
+                    ChannelConfig.channel_type == "microsoft_teams",
+                    ChannelConfig.is_configured == True,
+                )
+            )
+            config = config_result.scalar_one_or_none()
+            if not config:
+                return "❌ This agent has no Teams channel configured"
+
+            service_url = str((config.extra_config or {}).get("service_url") or "").strip()
+            if not service_url:
+                return "❌ Teams proactive send requires an existing inbound conversation to capture service_url"
+
+            agent_r = await db.execute(select(AgentModel).where(AgentModel.id == agent_id))
+            agent_obj = agent_r.scalar_one_or_none()
+            platform_user = await get_platform_user_by_org_member(
+                db=db,
+                org_member=target_member,
+                agent_tenant_id=agent_obj.tenant_id if agent_obj else None,
+            )
+
+            session_result = await db.execute(
+                select(ChatSession)
+                .where(
+                    ChatSession.agent_id == agent_id,
+                    ChatSession.user_id == platform_user.id,
+                    ChatSession.source_channel == "microsoft_teams",
+                    ChatSession.is_group == False,
+                )
+                .order_by(ChatSession.last_message_at.desc(), ChatSession.created_at.desc())
+                .limit(1)
+            )
+            session = session_result.scalar_one_or_none()
+            conversation_id = str(session.external_conv_id or "").strip() if session else ""
+            if not conversation_id:
+                return f"❌ Teams proactive send to {member_name} requires them to message the bot first"
+
+            await _send_teams_message(
+                config,
+                conversation_id,
+                {
+                    "type": "message",
+                    "text": message_text,
+                    "conversation": {"id": conversation_id},
+                },
+            )
+
+            db.add(ChatMessage(
+                agent_id=agent_id,
+                user_id=platform_user.id,
+                role="assistant",
+                content=message_text,
+                conversation_id=str(session.id),
+            ))
+            session.last_message_at = datetime.now(timezone.utc)
+            await db.commit()
+            logger.info(f"[Teams] Proactive message saved to session {session.id}")
+            return f"✅ Message sent to {member_name} via Teams"
+    except Exception as e:
+        logger.exception("[Teams] Error")
+        return f"❌ Teams message error: {str(e)[:200]}"
+
+
+async def _send_wechat_channel_message(
+    agent_id: uuid.UUID,
+    member_name: str,
+    message_text: str,
+    target_member: "OrgMember",
+) -> str:
+    """Send proactive WeChat message using the latest cached context_token."""
+    from app.services.wechat_channel import (
+        WECHAT_ILINK_BASE_URL,
+        get_wechat_context_entry,
+        send_wechat_text_message,
+    )
+
+    try:
+        async with async_session() as db:
+            config_result = await db.execute(
+                select(ChannelConfig).where(
+                    ChannelConfig.agent_id == agent_id,
+                    ChannelConfig.channel_type == "wechat",
+                    ChannelConfig.is_configured == True,
+                )
+            )
+            config = config_result.scalar_one_or_none()
+            if not config:
+                return "❌ This agent has no WeChat channel configured"
+
+            user_id = (target_member.external_id or "").strip()
+            if not user_id:
+                return f"❌ {member_name} has no WeChat user_id"
+
+            ctx_entry = get_wechat_context_entry(config.extra_config, from_user_id=user_id)
+            context_token = str((ctx_entry or {}).get("context_token") or "").strip()
+            conv_id = str((ctx_entry or {}).get("conv_id") or f"wechat_{user_id}").strip()
+            if not context_token:
+                return f"❌ WeChat proactive send to {member_name} requires them to message the bot first"
+
+            token = str((config.extra_config or {}).get("bot_token") or "").strip()
+            base_url = str((config.extra_config or {}).get("baseurl") or WECHAT_ILINK_BASE_URL).strip()
+            route_tag = str((config.extra_config or {}).get("route_tag") or "").strip() or None
+            if not token:
+                return "❌ WeChat bot token is missing"
+
+            await send_wechat_text_message(
+                token=token,
+                base_url=base_url,
+                to_user_id=user_id,
+                context_token=context_token,
+                text=message_text,
+                route_tag=route_tag,
+            )
+
+            agent_r = await db.execute(select(AgentModel).where(AgentModel.id == agent_id))
+            agent_obj = agent_r.scalar_one_or_none()
+            platform_user = await get_platform_user_by_org_member(
+                db=db,
+                org_member=target_member,
+                agent_tenant_id=agent_obj.tenant_id if agent_obj else None,
+            )
+            sess = await find_or_create_channel_session(
+                db=db,
+                agent_id=agent_id,
+                user_id=platform_user.id,
+                external_conv_id=conv_id,
+                source_channel="wechat",
+                first_message_title=message_text[:30],
+            )
+            db.add(ChatMessage(
+                agent_id=agent_id,
+                user_id=platform_user.id,
+                role="assistant",
+                content=message_text,
+                conversation_id=str(sess.id),
+            ))
+            sess.last_message_at = datetime.now(timezone.utc)
+            await db.commit()
+            logger.info(f"[WeChat] Proactive message saved to session {sess.id}")
+            return f"✅ Message sent to {member_name} via WeChat"
+    except Exception as e:
+        logger.exception("[WeChat] Error")
+        return f"❌ WeChat message error: {str(e)[:200]}"
 
 
 async def _send_platform_message(agent_id: uuid.UUID, args: dict) -> str:

--- a/backend/app/services/channel_user_service.py
+++ b/backend/app/services/channel_user_service.py
@@ -27,25 +27,46 @@ class ChannelUserResolutionError(ValueError):
 class ChannelUserService:
     """Service for resolving channel users via OrgMember and SSO patterns."""
 
+    CHANNEL_TYPE_ALIASES = {
+        "microsoft_teams": "teams",
+    }
+
+    def _normalize_channel_type(self, channel_type: str) -> str:
+        raw = (channel_type or "").strip().lower()
+        return self.CHANNEL_TYPE_ALIASES.get(raw, raw)
+
+    def _legacy_provider_types_for_channel(self, channel_type: str) -> list[str]:
+        normalized = self._normalize_channel_type(channel_type)
+        legacy = [normalized]
+        if normalized == "teams":
+            legacy.append("microsoft_teams")
+        elif normalized == "microsoft_teams":
+            legacy.append("teams")
+        return legacy
+
     def _get_channel_ids(
         self,
         channel_type: str,
         external_user_id: str | None,
         extra_info: dict[str, Any],
     ) -> tuple[str | None, str | None, str | None]:
+        normalized_channel = self._normalize_channel_type(channel_type)
         unionid = (extra_info.get("unionid") or extra_info.get("union_id") or "").strip() or None
         open_id = (extra_info.get("open_id") or "").strip() or None
         external_id = (extra_info.get("external_id") or external_user_id or "").strip() or None
 
-        if channel_type == "feishu":
+        if normalized_channel == "feishu":
             # Feishu external_id must remain tenant-stable user_id only.
             # Never backfill it from open_id.
             external_id = (extra_info.get("external_id") or "").strip() or None
-        elif channel_type == "dingtalk":
+        elif normalized_channel == "dingtalk":
             open_id = open_id or None
-        elif channel_type == "wecom":
+        elif normalized_channel == "wecom":
             unionid = None
             open_id = open_id or None
+        else:
+            unionid = None
+            open_id = None
 
         return unionid, open_id, external_id
 
@@ -68,7 +89,7 @@ class ChannelUserService:
         Args:
             db: Database session
             agent: Agent receiving the message (for tenant_id)
-            channel_type: "dingtalk" | "wecom" | "feishu"
+            channel_type: "dingtalk" | "wecom" | "wechat" | "feishu"
             external_user_id: User ID from external platform. For Feishu this must be user_id, not open_id.
             extra_info: Optional name/avatar/mobile/email from platform API
 
@@ -116,9 +137,11 @@ class ChannelUserService:
                     f"[{channel_type}] Matched user by mobile: {user.id}"
                 )
 
-        # If found User by email/mobile, link OrgMember if exists (only for org-sync channels)
+        should_persist_member = True
+
+        # If found User by email/mobile, link OrgMember if exists
         if user:
-            if channel_type in ("feishu", "dingtalk", "wecom"):
+            if should_persist_member:
                 if org_member and not org_member.user_id:
                     # Existing shell OrgMember not yet linked → link it
                     org_member.user_id = user.id
@@ -167,9 +190,8 @@ class ChannelUserService:
             db, channel_type, external_user_id, extra_info, tenant_id
         )
 
-        # Step 6: Link or create OrgMember (only for channels with org sync)
-        # Channels like Discord/Slack don't have OrgMember, skip this step
-        if channel_type in ("feishu", "dingtalk", "wecom"):
+        # Step 6: Link or create OrgMember
+        if should_persist_member:
             if org_member:
                 org_member.user_id = user.id
             else:
@@ -188,25 +210,41 @@ class ChannelUserService:
         self, db: AsyncSession, provider_type: str, tenant_id: uuid.UUID | None
     ) -> IdentityProvider:
         """Get or create IdentityProvider record."""
+        canonical_type = self._normalize_channel_type(provider_type)
+
         query = select(IdentityProvider).where(
-            IdentityProvider.provider_type == provider_type
+            IdentityProvider.provider_type == canonical_type
         )
         if tenant_id:
             query = query.where(IdentityProvider.tenant_id == tenant_id)
 
         result = await db.execute(query)
         provider = result.scalar_one_or_none()
+        if provider:
+            return provider
 
-        if not provider:
-            provider = IdentityProvider(
-                provider_type=provider_type,
-                name=provider_type.capitalize(),
-                is_active=True,
-                config={},
-                tenant_id=tenant_id,
+        for legacy_type in self._legacy_provider_types_for_channel(provider_type):
+            if legacy_type == canonical_type:
+                continue
+            legacy_query = select(IdentityProvider).where(
+                IdentityProvider.provider_type == legacy_type
             )
-            db.add(provider)
-            await db.flush()
+            if tenant_id:
+                legacy_query = legacy_query.where(IdentityProvider.tenant_id == tenant_id)
+            legacy_result = await db.execute(legacy_query)
+            legacy_provider = legacy_result.scalar_one_or_none()
+            if legacy_provider:
+                return legacy_provider
+
+        provider = IdentityProvider(
+            provider_type=canonical_type,
+            name=canonical_type.capitalize(),
+            is_active=True,
+            config={},
+            tenant_id=tenant_id,
+        )
+        db.add(provider)
+        await db.flush()
 
         return provider
 
@@ -223,6 +261,7 @@ class ChannelUserService:
         For Feishu: try unionid first, then open_id, then external_id
         For DingTalk: try unionid first, then external_id
         For WeCom: try external_id (userid)
+        For WeChat: try external_id (from_user_id)
 
         Returns None if OrgMember not found or org sync is not enabled for this channel.
         """
@@ -236,12 +275,15 @@ class ChannelUserService:
             conditions = [OrgMember.provider_id == provider_id, OrgMember.status == "active"]
 
             # Channel-specific matching priority
-            if channel_type == "feishu":
+            normalized_channel = self._normalize_channel_type(channel_type)
+            if normalized_channel == "feishu":
                 # Feishu identifiers have distinct semantics:
-                # unionid and open_id come from extra_info; external_id is user_id only.
+                # unionid/open_id come from extra_info; external_id is user_id only.
                 lookup_conditions = []
                 if unionid:
                     lookup_conditions.append(OrgMember.unionid == unionid)
+                if open_id:
+                    lookup_conditions.append(OrgMember.open_id == open_id)
                 if external_id:
                     lookup_conditions.append(OrgMember.external_id == external_id)
                 if not lookup_conditions:
@@ -249,7 +291,7 @@ class ChannelUserService:
                 conditions.append(lookup_conditions[0])
                 for cond in lookup_conditions[1:]:
                     conditions[-1] = conditions[-1] | cond
-            elif channel_type == "dingtalk":
+            elif normalized_channel == "dingtalk":
                 # DingTalk: unionid is stable across apps, then external_id
                 lookup_conditions = []
                 if unionid:
@@ -261,15 +303,17 @@ class ChannelUserService:
                 conditions.append(lookup_conditions[0])
                 for cond in lookup_conditions[1:]:
                     conditions[-1] = conditions[-1] | cond
-            elif channel_type == "wecom":
+            elif normalized_channel == "wecom":
                 # WeCom: external_id (userid) is the primary identifier
                 if not external_id:
                     return None
                 conditions.append(OrgMember.external_id == external_id)
             else:
-                # Generic fallback (discord, slack, etc. - no org sync)
-                # These channels don't have OrgMember, return None immediately
-                return None
+                # Generic channels: provider is already channel-scoped, so external_id
+                # can be used directly without namespacing.
+                if not external_id:
+                    return None
+                conditions.append(OrgMember.external_id == external_id)
 
             # Use limit(1) + prioritize records that are already linked to a User.
             # scalar_one_or_none() would raise MultipleResultsFound when duplicate
@@ -468,15 +512,17 @@ async def get_platform_user_by_org_member(
     from app.models.identity import IdentityProvider
     provider = await db.get(IdentityProvider, org_member.provider_id)
     channel_type = provider.provider_type if provider else "unknown"
+    external_seed = org_member.external_id
 
     # Generate username from OrgMember info
     email = org_member.email
-    name = org_member.name or f"{channel_type.capitalize()} User {org_member.external_id[:8]}"
+    seed_for_name = external_seed or org_member.id.hex
+    name = org_member.name or f"{channel_type.capitalize()} User {seed_for_name[:8]}"
 
     if email:
         username = email.split("@")[0]
-    elif org_member.external_id:
-        username = f"{channel_type}_{org_member.external_id[:12]}"
+    elif external_seed:
+        username = f"{channel_type}_{external_seed[:12]}"
     else:
         username = f"{channel_type}_{org_member.id.hex[:12]}"
 
@@ -491,7 +537,7 @@ async def get_platform_user_by_org_member(
 
     existing = await db.execute(query)
     if existing.scalar_one_or_none():
-        username = f"{username}_{org_member.external_id[:6] if org_member.external_id else org_member.id.hex[:6]}"
+        username = f"{username}_{external_seed[:6] if external_seed else org_member.id.hex[:6]}"
 
     email = email or f"{username}@{channel_type}.local"
 

--- a/backend/app/services/wechat_channel.py
+++ b/backend/app/services/wechat_channel.py
@@ -26,6 +26,8 @@ from app.services.channel_user_service import channel_user_service
 WECHAT_ILINK_BASE_URL = "https://ilinkai.weixin.qq.com"
 WECHAT_CHANNEL_VERSION = "1.0.0"
 WECHAT_TEXT_LIMIT = 2000
+WECHAT_CONTEXT_CACHE_KEY = "recent_context_tokens"
+WECHAT_CONTEXT_CACHE_LIMIT = 100
 
 
 class WeChatSessionExpiredError(RuntimeError):
@@ -104,8 +106,73 @@ async def send_wechat_text_message(
                     },
                 },
             )
+            data = resp.json()
             if resp.status_code >= 400:
                 raise RuntimeError(f"WeChat sendmessage failed: {resp.text[:300]}")
+            ret = data.get("ret", 0)
+            errcode = data.get("errcode", 0)
+            if ret not in (0, None) or errcode not in (0, None):
+                raise RuntimeError(data.get("errmsg") or f"WeChat sendmessage failed: ret={ret}, errcode={errcode}")
+
+
+def update_wechat_context_cache(
+    extra_config: dict[str, Any] | None,
+    *,
+    from_user_id: str,
+    context_token: str,
+    conv_id: str,
+) -> dict[str, Any]:
+    extra = dict(extra_config or {})
+    cache = dict(extra.get(WECHAT_CONTEXT_CACHE_KEY) or {})
+    cache[from_user_id] = {
+        "context_token": context_token,
+        "conv_id": conv_id,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if len(cache) > WECHAT_CONTEXT_CACHE_LIMIT:
+        ordered = sorted(
+            cache.items(),
+            key=lambda item: str((item[1] or {}).get("updated_at") or ""),
+            reverse=True,
+        )
+        cache = dict(ordered[:WECHAT_CONTEXT_CACHE_LIMIT])
+    extra[WECHAT_CONTEXT_CACHE_KEY] = cache
+    return extra
+
+
+def get_wechat_context_entry(
+    extra_config: dict[str, Any] | None,
+    *,
+    from_user_id: str,
+) -> dict[str, Any] | None:
+    cache = dict((extra_config or {}).get(WECHAT_CONTEXT_CACHE_KEY) or {})
+    entry = cache.get(from_user_id)
+    return entry if isinstance(entry, dict) else None
+
+
+async def remember_wechat_context(
+    db,
+    *,
+    agent_id: uuid.UUID,
+    from_user_id: str,
+    context_token: str,
+    conv_id: str,
+) -> None:
+    config_result = await db.execute(
+        select(ChannelConfig).where(
+            ChannelConfig.agent_id == agent_id,
+            ChannelConfig.channel_type == "wechat",
+        )
+    )
+    config = config_result.scalar_one_or_none()
+    if not config:
+        return
+    config.extra_config = update_wechat_context_cache(
+        config.extra_config,
+        from_user_id=from_user_id,
+        context_token=context_token,
+        conv_id=conv_id,
+    )
 
 
 def _extract_wechat_text(item_list: list[dict[str, Any]] | None) -> str:
@@ -165,6 +232,13 @@ async def _process_wechat_message(agent_id: uuid.UUID, msg: dict[str, Any], conf
             first_message_title=user_text,
         )
         session_conv_id = str(sess.id)
+        await remember_wechat_context(
+            db,
+            agent_id=agent_id,
+            from_user_id=from_user_id,
+            context_token=context_token,
+            conv_id=conv_id,
+        )
 
         history_r = await db.execute(
             select(ChatMessage)

--- a/backend/tests/test_identity_id_mapping.py
+++ b/backend/tests/test_identity_id_mapping.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -82,12 +82,32 @@ def test_channel_user_service_keeps_feishu_user_id_out_of_unionid():
     assert external_id == "u_emp_789"
 
 
+def test_channel_user_service_maps_generic_channels_to_dedicated_provider():
+    service = ChannelUserService()
+
+    assert service._normalize_channel_type("wechat") == "wechat"
+    assert service._normalize_channel_type("slack") == "slack"
+    assert service._normalize_channel_type("teams") == "teams"
+    assert service._normalize_channel_type("microsoft_teams") == "teams"
+    assert service._normalize_channel_type("feishu") == "feishu"
+
+
+def test_channel_user_service_keeps_generic_channel_external_ids_unscoped():
+    service = ChannelUserService()
+
+    assert service._get_channel_ids("wechat", "wx_user_123", {}) == (None, None, "wx_user_123")
+    assert service._get_channel_ids("slack", "U123456", {}) == (None, None, "U123456")
+    assert service._get_channel_ids("teams", "29:abc", {}) == (None, None, "29:abc")
+
+
 @pytest.mark.asyncio
 async def test_channel_user_service_uses_feishu_open_id_for_existing_member_lookup():
     service = ChannelUserService()
     db = AsyncMock()
     expected_member = SimpleNamespace(id="member-1")
-    db.execute.return_value.scalar_one_or_none.return_value = expected_member
+    db.execute = AsyncMock(
+        return_value=Mock(scalar_one_or_none=Mock(return_value=expected_member))
+    )
 
     member = await service._find_org_member(
         db,
@@ -136,3 +156,57 @@ async def test_channel_user_service_skips_dingtalk_lookup_when_ids_missing():
 
     assert member is None
     db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_channel_user_service_uses_wechat_external_id_for_existing_member_lookup():
+    service = ChannelUserService()
+    db = AsyncMock()
+    expected_member = SimpleNamespace(id="member-wechat-1")
+    db.execute = AsyncMock(
+        return_value=Mock(scalar_one_or_none=Mock(return_value=expected_member))
+    )
+
+    member = await service._find_org_member(
+        db,
+        provider_id="provider-1",
+        channel_type="wechat",
+        external_user_id="wx_user_123",
+        extra_info={"external_id": "wx_user_123"},
+    )
+
+    assert member is expected_member
+    db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_user_service_creates_wechat_org_member_shell_for_lazy_registration():
+    service = ChannelUserService()
+    db = AsyncMock()
+    db.get.return_value = None
+    agent = SimpleNamespace(tenant_id="tenant-1")
+    provider = SimpleNamespace(id="provider-1")
+    created_user = SimpleNamespace(id="user-1")
+
+    service._ensure_provider = AsyncMock(return_value=provider)
+    service._find_org_member = AsyncMock(return_value=None)
+    service._create_channel_user = AsyncMock(return_value=created_user)
+    service._create_org_member_shell = AsyncMock()
+
+    user = await service.resolve_channel_user(
+        db=db,
+        agent=agent,
+        channel_type="wechat",
+        external_user_id="wx_user_123",
+        extra_info={"external_id": "wx_user_123"},
+    )
+
+    assert user is created_user
+    service._create_org_member_shell.assert_awaited_once_with(
+        db,
+        provider,
+        "wechat",
+        "wx_user_123",
+        {"external_id": "wx_user_123"},
+        linked_user_id="user-1",
+    )

--- a/backend/tests/test_wechat_channel_context.py
+++ b/backend/tests/test_wechat_channel_context.py
@@ -1,0 +1,37 @@
+from app.services.wechat_channel import (
+    WECHAT_CONTEXT_CACHE_KEY,
+    WECHAT_CONTEXT_CACHE_LIMIT,
+    get_wechat_context_entry,
+    update_wechat_context_cache,
+)
+
+
+def test_update_wechat_context_cache_stores_latest_entry():
+    extra = update_wechat_context_cache(
+        {},
+        from_user_id="wx_user_123",
+        context_token="ctx_abc",
+        conv_id="wechat_session_1",
+    )
+
+    assert WECHAT_CONTEXT_CACHE_KEY in extra
+    entry = get_wechat_context_entry(extra, from_user_id="wx_user_123")
+    assert entry is not None
+    assert entry["context_token"] == "ctx_abc"
+    assert entry["conv_id"] == "wechat_session_1"
+
+
+def test_update_wechat_context_cache_prunes_old_entries():
+    extra = {}
+    for idx in range(WECHAT_CONTEXT_CACHE_LIMIT + 5):
+        extra = update_wechat_context_cache(
+            extra,
+            from_user_id=f"wx_user_{idx}",
+            context_token=f"ctx_{idx}",
+            conv_id=f"wechat_session_{idx}",
+        )
+
+    cache = extra[WECHAT_CONTEXT_CACHE_KEY]
+    assert len(cache) == WECHAT_CONTEXT_CACHE_LIMIT
+    assert get_wechat_context_entry(extra, from_user_id="wx_user_0") is None
+    assert get_wechat_context_entry(extra, from_user_id=f"wx_user_{WECHAT_CONTEXT_CACHE_LIMIT + 4}") is not None


### PR DESCRIPTION
## Summary
- fix channel user identity reuse for wechat and other per-channel providers
- extend send_channel_message to slack, teams, and wechat
- reduce noisy websocket connection logs to warnings/errors only
- add regression tests for channel identity mapping and wechat context caching

## Testing
- PYTHONPATH=/Users/alex/Code/dataelem/Clawith/backend pytest tests/test_identity_id_mapping.py tests/test_wechat_channel_context.py