### PR TITLE
Fix IME Enter submitting chat messages on macOS

### DIFF
--- a/frontend/src/pages/AgentDetail.tsx
+++ b/frontend/src/pages/AgentDetail.tsx
@@ -6584,7 +6584,7 @@ function AgentDetailInner() {
                                                     }}
                                                     onKeyDown={e => {
                                                         // Enter sends the message; Shift+Enter inserts a newline
-                                                        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !isWaiting && !isStreaming) {
+                                                        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229 && !isWaiting && !isStreaming) {
                                                             e.preventDefault();
                                                             sendChatMsg();
                                                         }

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -805,7 +805,7 @@ export default function Chat() {
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
         // Enter sends the message; Shift+Enter inserts a newline
-        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && !isWaiting && !streaming) {
+        if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing && e.keyCode !== 229 && !isWaiting && !streaming) {
             e.preventDefault();
             sendMessage();
         }


### PR DESCRIPTION
## Summary
- prevent Enter keydown events used by IME candidate confirmation from sending chat messages
- apply the guard to both chat entry points while preserving Enter-to-send and Shift+Enter newline behavior

## Testing
- npm run build

Closes #524