### PR TITLE
fix(agentbay): use Pydantic RootModel[Any] for browser extract schema

### DIFF
--- a/backend/app/services/agentbay_client.py
+++ b/backend/app/services/agentbay_client.py
@@ -8,8 +8,14 @@ import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Any, Optional
 from loguru import logger
+from pydantic import RootModel
+
+
+class GenericExtractSchema(RootModel[Any]):
+    pass
+
 
 from agentbay import AgentBay, CreateSessionParams
 from app.core.logging_config import _disable_agentbay_logger_override, configure_logging
@@ -268,15 +274,18 @@ class AgentBayClient:
         await asyncio.sleep(3)
 
         from agentbay._common.models.browser_operator import ExtractOptions
-        # Use a generic dict schema since we cannot define a Pydantic model at runtime
+        # Use a generic RootModel schema since we cannot define a custom Pydantic model at runtime
         options = ExtractOptions(
             instruction=instruction,
-            schema=dict,
+            schema=GenericExtractSchema,
             selector=selector or None,
         )
         success, data = await asyncio.to_thread(
             self._session.browser.operator.extract, options
         )
+        if success and data:
+            if hasattr(data, "model_dump"):
+                data = data.model_dump()
         return {"success": success, "data": data}
 
     async def browser_observe(self, instruction: str, selector: str = "") -> dict:


### PR DESCRIPTION
Resolves the error 'type object dict has no attribute model_json_schema' caused by newer agentbay-sdk versions requiring a Pydantic Model for schema validation.