### PR TITLE
fix: offset top-anchored sticky elements below notification bar

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -700,10 +700,10 @@ select:focus {
 
 .tenant-switcher-popover {
   position: fixed;
-  top: 82px;
+  top: calc(82px + var(--notification-bar-height));
   left: var(--space-4);
   width: 304px;
-  max-height: min(520px, calc(100vh - 96px));
+  max-height: min(520px, calc(100vh - 96px - var(--notification-bar-height)));
   overflow: hidden;
   z-index: 10020;
   padding: 10px;
@@ -1316,11 +1316,11 @@ select:focus {
 
 .sidebar-agent-drawer {
   position: fixed;
-  top: 10px;
+  top: calc(10px + var(--notification-bar-height));
   left: calc(var(--sidebar-width-collapsed) + 8px);
   z-index: 9400;
   width: 278px;
-  height: calc(100vh - 20px);
+  height: calc(100vh - 20px - var(--notification-bar-height));
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -1929,7 +1929,7 @@ select:focus {
   border-bottom: 1px solid var(--border-subtle);
   margin-bottom: var(--space-6);
   position: sticky;
-  top: 0;
+  top: var(--notification-bar-height);
   background: var(--bg-primary);
   z-index: 5;
   padding-top: var(--space-2);

--- a/frontend/src/pages/Plaza.tsx
+++ b/frontend/src/pages/Plaza.tsx
@@ -848,7 +848,7 @@ export default function Plaza() {
                 <div style={{
                     width: '260px', flexShrink: 0,
                     display: 'flex', flexDirection: 'column', gap: '12px',
-                    position: 'sticky', top: '20px',
+                    position: 'sticky', top: 'calc(20px + var(--notification-bar-height))',
                 }}>
                     {/* Online Agents */}
                     {runningAgents.length > 0 && (


### PR DESCRIPTION
 Summary
   When the notification bar is shown, viewport-top-anchored sticky/fixed elements were either covering 
   or being covered by the bar. This PR offsets each of them by --notification-bar-height so they sit 
   below the bar (and naturally collapse to their original positions when the bar is hidden, since the 
   variable is then 0px).

## Checklist
   - Open sidebar workspace switcher → popover starts below the bar, doesn't overflow viewport
   - Expand collapsed sidebar agent drawer → drawer doesn't extend past viewport
   - Scroll Plaza page → right-side sticky panel sits below the bar
   - Disable notification bar → all four elements return to original positions (no visual gap)
