### PR TITLE
对接飞书时，同一手机号下的多个账号会出现user_id泄露问题

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -10470,10 +10470,16 @@ async def _feishu_user_search(agent_id: uuid.UUID, arguments: dict) -> str:
         from app.database import async_session as _async_session
         from sqlalchemy import select as _sa_select
         from app.models.org import OrgMember as _OrgMember
+        from app.models.agent import Agent as _AgentModel
         async with _async_session() as _db:
-            _r = await _db.execute(
-                _sa_select(_OrgMember).where(_OrgMember.name.ilike(f"%{name}%"))
+            _agent_tenant_id = await _db.execute(
+                _sa_select(_AgentModel.tenant_id).where(_AgentModel.id == agent_id)
             )
+            _tid = _agent_tenant_id.scalar_one_or_none()
+            _query = _sa_select(_OrgMember).where(_OrgMember.name.ilike(f"%{name}%"))
+            if _tid:
+                _query = _query.where(_OrgMember.tenant_id == _tid)
+            _r = await _db.execute(_query)
             _org_members = _r.scalars().all()
         if _org_members:
             lines = [f"🔍 从通讯录找到 {len(_org_members)} 位匹配「{name}」的用户：\n"]
@@ -10496,10 +10502,16 @@ async def _feishu_user_search(agent_id: uuid.UUID, arguments: dict) -> str:
         from app.database import async_session as _async_session
         from sqlalchemy import select as _sa_select
         from app.models.user import User as _User
+        from app.models.agent import Agent as _AgentModel2
         async with _async_session() as _db:
-            _r = await _db.execute(
-                _sa_select(_User).where(_User.display_name.ilike(f"%{name}%"))
+            _agent_tenant_id2 = await _db.execute(
+                _sa_select(_AgentModel2.tenant_id).where(_AgentModel2.id == agent_id)
             )
+            _tid2 = _agent_tenant_id2.scalar_one_or_none()
+            _query2 = _sa_select(_User).where(_User.display_name.ilike(f"%{name}%"))
+            if _tid2:
+                _query2 = _query2.where(_User.tenant_id == _tid2)
+            _r = await _db.execute(_query2)
             _platform_users = _r.scalars().all()
         for _pu in _platform_users:
             _uid = getattr(_pu, "feishu_user_id", None)

--- a/backend/app/services/feishu_service.py
+++ b/backend/app/services/feishu_service.py
@@ -558,12 +558,18 @@ class FeishuService:
 
             # Send text accompany message first if provided
             if accompany_msg:
-                await client.post(
+                text_resp = await client.post(
                     f"{FEISHU_SEND_MSG_URL}?receive_id_type={receive_id_type}",
                     json={"receive_id": receive_id, "msg_type": "text",
                           "content": _json.dumps({"text": accompany_msg})},
                     headers=headers,
                 )
+                if text_resp.status_code != 200:
+                    logger.error(
+                        f"[Feishu] Failed to send text accompany message: "
+                        f"status={text_resp.status_code}, body={text_resp.text}, "
+                        f"receive_id={receive_id}, receive_id_type={receive_id_type}"
+                    )
 
             # Send file message
             resp = await client.post(
@@ -572,6 +578,13 @@ class FeishuService:
                       "content": _json.dumps({"file_key": file_key})},
                 headers=headers,
             )
+            if resp.status_code != 200:
+                logger.error(
+                    f"[Feishu] Failed to send file message: "
+                    f"status={resp.status_code}, body={resp.text}, "
+                    f"receive_id={receive_id}, receive_id_type={receive_id_type}, "
+                    f"file_key={file_key}"
+                )
             return resp.json()
 
     # --- Bitable (多维表格) API ---


### PR DESCRIPTION
## Summary
对接飞书时，同一手机号下的多个账号配置了不同的公司的的员工时，会出现发送文件失败的情况，原因是后配置的user_id会使用先配置的user_id

## Checklist
1. 日志DEBUG打印，方便问题排查定位
2. 修复：为 _feishu_user_search 添加 tenant_id 过滤，防止跨租户用户 ID 泄露
