### PR TITLE
fix: disable AgentBay SDK logging override to prevent resetting loguru config

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -3,7 +3,6 @@
 import sys
 import logging
 from contextvars import ContextVar
-from typing import Optional
 
 from loguru import logger
 
@@ -36,6 +35,17 @@ def set_trace_id(trace_id: str) -> None:
     trace_id_var.set(trace_id)
 
 
+def _disable_agentbay_logger_override():
+    """Disable AgentBay SDK's logging override to prevent it from resetting loguru."""
+    if "agentbay._common.logger" in sys.modules:
+        try:
+            from agentbay._common.logger import AgentBayLogger
+            AgentBayLogger._initialized = True
+            AgentBayLogger.setup = classmethod(lambda cls, *args, **kwargs: None)
+        except Exception:
+            pass
+
+
 def configure_logging():
     """Configure loguru with custom format including trace ID."""
     # Remove default handler
@@ -51,6 +61,8 @@ def configure_logging():
         diagnose=True,
         filter=lambda record: (record["extra"].setdefault("trace_id", get_trace_id() or str(uuid4())) is not None)
     )
+
+    _disable_agentbay_logger_override()
 
     return logger
 

--- a/backend/app/services/agentbay_client.py
+++ b/backend/app/services/agentbay_client.py
@@ -11,7 +11,11 @@ from datetime import datetime, timedelta
 from typing import Optional
 from loguru import logger
 
-from agentbay import AgentBay, BrowserOption, CreateSessionParams
+from agentbay import AgentBay, CreateSessionParams
+from app.core.logging_config import _disable_agentbay_logger_override, configure_logging
+
+_disable_agentbay_logger_override()
+configure_logging()
 
 
 @dataclass
@@ -72,7 +76,7 @@ class AgentBayClient:
             return
         try:
             await asyncio.to_thread(self._session.delete)
-            logger.info(f"[AgentBay] Closed session")
+            logger.info("[AgentBay] Closed session")
         except Exception as e:
             logger.warning(f"[AgentBay] Failed to close session: {e}")
         finally:


### PR DESCRIPTION
## Problem
The AgentBay SDK logging configuration overrides the global loguru logger setup, resetting it or causing logs to not be formatted/intercepted correctly.

## Solution
1. In `app/core/logging_config.py`, added `_disable_agentbay_logger_override` to mock/disable the `AgentBayLogger.setup` classmethod and set `_initialized` to `True` if `agentbay._common.logger` is loaded.
2. In `app/services/agentbay_client.py`, imported and invoked `_disable_agentbay_logger_override()` and `configure_logging()` immediately after importing `agentbay` client components to make sure loguru is restored/reconfigured.