### PR TITLE
fix: soul.md silently truncated to 2000 chars in agent system prompt

### DIFF
--- a/backend/app/services/agent_context.py
+++ b/backend/app/services/agent_context.py
@@ -250,7 +250,13 @@ async def build_agent_context(agent_id: uuid.UUID, agent_name: str, role_descrip
     - Database → relationship network (human + agent)
     """
     # --- Soul ---
-    soul = await _read_file_safe(normalize_storage_key(f"{agent_id}/soul.md"), 2000)
+    # Soul is the agent's full author-curated identity; detailed souls (e.g.
+    # bundle agents) run 4-12k chars. A tight cap silently drops every tail
+    # section — rules, boundaries, facts — and the agent then confidently
+    # denies things its soul plainly states, with no log of the truncation.
+    # Memory and relationships below keep small caps because they grow
+    # unbounded at runtime; the soul does not (only seeded/explicitly edited).
+    soul = await _read_file_safe(normalize_storage_key(f"{agent_id}/soul.md"), 30000)
     # Strip markdown heading if present
     if soul.startswith("# "):
         soul = "\n".join(soul.split("\n")[1:]).strip()


### PR DESCRIPTION
## Problem

`build_agent_context()` — the prompt assembler used by chat, heartbeat, A2A and task execution — reads the agent's soul with a 2000-character cap:

https://github.com/dataelement/Clawith/blob/30e8b774/backend/app/services/agent_context.py#L253

`_read_file_safe` (L15–23) silently truncates anything past `max_chars`, appending `...(truncated)` with **no log**. So for any agent whose `soul.md` exceeds 2000 chars, everything after char 2000 — rules, boundaries, operational facts — never reaches the model, while the file, the DB and the UI all display the full soul. That makes the failure very hard to diagnose: the agent behaves correctly on the head of its soul and confidently denies facts stated in the tail.

## Evidence

On one of our deployments, 68 of 141 agents had souls over the cap (largest 12,089 chars — only the first 17% ever reached the model). The symptom that surfaced it: an agent whose soul explicitly lists a service URL kept answering "there is no URL I can share" — the URL section sat at char ~5550 of a 5,927-char soul, past the cut.

## Fix

Raise the soul read cap to 30000 at the call site, with a comment explaining the asymmetry: soul is author-curated and bounded (only seeded or explicitly edited), unlike `memory`/`relationships` which grow unbounded at runtime and keep their small caps.

One line + comment. Agents with souls ≤2000 chars see a byte-identical prompt — zero behavior change for them.

Verified on a live deployment: after this change, `build_agent_context` static prompts for previously-truncated agents contain their full souls (no `...(truncated)` marker), and the misbehaving agents answer tail-section questions correctly.

## Possible follow-ups (not in this PR)

- Log a warning in `_read_file_safe` when truncation actually fires, so silent prompt loss is visible in logs.
- Validate soul size at seed/edit time instead of truncating at read time.
- Hoist the cap into a named constant (e.g. `SOUL_CONTEXT_MAX_CHARS`) and add a unit test asserting the soul read uses it while memory keeps its small cap.

> Unrelated pre-existing note: `backend/tests/test_agent_context.py` still asserts `## Focus` injection, but that injection is commented out at main ([agent_context.py#L676](https://github.com/dataelement/Clawith/blob/30e8b774/backend/app/services/agent_context.py#L676)) — that test fails on main with or without this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
