### PR TITLE
fix(alembic): resolve conflict markers in 059_add_title_to_agent_focus_items.py

### DIFF
--- a/backend/alembic/versions/059_add_title_to_agent_focus_items.py
+++ b/backend/alembic/versions/059_add_title_to_agent_focus_items.py
@@ -10,11 +10,7 @@ from alembic import op
 import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
-<<<<<<< HEAD:backend/alembic/versions/059_add_title_to_agent_focus_items.py
 revision: str = 'add_title_to_agent_focus_items'
-=======
-revision: str = '043e5f59eb8a'
->>>>>>> f5bb364460d8d714550cbbe43de342580e04485f:backend/alembic/versions/043e5f59eb8a_add_title_to_agent_focus_items.py
 down_revision: Union[str, None] = 'merge_heads_20260521'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None


### PR DESCRIPTION
This PR resolves the git conflict markers that were accidentally checked into `main` inside the migration file `backend/alembic/versions/059_add_title_to_agent_focus_items.py`.