### PR TITLE
feat: add global toggle for sso custom domain redirect and fix reset password theme adaptive colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,7 @@ Each agent has a private file workspace under `agent_template/`. The files `soul
 - **Integrations**: Feishu/Lark, DingTalk, WeCom, Slack, Discord, Jira/Confluence, Microsoft Teams
 - **Linting**: Ruff (Python, line-length 120, target py311), TypeScript strict mode
 - **Testing**: pytest + pytest-asyncio (asyncio_mode = "auto")
+
+## Code Guidelines
+
+- **Python Imports**: Python imports should be placed at the top of the file (file header) as much as possible. Avoid inline imports within functions or methods unless strictly necessary (e.g., to prevent circular import dependencies).

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -54,11 +54,13 @@ class CompanyCreateResponse(BaseModel):
 class PlatformSettingsOut(BaseModel):
     allow_self_create_company: bool = True
     invitation_code_enabled: bool = False
+    sso_custom_domain_redirect_enabled: bool = True
 
 
 class PlatformSettingsUpdate(BaseModel):
     allow_self_create_company: bool | None = None
     invitation_code_enabled: bool | None = None
+    sso_custom_domain_redirect_enabled: bool | None = None
 
 
 # ─── Company Management ────────────────────────────────
@@ -589,6 +591,7 @@ async def get_platform_settings(
     for key, default in [
         ("allow_self_create_company", True),
         ("invitation_code_enabled", False),
+        ("sso_custom_domain_redirect_enabled", True),
     ]:
         r = await db.execute(select(SystemSetting).where(SystemSetting.key == key))
         s = r.scalar_one_or_none()

--- a/backend/app/api/tenants.py
+++ b/backend/app/api/tenants.py
@@ -414,26 +414,34 @@ async def resolve_tenant_by_domain(
     """
     tenant = None
 
-    # 1. Match by stripping protocol from stored sso_domain
-    # sso_domain = "https://acme.clawith.ai" → compare against "acme.clawith.ai"
-    for proto in ("https://", "http://"):
-        result = await db.execute(
-            select(Tenant).where(Tenant.sso_domain == f"{proto}{domain}")
-        )
-        tenant = result.scalar_one_or_none()
-        if tenant:
-            break
+    from app.models.system_settings import SystemSetting
+    setting_result = await db.execute(
+        select(SystemSetting).where(SystemSetting.key == "sso_custom_domain_redirect_enabled")
+    )
+    setting_s = setting_result.scalar_one_or_none()
+    sso_redirect_enabled = setting_s.value.get("enabled", True) if setting_s else True
 
-    # 2. Try without port (e.g. domain = "1.2.3.4:3009" → try "1.2.3.4")
-    if not tenant and ":" in domain:
-        domain_no_port = domain.split(":")[0]
+    if sso_redirect_enabled:
+        # 1. Match by stripping protocol from stored sso_domain
+        # sso_domain = "https://acme.clawith.ai" → compare against "acme.clawith.ai"
         for proto in ("https://", "http://"):
             result = await db.execute(
-                select(Tenant).where(Tenant.sso_domain.like(f"{proto}{domain_no_port}%"))
+                select(Tenant).where(Tenant.sso_domain == f"{proto}{domain}")
             )
             tenant = result.scalar_one_or_none()
             if tenant:
                 break
+
+        # 2. Try without port (e.g. domain = "1.2.3.4:3009" → try "1.2.3.4")
+        if not tenant and ":" in domain:
+            domain_no_port = domain.split(":")[0]
+            for proto in ("https://", "http://"):
+                result = await db.execute(
+                    select(Tenant).where(Tenant.sso_domain.like(f"{proto}{domain_no_port}%"))
+                )
+                tenant = result.scalar_one_or_none()
+                if tenant:
+                    break
 
     # 3. Fallback: extract slug from subdomain pattern
     if not tenant:

--- a/backend/app/services/platform_service.py
+++ b/backend/app/services/platform_service.py
@@ -41,13 +41,15 @@ class PlatformService:
 
 
     async def get_tenant_sso_base_url(self, db: AsyncSession, tenant, request: Request | None = None) -> str:
-        """Generate the SSO base URL for a tenant based on IP/Domain logic.
-        
-        Priority:
-        1. Explicit sso_domain stored in tenant record (if present)
-        2. Auto-generated URL based on the unified public_base_url (ENV > Request > Fallback)
-        """
-        if tenant.sso_domain:
+        """Generate the SSO base URL for a tenant based on IP/Domain logic."""
+        # Check if custom domain SSO redirect is enabled globally
+        setting_result = await db.execute(
+            select(SystemSetting).where(SystemSetting.key == "sso_custom_domain_redirect_enabled")
+        )
+        setting_s = setting_result.scalar_one_or_none()
+        sso_redirect_enabled = setting_s.value.get("enabled", True) if setting_s else True
+
+        if sso_redirect_enabled and tenant.sso_domain:
             return tenant.sso_domain.rstrip("/")
 
         base_url = await self.get_public_base_url(db, request)

--- a/backend/tests/test_sso_toggle.py
+++ b/backend/tests/test_sso_toggle.py
@@ -1,0 +1,88 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+from types import SimpleNamespace
+
+from app.api import admin as admin_api
+from app.api import tenants as tenants_api
+from app.services.platform_service import platform_service
+from tests.test_auth import RecordingDB, DummyResult
+
+@pytest.mark.asyncio
+async def test_get_platform_settings_sso_toggle_default():
+    """Verify that get_platform_settings returns sso_custom_domain_redirect_enabled by default."""
+    db = RecordingDB(responses=[
+        DummyResult(),  # allow_self_create_company lookup -> None (default True)
+        DummyResult(),  # invitation_code_enabled lookup -> None (default False)
+        DummyResult(),  # sso_custom_domain_redirect_enabled lookup -> None (default True)
+    ])
+    
+    current_user = MagicMock()
+    settings = await admin_api.get_platform_settings(current_user=current_user, db=db)
+    
+    assert settings.sso_custom_domain_redirect_enabled is True
+    assert settings.allow_self_create_company is True
+    assert settings.invitation_code_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_get_platform_settings_sso_toggle_disabled():
+    """Verify that get_platform_settings returns sso_custom_domain_redirect_enabled False if set."""
+    setting_record = SimpleNamespace(key="sso_custom_domain_redirect_enabled", value={"enabled": False})
+    db = RecordingDB(responses=[
+        DummyResult(),  # allow_self_create_company -> None
+        DummyResult(),  # invitation_code_enabled -> None
+        DummyResult(values=[setting_record]),  # sso_custom_domain_redirect_enabled -> disabled
+    ])
+    
+    current_user = MagicMock()
+    settings = await admin_api.get_platform_settings(current_user=current_user, db=db)
+    assert settings.sso_custom_domain_redirect_enabled is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_tenant_by_domain_sso_toggle():
+    """Verify that resolve_tenant_by_domain respects the sso_custom_domain_redirect_enabled toggle."""
+    # When enabled, custom domain lookup should match the tenant by domain
+    active_tenant = SimpleNamespace(id="tenant-id", name="Acme", slug="acme", sso_enabled=True, sso_domain="https://acme.com", is_active=True)
+    
+    # Check 1: SSO toggle enabled, matches tenant
+    db_enabled = RecordingDB(responses=[
+        DummyResult(),  # sso_custom_domain_redirect_enabled -> None (default True)
+        DummyResult(values=[active_tenant]),  # Match for https://acme.com
+    ])
+    res = await tenants_api.resolve_tenant_by_domain(domain="acme.com", db=db_enabled)
+    assert res["id"] == "tenant-id"
+    assert res["sso_domain"] == "https://acme.com"
+
+    # Check 2: SSO toggle disabled, does not match tenant by domain, falls back or fails
+    setting_disabled = SimpleNamespace(key="sso_custom_domain_redirect_enabled", value={"enabled": False})
+    db_disabled = RecordingDB(responses=[
+        DummyResult(values=[setting_disabled]),  # sso_custom_domain_redirect_enabled -> False
+        DummyResult(),  # Fallback search slug (which fails)
+    ])
+    with pytest.raises(HTTPException) as exc:
+        await tenants_api.resolve_tenant_by_domain(domain="acme.com", db=db_disabled)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_tenant_sso_base_url_toggle():
+    """Verify that get_tenant_sso_base_url respects the sso_custom_domain_redirect_enabled toggle."""
+    tenant = SimpleNamespace(slug="acme", sso_domain="https://acme.com")
+    
+    # 1. Enabled: returns the custom sso_domain
+    db_enabled = RecordingDB(responses=[
+        DummyResult(),  # sso_custom_domain_redirect_enabled -> None (default True)
+    ])
+    url = await platform_service.get_tenant_sso_base_url(db=db_enabled, tenant=tenant)
+    assert url == "https://acme.com"
+
+    # 2. Disabled: falls back to generated slug domain URL
+    setting_disabled = SimpleNamespace(key="sso_custom_domain_redirect_enabled", value={"enabled": False})
+    db_disabled = RecordingDB(responses=[
+        DummyResult(values=[setting_disabled]),  # sso_custom_domain_redirect_enabled -> False
+    ])
+    with patch.object(platform_service, "get_public_base_url", return_value="https://try.clawith.ai"):
+        url = await platform_service.get_tenant_sso_base_url(db=db_disabled, tenant=tenant)
+        assert url == "https://acme.clawith.ai"

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1838,6 +1838,8 @@
     "next": "Next",
     "allowSelfCreate": "Allow users to create their own companies",
     "allowSelfCreateDesc": "When disabled, only platform admins can create companies.",
+    "ssoCustomDomainRedirect": "Enable tenant SSO custom domain redirect",
+    "ssoCustomDomainRedirectDesc": "When disabled, all tenants will be blocked from using custom domains or dedicated links to redirect to SSO providers.",
     "editCompany": "Edit Company",
     "ssoConfigTitle": "SSO & Domain Configuration",
     "ssoConfigDesc": "Configure SSO and custom domain for this company.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1681,6 +1681,8 @@
     "platformSettings": "平台设置",
     "allowSelfCreate": "允许用户自行创建公司",
     "allowSelfCreateDesc": "关闭后，仅平台管理员可以创建公司。",
+    "ssoCustomDomainRedirect": "启用租户 SSO 自定义域名重定向",
+    "ssoCustomDomainRedirectDesc": "关闭后，整个平台所有的租户都无法使用自定义域名或专属链接跳转到单点登录提供商。",
     "inviteCodeRequired": "注册需要邀请码",
     "inviteCodeRequiredDesc": "开启后，新用户必须提供有效的邀请码才能注册。",
     "companyNamePlaceholder": "公司名称",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,7 @@
   --error: #ef4444;
   --error-subtle: rgba(239, 68, 68, 0.12);
   --info: #3b82f6;
+  --info-subtle: rgba(59, 130, 246, 0.12);
   --info-card-accent: #818cf8;
   --info-card-accent-end: #a78bfa;
 
@@ -251,6 +252,7 @@
   --error: #dc2626;
   --error-subtle: rgba(220, 38, 38, 0.08);
   --info: #2563eb;
+  --info-subtle: rgba(37, 99, 235, 0.08);
   --info-card-accent: #6366f1;
   --info-card-accent-end: #8b5cf6;
 

--- a/frontend/src/pages/AdminCompanies.tsx
+++ b/frontend/src/pages/AdminCompanies.tsx
@@ -459,11 +459,12 @@ function PlatformTab() {
                 }}>{toast.msg}</div>
             )}
 
-            {/* Allow self-create company toggle */}
+            {/* Allow self-create company and SSO redirect toggle */}
             <div className="card" style={{ padding: '16px', marginBottom: '16px' }}>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
                     {[
                         { key: 'allow_self_create_company', label: t('admin.allowSelfCreate', 'Allow users to create their own companies'), desc: t('admin.allowSelfCreateDesc', 'When disabled, only platform admins can create companies.') },
+                        { key: 'sso_custom_domain_redirect_enabled', label: t('admin.ssoCustomDomainRedirect', 'Enable tenant SSO custom domain redirect'), desc: t('admin.ssoCustomDomainRedirectDesc', 'When disabled, all tenants will be blocked from using custom domains or dedicated links to redirect to SSO providers.') },
                     ].map(s => (
                         <div key={s.key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0' }}>
                             <div>

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -74,13 +74,13 @@ export default function ForgotPassword() {
                     )}
 
                     {message && (
-                        <div className="login-error" style={{ background: 'rgba(34,197,94,0.14)', borderColor: 'rgba(34,197,94,0.35)', color: '#dcfce7' }}>
+                        <div className="login-error" style={{ background: 'var(--success-subtle)', borderColor: 'color-mix(in srgb, var(--success) 20%, transparent)', color: 'var(--success)' }}>
                             <span><IconCheck size={14} stroke={1.8} /></span> {message}
                         </div>
                     )}
 
                     {hintResult && (
-                        <div className="login-error" style={{ background: 'rgba(56,189,248,0.1)', borderColor: 'rgba(56,189,248,0.3)', color: '#bae6fd' }}>
+                        <div className="login-error" style={{ background: 'var(--info-subtle)', borderColor: 'color-mix(in srgb, var(--info) 20%, transparent)', color: 'var(--info)' }}>
                             <IconBulb size={14} stroke={1.8} style={{ marginRight: '6px' }} />
                             {t('auth.emailHintResult', 'Email hint')}: <strong>{hintResult}</strong>
                         </div>

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -70,7 +70,7 @@ export default function ResetPassword() {
                     )}
 
                     {success && (
-                        <div className="login-error" style={{ background: 'rgba(34,197,94,0.14)', borderColor: 'rgba(34,197,94,0.35)', color: '#dcfce7' }}>
+                        <div className="login-error" style={{ background: 'var(--success-subtle)', borderColor: 'color-mix(in srgb, var(--success) 20%, transparent)', color: 'var(--success)' }}>
                             <span><IconCheck size={14} stroke={1.8} /></span> {t('auth.resetPasswordSuccess', 'Password updated. Redirecting to login...')}
                         </div>
                     )}


### PR DESCRIPTION
This PR adds a global toggle for SSO custom domain redirect and fixes the light/dark theme adaptive colors for forgot/reset password pages. It also includes unit tests and updates the import code guidelines in CLAUDE.md.