### PR TITLE
ci: use faster Alpine mirror for image builds

### DIFF
--- a/.github/drone.yml
+++ b/.github/drone.yml
@@ -81,6 +81,9 @@ steps:
       https_proxy:
         from_secret: PROXY
     commands:
+      # Docker Hub mirror does not cover Alpine packages. Use a fast APK mirror
+      # before installing the Git client required by the image build step.
+      - sed -i 's|https://dl-cdn.alpinelinux.org/alpine|https://mirrors.aliyun.com/alpine|g' /etc/apk/repositories
       - apk add --no-cache git
       - |
         set -eu


### PR DESCRIPTION
Use the Aliyun Alpine mirror before installing Git in the Drone build-images step. This avoids slow access to dl-cdn.alpinelinux.org while retaining --no-cache for ephemeral CI containers.