### PR TITLE
fix(vercel): use 'encrypted' instead of 'secret' for env var type

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -14648,7 +14648,7 @@ async def _vercel_set_env(agent_id: uuid.UUID, arguments: dict) -> str:
     payload = {
         "key": key,
         "value": value,
-        "type": "secret" if key == "DATABASE_URL" else "plain",
+        "type": "encrypted" if key == "DATABASE_URL" else "plain",
         "target": target
     }
     


### PR DESCRIPTION
Change Vercel environment variable type from 'secret' to 'encrypted' to align with latest Vercel API specification.