### PR TITLE
fix: auto-detect GCS endpoint for correct V4 signature config

### DIFF
--- a/backend/app/services/storage_runtime/s3.py
+++ b/backend/app/services/storage_runtime/s3.py
@@ -49,28 +49,47 @@ class S3StorageBackend(StorageBackend):
         normalized = normalize_storage_key(key)
         return f"{self.prefix}/{normalized}" if self.prefix else normalized
 
+    def _is_gcs(self) -> bool:
+        """Return True if the endpoint targets Google Cloud Storage."""
+        if not self.endpoint_url:
+            return False
+        return "storage.googleapis.com" in self.endpoint_url
+
+    def _boto_config(self):
+        """Build a botocore Config appropriate for the target endpoint."""
+        from botocore.config import Config
+
+        if self._is_gcs():
+            # GCS S3-compatible API requires virtual-hosted-style addressing
+            # and an explicit region of "auto" for V4 signatures to verify.
+            addressing = "virtual"
+            region = "auto"
+        else:
+            addressing = "path"
+            region = self.region or None
+        return Config(
+            max_pool_connections=self.max_pool_connections,
+            proxies={},
+            s3={"addressing_style": addressing},
+            signature_version="s3v4",
+            connect_timeout=5,
+            read_timeout=30,
+            tcp_keepalive=True,
+            region_name=region,
+        )
+
     def _client_or_raise(self):
         if self._client is None:
             try:
                 import boto3
-                from botocore.config import Config
             except ImportError as exc:
                 raise RuntimeError("boto3 is required for S3 storage backend") from exc
             self._client = boto3.client(
                 "s3",
-                region_name=self.region or None,
                 endpoint_url=self.endpoint_url,
                 aws_access_key_id=self.access_key_id,
                 aws_secret_access_key=self.secret_access_key,
-                config=Config(
-                    max_pool_connections=self.max_pool_connections,
-                    proxies={},
-                    s3={"addressing_style": "path"},
-                    signature_version="s3v4",
-                    connect_timeout=5,
-                    read_timeout=30,
-                    tcp_keepalive=True,
-                ),
+                config=self._boto_config(),
             )
         return self._client
 
@@ -79,26 +98,16 @@ class S3StorageBackend(StorageBackend):
         """Shared aioboto3 session with aiohttp connection pool — reuses connections but detects stale ones correctly."""
         try:
             import aioboto3
-            from botocore.config import Config
         except ImportError as exc:
             raise RuntimeError("aioboto3 is required for async S3 writes") from exc
         if self._aioboto3_session is None:
             self._aioboto3_session = aioboto3.Session()
         async with self._aioboto3_session.client(
             "s3",
-            region_name=self.region or None,
             endpoint_url=self.endpoint_url,
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.secret_access_key,
-            config=Config(
-                max_pool_connections=self.max_pool_connections,
-                proxies={},
-                s3={"addressing_style": "path"},
-                signature_version="s3v4",
-                connect_timeout=5,
-                read_timeout=30,
-                tcp_keepalive=True,
-            ),
+            config=self._boto_config(),
         ) as client:
             yield client
 


### PR DESCRIPTION
## Problem

GCS S3-compatible API continues to reject put_object with SignatureDoesNotMatch even after setting ContentType explicitly.

## Root Cause

The boto3/aiobotocore clients were hardcoded to:
- `addressing_style: "path"` — GCS S3 API requires `virtual-hosted-style`
- `region_name`: used raw `S3_REGION` env var (often empty) — GCS requires `"auto"` for V4 signatures

With path-style addressing, GCS computes the signature over a different canonical request than what boto3 signs, causing an unrecoverable mismatch.

## Fix

- Extract shared `_boto_config()` method used by both sync and async clients
- Auto-detect `storage.googleapis.com` in endpoint URL via `_is_gcs()`
- When GCS is detected: set `addressing_style=virtual`, `region_name=auto`
- MinIO and other S3 backends remain unchanged (`path` style, user-specified region)

## Verification

Existing test `test_s3_backend_passes_max_pool_connections` passes. The test creates a mock S3Backend — GCS detection is endpoint-based and only activates when `storage.googleapis.com` appears in the URL.
