### PR TITLE
Relax subprocess sandbox restrictions

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -7236,45 +7236,66 @@ async def _plaza_add_comment(agent_id: uuid.UUID, arguments: dict) -> str:
 # ─── Code Execution ─────────────────────────────────────────────
 
 # Dangerous patterns to block (for legacy fallback)
-_DANGEROUS_BASH = [
+_DANGEROUS_BASH_ALWAYS = [
     "rm -rf /", "rm -rf ~", "sudo ", "mkfs", "dd if=",
     ":(){ :", "chmod 777 /", "chown ", "shutdown", "reboot",
-    "curl ", "wget ", "nc ", "ncat ", "ssh ", "scp ",
-    "python3 -c", "python -c",
 ]
 
-_DANGEROUS_PYTHON_IMPORTS = [
-    "subprocess", "shutil.rmtree", "os.system", "os.popen",
+_DANGEROUS_BASH_NETWORK = [
+    "curl ", "wget ", "nc ", "ncat ", "ssh ", "scp ",
+]
+
+_DANGEROUS_PYTHON_IMPORTS_ALWAYS = [
+    "shutil.rmtree", "os.system", "os.popen",
     "os.exec", "os.spawn",
+]
+
+_DANGEROUS_PYTHON_IMPORTS_NETWORK = [
     "socket", "http.client", "urllib.request", "requests",
     "ftplib", "smtplib", "telnetlib", "ctypes",
-    "__import__", "importlib",
+]
+
+_DANGEROUS_NODE_ALWAYS = [
+    "fs.rmSync", "fs.rmdirSync", "process.exit",
+]
+
+_DANGEROUS_NODE_NETWORK = [
+    "require('http')", "require('https')", "require('net')",
 ]
 
 
-def _check_code_safety(language: str, code: str) -> str | None:
+def _check_code_safety(language: str, code: str, allow_network: bool = False) -> str | None:
     """Check code for dangerous patterns. Returns error message if unsafe, None if ok."""
     code_lower = code.lower()
 
     if language == "bash":
-        for pattern in _DANGEROUS_BASH:
+        for pattern in _DANGEROUS_BASH_ALWAYS:
             if pattern.lower() in code_lower:
                 return f"❌ Blocked: dangerous command detected ({pattern.strip()})"
-        # Block deep path traversal outside workspace
+        if not allow_network:
+            for pattern in _DANGEROUS_BASH_NETWORK:
+                if pattern.lower() in code_lower:
+                    return f"❌ Blocked: network command not allowed ({pattern.strip()})"
         if "../../" in code:
             return "❌ Blocked: directory traversal not allowed"
 
     elif language == "python":
-        for pattern in _DANGEROUS_PYTHON_IMPORTS:
+        for pattern in _DANGEROUS_PYTHON_IMPORTS_ALWAYS:
             if pattern.lower() in code_lower:
                 return f"❌ Blocked: unsafe operation detected ({pattern})"
+        if not allow_network:
+            for pattern in _DANGEROUS_PYTHON_IMPORTS_NETWORK:
+                if pattern.lower() in code_lower:
+                    return f"❌ Blocked: network operation not allowed ({pattern})"
 
     elif language == "node":
-        dangerous_node = ["child_process", "fs.rmSync", "fs.rmdirSync", "process.exit",
-                          "require('http')", "require('https')", "require('net')"]
-        for pattern in dangerous_node:
+        for pattern in _DANGEROUS_NODE_ALWAYS:
             if pattern.lower() in code_lower:
                 return f"❌ Blocked: unsafe operation detected ({pattern})"
+        if not allow_network:
+            for pattern in _DANGEROUS_NODE_NETWORK:
+                if pattern.lower() in code_lower:
+                    return f"❌ Blocked: network operation not allowed ({pattern})"
 
     return None
 
@@ -7350,7 +7371,7 @@ async def _execute_code(
             # Do not silently fall back — surface the config error to the user
             return f"❌ E2B sandbox configuration error: {str(e)[:300]}\nPlease check the API key in the tool settings."
         logger.warning(f"[Sandbox] Config issue, falling back to legacy subprocess: {e}")
-        return await _execute_code_legacy(ws, arguments)
+        return await _execute_code_legacy(ws, arguments, allow_network=fallback_config.allow_network)
 
     except Exception as e:
         logger.exception(f"[Sandbox] Execution failed for agent {agent_id} (tool={tool_name})")
@@ -7359,13 +7380,13 @@ async def _execute_code(
             return f"❌ E2B execution error: {str(e)[:200]}"
         # For local tool: try legacy subprocess as last resort
         try:
-            return await _execute_code_legacy(ws, arguments)
+            return await _execute_code_legacy(ws, arguments, allow_network=sandbox_config.allow_network)
         except Exception:
             logger.exception(f"[Sandbox] Fallback also failed for agent {agent_id}")
             return f"❌ Execution error: {str(e)[:200]}"
 
 
-async def _execute_code_legacy(ws: Path, arguments: dict) -> str:
+async def _execute_code_legacy(ws: Path, arguments: dict, allow_network: bool = False) -> str:
     """Legacy subprocess-based code execution (fallback)."""
     import asyncio
 
@@ -7380,7 +7401,7 @@ async def _execute_code_legacy(ws: Path, arguments: dict) -> str:
         return f"❌ Unsupported language: {language}. Use: python, bash, or node"
 
     # Security check
-    safety_error = _check_code_safety(language, code)
+    safety_error = _check_code_safety(language, code, allow_network)
     if safety_error:
         return safety_error
 

--- a/backend/app/services/sandbox/local/subprocess_backend.py
+++ b/backend/app/services/sandbox/local/subprocess_backend.py
@@ -17,7 +17,6 @@ from app.services.workspace_paths import WorkspacePathError, resolve_path_within
 _DANGEROUS_BASH_ALWAYS = [
     "rm -rf /", "rm -rf ~", "sudo ", "mkfs", "dd if=",
     ":(){ :", "chmod 777 /", "chown ", "shutdown", "reboot",
-    "python3 -c", "python -c",
 ]
 
 _DANGEROUS_BASH_NETWORK = [
@@ -25,18 +24,17 @@ _DANGEROUS_BASH_NETWORK = [
 ]
 
 _DANGEROUS_PYTHON_IMPORTS_ALWAYS = [
-    "subprocess", "shutil.rmtree", "os.system", "os.popen",
+    "shutil.rmtree", "os.system", "os.popen",
     "os.exec", "os.spawn",
 ]
 
 _DANGEROUS_PYTHON_IMPORTS_NETWORK = [
     "socket", "http.client", "urllib.request", "requests",
     "ftplib", "smtplib", "telnetlib", "ctypes",
-    "__import__", "importlib",
 ]
 
 _DANGEROUS_NODE_ALWAYS = [
-    "child_process", "fs.rmSync", "fs.rmdirSync", "process.exit",
+    "fs.rmSync", "fs.rmdirSync", "process.exit",
 ]
 
 _DANGEROUS_NODE_NETWORK = [
@@ -105,25 +103,54 @@ class SubprocessBackend(BaseSandboxBackend):
     def __init__(self, config: SandboxConfig):
         self.config = config
 
-    def _build_command(self, language: str, script_path: str) -> list[str]:
+    def _venv_python(self, work_path: Path) -> str:
+        return f"/workspace/{work_path.joinpath('.venv', 'bin', 'python').relative_to(work_path)}"
+
+    def _build_command(self, language: str, script_path: str, work_path: Path) -> list[str]:
         if language == "python":
-            return ["python3", "-I", "-B", str(script_path)]
+            return [self._venv_python(work_path), "-I", "-B", str(script_path)]
         if language == "bash":
             return ["bash", "--noprofile", "--norc", str(script_path)]
         return ["node", str(script_path)]
 
     def _build_safe_env(self, work_path: Path) -> dict[str, str]:
+        venv_bin = work_path / ".venv" / "bin"
+        workspace_tmp = work_path / ".tmp"
         env = {
             "HOME": str(work_path),
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PATH": f"{venv_bin}:{os.environ.get('PATH', '/usr/bin:/bin')}",
             "PYTHONDONTWRITEBYTECODE": "1",
             "PYTHONNOUSERSITE": "1",
-            "TMPDIR": str(work_path / ".tmp"),
+            "TMPDIR": str(workspace_tmp),
             "NODE_PATH": "",
             "BASH_ENV": "",
             "ENV": "",
+            "VIRTUAL_ENV": str(work_path / ".venv"),
+            "PIP_CACHE_DIR": str(workspace_tmp / "pip-cache"),
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
         }
         return env
+
+    def _bind_if_exists(self, host_path: str, guest_path: str | None = None, *, read_only: bool = True) -> list[str]:
+        host = Path(host_path)
+        if not host.exists():
+            return []
+        target = guest_path or host_path
+        bind_flag = "--ro-bind" if read_only else "--bind"
+        return [bind_flag, str(host), target]
+
+    def _ensure_workspace_venv(self, work_path: Path) -> None:
+        venv_python = work_path / ".venv" / "bin" / "python"
+        if venv_python.exists():
+            return
+
+        import subprocess
+
+        subprocess.run(
+            ["python3", "-m", "venv", str(work_path / ".venv")],
+            check=True,
+            cwd=str(work_path),
+        )
 
     def _build_preexec_fn(self, work_path: Path, timeout: int):
         def _preexec():
@@ -177,6 +204,15 @@ class SubprocessBackend(BaseSandboxBackend):
                 SubprocessBackend._bwrap_missing_warned = True
             return None
 
+        base_binds = (
+            self._bind_if_exists("/usr")
+            + self._bind_if_exists("/usr/local")
+            + self._bind_if_exists("/bin")
+            + self._bind_if_exists("/lib")
+            + self._bind_if_exists("/lib64")
+            + self._bind_if_exists("/etc")
+        )
+
         cmd = [
             bwrap,
             "--die-with-parent",
@@ -186,22 +222,22 @@ class SubprocessBackend(BaseSandboxBackend):
             "--unshare-pid",
             "--unshare-uts",
             "--unshare-cgroup",
-            "--ro-bind", "/usr", "/usr",
-            "--ro-bind", "/bin", "/bin",
-            "--ro-bind", "/lib", "/lib",
-            "--ro-bind", "/lib64", "/lib64",
-            "--ro-bind", "/etc", "/etc",
+            *base_binds,
             "--bind", str(work_path), "/workspace",
             "--dev", "/dev",
             "--proc", "/proc",
             "--dir", "/tmp",
             "--setenv", "HOME", "/workspace",
+            "--setenv", "PATH", f"/workspace/.venv/bin:{os.environ.get('PATH', '/usr/bin:/bin')}",
             "--setenv", "TMPDIR", "/workspace/.tmp",
             "--setenv", "PYTHONDONTWRITEBYTECODE", "1",
             "--setenv", "PYTHONNOUSERSITE", "1",
             "--setenv", "NODE_PATH", "",
             "--setenv", "BASH_ENV", "",
             "--setenv", "ENV", "",
+            "--setenv", "VIRTUAL_ENV", "/workspace/.venv",
+            "--setenv", "PIP_CACHE_DIR", "/workspace/.tmp/pip-cache",
+            "--setenv", "PIP_DISABLE_PIP_VERSION_CHECK", "1",
             "--chdir", "/workspace",
         ]
         if not self.config.allow_network:
@@ -283,6 +319,7 @@ class SubprocessBackend(BaseSandboxBackend):
             )
         work_path.mkdir(parents=True, exist_ok=True)
         (work_path / ".tmp").mkdir(parents=True, exist_ok=True)
+        (work_path / ".tmp" / "pip-cache").mkdir(parents=True, exist_ok=True)
 
         # Determine command and file extension
         if language == "python":
@@ -296,9 +333,10 @@ class SubprocessBackend(BaseSandboxBackend):
         script_path = work_path / f"_exec_tmp{ext}"
 
         try:
+            self._ensure_workspace_venv(work_path)
             script_path.write_text(code, encoding="utf-8")
 
-            sandbox_command = self._build_command(language, f"/workspace/{script_path.name}")
+            sandbox_command = self._build_command(language, f"/workspace/{script_path.name}", work_path)
             bwrap_command = self._build_bwrap_command(sandbox_command, work_path)
             if not bwrap_command:
                 duration_ms = int((time.time() - start_time) * 1000)


### PR DESCRIPTION
## Summary
- allow subprocess sandboxed execution to use a workspace-local Python venv and pip cache
- relax static command blacklists for python/bash/node where bwrap isolation already covers the risk
- align legacy fallback network gating with allow_network so behavior matches the subprocess backend

## Testing
- python3 -m py_compile backend/app/services/sandbox/local/subprocess_backend.py backend/app/services/agent_tools.py