### PR TITLE
fix: Tooltip popup being clipped in PlatformDashboard | 修复平台仪表盘页面 Tooltip 弹出框被裁剪问题

### DIFF
--- a/frontend/src/pages/PlatformDashboard.tsx
+++ b/frontend/src/pages/PlatformDashboard.tsx
@@ -349,7 +349,7 @@ export default function PlatformDashboard() {
     const ChurnTable = () => {
         const data = enhanced?.churn_warnings || [];
         return (
-            <div className="card" style={{ padding: '0', overflow: 'hidden' }}>
+            <div className="card" style={{ padding: '0', overflow: 'visible' }}>
                 <div style={{
                     padding: '20px',
                     fontSize: '13px',
@@ -413,7 +413,7 @@ export default function PlatformDashboard() {
         title: string; tooltip: string; items: any[];
         renderItem: (item: any, i: number) => React.ReactNode;
     }) => (
-        <div className="card" style={{ flex: 1, minWidth: '300px', padding: '0', overflow: 'hidden' }}>
+        <div className="card" style={{ flex: 1, minWidth: '300px', padding: '0', overflow: 'visible' }}>
             <div style={{
                 padding: '20px',
                 fontSize: '13px',


### PR DESCRIPTION
## Description | 描述

**English:**
Fix tooltip popup being clipped in PlatformDashboard page.

**中文:**
修复 PlatformDashboard 页面中的 Tooltip 弹出框被裁剪的问题。

---

## Changes Made | 修改内容

**English:**
- **frontend/src/pages/PlatformDashboard.tsx**: 
  - Changed `overflow: 'hidden'` to `overflow: 'visible'` in `LeaderboardCard` component (L417)
  - Changed `overflow: 'hidden'` to `overflow: 'visible'` in `ChurnTable` component (L352)

**中文:**
- **frontend/src/pages/PlatformDashboard.tsx**: 
  - 在 `LeaderboardCard` 组件中将 `overflow: 'hidden'` 改为 `overflow: 'visible'` (L417)
  - 在 `ChurnTable` 组件中将 `overflow: 'hidden'` 改为 `overflow: 'visible'` (L352)

---

## Bug Fixed | 修复的问题

**English:**
The InfoTooltip popup icons (i) next to:
- "Top 20 Companies by Tokens"
- "Top 20 Agents by Tokens"  
- "Churn Warning"

were being clipped by their parent containers' `overflow: hidden` styles.

**中文:**
以下三个模块旁边的说明提示图标 (i) 的弹出框：
- "Top 20 Companies by Tokens"（按令牌使用排行前 20 家公司）
- "Top 20 Agents by Tokens"（按令牌使用排行前 20 个 Agent）
- "Churn Warning"（流失警告）

会被其父容器的 `overflow: hidden` 样式裁剪，导致无法正常显示。

---

## Testing | 测试
<img width="1203" height="450" alt="image" src="https://github.com/user-attachments/assets/cd38e6ec-3a45-46b3-bbd9-00c389bc493b" />

**English:**
1. Navigate to Platform Dashboard as admin
2. Hover over the (i) icons next to the affected sections
3. Verify tooltips display correctly without being clipped

**中文:**
1. 以管理员身份导航到 Platform Dashboard（平台仪表盘）
2. 将鼠标悬停在受影响部分旁边的 (i) 图标上
3. 验证 Tooltip 能够正确显示而不被裁剪