### PR TITLE
fix: keep notification bar fixed at top when page scrolls

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -114,7 +114,8 @@
   font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.01em;
-  position: relative;
+  position: sticky;
+  top: 0;
   z-index: 100;
   flex-shrink: 0;
   overflow: visible;


### PR DESCRIPTION
## Summary
  - Change `.notification-bar` from `position: relative` to `position: sticky; top: 0` so the top
  notification bar stays pinned while the page scrolls.

## Checklist

 - [x] Visually verified: with the notification bar enabled, scrolled a long page and confirmed the bar
  stays pinned at the top.
  - [x] Confirmed sidebar still aligns under the bar (its `top: var(--notification-bar-height)` and height
   calc remain correct).
