### PR TITLE
feat(groups): pick members while creating a group

### DIFF
--- a/backend/app/api/groups.py
+++ b/backend/app/api/groups.py
@@ -46,6 +46,7 @@ router = APIRouter(prefix="/api/groups", tags=["groups"])
 class CreateGroupIn(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str | None = None
+    member_participant_ids: list[uuid.UUID] = Field(default_factory=list, max_length=100)
 
 
 class PatchGroupIn(BaseModel):
@@ -494,6 +495,7 @@ async def create_group(
             creator_participant_id=participant.id,
             name=body.name,
             description=body.description,
+            member_participant_ids=body.member_participant_ids,
         )
     except GroupChatServiceError as exc:
         raise _translate_domain_error(exc) from exc
@@ -503,6 +505,11 @@ async def create_group(
         action="group:create",
         tenant_id=tenant_id,
         group_id=group.id,
+        details={
+            "member_participant_ids": [
+                str(participant_id) for participant_id in body.member_participant_ids
+            ]
+        },
     )
     return group
 
@@ -519,6 +526,32 @@ async def list_groups(
         tenant_id=tenant_id,
         participant_id=participant.id,
     )
+
+
+# Registered before "/{group_id}" so the literal path is not parsed as a group id.
+@router.get("/member-candidates", response_model=list[GroupMemberCandidateOut])
+async def list_tenant_member_candidates(
+    participant_type: Annotated[Literal["user", "agent"], Query()],
+    limit: Annotated[int, Query(ge=1, le=100)] = 100,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Candidates for the create-group flow, before any group exists."""
+    tenant_id = _tenant_id(current_user)
+    try:
+        candidates = await group_chat_service.list_tenant_member_candidates(
+            db,
+            tenant_id=tenant_id,
+            actor_user=current_user,
+            participant_type=participant_type,
+            limit=limit,
+        )
+    except GroupChatServiceError as exc:
+        raise _translate_domain_error(exc) from exc
+    return [
+        GroupMemberCandidateOut.model_validate(candidate, from_attributes=True)
+        for candidate in candidates
+    ]
 
 
 @router.get("/{group_id}", response_model=GroupOut)

--- a/backend/app/services/group_chat_service.py
+++ b/backend/app/services/group_chat_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -164,6 +165,64 @@ async def _active_membership(
     return membership
 
 
+async def _human_actor_user(
+    db: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    actor: Participant,
+) -> User:
+    """Resolve the active tenant user behind a validated human participant."""
+    result = await db.execute(
+        select(User).where(
+            User.id == actor.ref_id,
+            User.tenant_id == tenant_id,
+            User.is_active.is_(True),
+        )
+    )
+    actor_user = result.scalar_one_or_none()
+    if actor_user is None:
+        raise GroupChatServiceError(
+            "group_human_member_required",
+            "An active human group member is required",
+        )
+    return actor_user
+
+
+async def _invitable_participant(
+    db: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    actor: Participant,
+    participant_id: uuid.UUID,
+) -> Participant:
+    """Validate an invite target, including Agent visibility for the inviter."""
+    target = await _valid_participant(
+        db,
+        tenant_id=tenant_id,
+        participant_id=participant_id,
+        human_only=False,
+        error_code="group_participant_invalid",
+    )
+    if target.type != "agent":
+        return target
+
+    # Resolved only for Agent targets, where inviter visibility must be checked.
+    actor_user = await _human_actor_user(db, tenant_id=tenant_id, actor=actor)
+    target_agent_result = await db.execute(
+        select(Agent).where(
+            Agent.id == target.ref_id,
+            Agent.tenant_id == tenant_id,
+        )
+    )
+    target_agent = target_agent_result.scalar_one_or_none()
+    if target_agent is None or not await can_use_agent(db, actor_user, target_agent):
+        raise GroupChatServiceError(
+            "group_participant_invalid",
+            "Agent is not visible to the inviting member",
+        )
+    return target
+
+
 async def _human_actor(
     db: AsyncSession,
     *,
@@ -321,6 +380,7 @@ async def create_group(
     creator_participant_id: uuid.UUID,
     name: str,
     description: str | None = None,
+    member_participant_ids: Sequence[uuid.UUID] = (),
 ) -> Group:
     """Create a group and its initial manager without owning the transaction."""
     normalized_name = _required_text(
@@ -329,13 +389,29 @@ async def create_group(
         field="name",
         max_length=200,
     )
-    await _valid_participant(
+    creator = await _valid_participant(
         db,
         tenant_id=tenant_id,
         participant_id=creator_participant_id,
         human_only=True,
         error_code="group_creator_invalid",
     )
+
+    invited_ids: list[uuid.UUID] = []
+    seen_ids = {creator_participant_id}
+    for participant_id in member_participant_ids:
+        if participant_id in seen_ids:
+            continue
+        seen_ids.add(participant_id)
+        invited_ids.append(participant_id)
+
+    for participant_id in invited_ids:
+        await _invitable_participant(
+            db,
+            tenant_id=tenant_id,
+            actor=creator,
+            participant_id=participant_id,
+        )
 
     now = _now()
     group = Group(
@@ -359,6 +435,18 @@ async def create_group(
     )
     db.add(group)
     db.add(creator_membership)
+    for participant_id in invited_ids:
+        db.add(
+            GroupMember(
+                id=uuid.uuid4(),
+                group_id=group.id,
+                participant_id=participant_id,
+                role="member",
+                joined_at=now,
+                removed_at=None,
+                session_read_state={},
+            )
+        )
     await db.flush()
     return group
 
@@ -518,6 +606,57 @@ async def list_group_member_candidates(
     )
     active_ref_ids = set(active_refs_result.scalars().all())
 
+    return await _member_candidates(
+        db,
+        tenant_id=tenant_id,
+        actor_user=actor_user,
+        participant_type=participant_type,
+        limit=limit,
+        excluded_ref_ids=active_ref_ids,
+    )
+
+
+async def list_tenant_member_candidates(
+    db: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    actor_user: User,
+    participant_type: str,
+    limit: int,
+) -> tuple[GroupMemberCandidate, ...]:
+    """List inviteable identities before a group exists, for the create flow."""
+    if participant_type not in {"user", "agent"}:
+        raise GroupChatServiceError(
+            "group_participant_type_invalid",
+            "Participant type must be 'user' or 'agent'",
+        )
+    if actor_user.tenant_id != tenant_id or not actor_user.is_active:
+        raise GroupChatServiceError(
+            "group_human_member_required",
+            "An active human group member is required",
+        )
+
+    # The creator joins as manager on create, so never offer them as a candidate.
+    return await _member_candidates(
+        db,
+        tenant_id=tenant_id,
+        actor_user=actor_user,
+        participant_type=participant_type,
+        limit=limit,
+        excluded_ref_ids={actor_user.id} if participant_type == "user" else set(),
+    )
+
+
+async def _member_candidates(
+    db: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    actor_user: User,
+    participant_type: str,
+    limit: int,
+    excluded_ref_ids: set[uuid.UUID],
+) -> tuple[GroupMemberCandidate, ...]:
+    active_ref_ids = excluded_ref_ids
     candidates: list[GroupMemberCandidate] = []
     if participant_type == "user":
         statement = select(User).where(
@@ -598,38 +737,12 @@ async def invite_group_member(
         participant_id=actor_participant_id,
         manager_only=False,
     )
-    target = await _valid_participant(
+    await _invitable_participant(
         db,
         tenant_id=tenant_id,
+        actor=actor,
         participant_id=participant_id,
-        human_only=False,
-        error_code="group_participant_invalid",
     )
-    if target.type == "agent":
-        actor_user_result = await db.execute(
-            select(User).where(
-                User.id == actor.ref_id,
-                User.tenant_id == tenant_id,
-                User.is_active.is_(True),
-            )
-        )
-        actor_user = actor_user_result.scalar_one_or_none()
-        target_agent_result = await db.execute(
-            select(Agent).where(
-                Agent.id == target.ref_id,
-                Agent.tenant_id == tenant_id,
-            )
-        )
-        target_agent = target_agent_result.scalar_one_or_none()
-        if (
-            actor_user is None
-            or target_agent is None
-            or not await can_use_agent(db, actor_user, target_agent)
-        ):
-            raise GroupChatServiceError(
-                "group_participant_invalid",
-                "Agent is not visible to the inviting member",
-            )
 
     existing_result = await db.execute(
         select(GroupMember)

--- a/backend/tests/test_group_api.py
+++ b/backend/tests/test_group_api.py
@@ -94,6 +94,7 @@ def test_group_router_exposes_management_and_read_state_boundaries() -> None:
     assert ("POST", "/api/groups") in routes
     assert ("GET", "/api/groups/{group_id}/members") in routes
     assert ("GET", "/api/groups/{group_id}/member-candidates") in routes
+    assert ("GET", "/api/groups/member-candidates") in routes
     assert ("POST", "/api/groups/{group_id}/sessions") in routes
     assert ("DELETE", "/api/groups/{group_id}/sessions/{session_id}") in routes
     assert ("POST", "/api/groups/{group_id}/sessions/{session_id}/read") in routes
@@ -113,6 +114,13 @@ def test_group_router_exposes_management_and_read_state_boundaries() -> None:
     assert ("PUT", "/api/groups/{group_id}/workspace/file") in routes
     assert ("DELETE", "/api/groups/{group_id}/workspace/file") in routes
     assert ("PATCH", "/api/groups/{group_id}/members/{member_id}") not in routes
+
+
+def test_tenant_member_candidates_is_matched_before_the_group_id_route() -> None:
+    """A literal path after "/{group_id}" would be parsed as a group id and 422."""
+    paths = [getattr(route, "path", None) for route in groups_api.router.routes]
+
+    assert paths.index("/api/groups/member-candidates") < paths.index("/api/groups/{group_id}")
 
 
 def test_group_invite_write_contract_only_accepts_participant_id() -> None:
@@ -255,6 +263,7 @@ async def test_create_group_stages_domain_change_and_audit_in_one_transaction(mo
             "creator_participant_id": participant.id,
             "name": "Runtime Group",
             "description": None,
+            "member_participant_ids": [],
         }
     ]
     assert len(db.added) == 1
@@ -262,7 +271,43 @@ async def test_create_group_stages_domain_change_and_audit_in_one_transaction(mo
     assert isinstance(audit, AuditLog)
     assert audit.action == "group:create"
     assert audit.user_id == user.id
-    assert audit.details == {"tenant_id": str(tenant_id), "group_id": str(group.id)}
+    assert audit.details == {
+        "tenant_id": str(tenant_id),
+        "group_id": str(group.id),
+        "member_participant_ids": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_group_forwards_initial_members_and_audits_them(monkeypatch) -> None:
+    tenant_id = uuid.uuid4()
+    user = _user(tenant_id)
+    participant = _participant(user)
+    group = _group(tenant_id, participant.id)
+    invited = [uuid.uuid4(), uuid.uuid4()]
+    db = _RecordingDB()
+    calls = []
+
+    async def fake_participant(_db, current_user):
+        return participant
+
+    async def fake_create(_db, **kwargs):
+        calls.append(kwargs)
+        return group
+
+    monkeypatch.setattr(groups_api, "_current_participant", fake_participant)
+    monkeypatch.setattr(groups_api.group_chat_service, "create_group", fake_create)
+
+    result = await groups_api.create_group(
+        groups_api.CreateGroupIn(name="Runtime Group", member_participant_ids=invited),
+        current_user=user,
+        db=db,
+    )
+
+    assert result is group
+    assert calls[0]["member_participant_ids"] == invited
+    audit = db.added[0]
+    assert audit.details["member_participant_ids"] == [str(value) for value in invited]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_group_chat_service.py
+++ b/backend/tests/test_group_chat_service.py
@@ -205,6 +205,95 @@ async def test_create_group_stages_the_human_creator_as_manager() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_group_stages_initial_members_in_the_same_transaction() -> None:
+    tenant_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    creator = _participant("user", user_id)
+    agent_id = uuid.uuid4()
+    invited_agent = _participant("agent", agent_id)
+    target_agent = _agent(tenant_id, agent_id)
+    invited_user_id = uuid.uuid4()
+    invited_user = _participant("user", invited_user_id)
+    creator_user = User(
+        id=user_id,
+        tenant_id=tenant_id,
+        display_name="Group Creator",
+        role="member",
+        is_active=True,
+    )
+    db = _RecordingDB(
+        _Result([creator]),
+        _Result([user_id]),
+        # Agent target: participant, tenant agent, inviter user, visibility agent.
+        _Result([invited_agent]),
+        _Result([target_agent]),
+        _Result([creator_user]),
+        _Result([target_agent]),
+        # User target: participant, then the active tenant user behind it.
+        _Result([invited_user]),
+        _Result([invited_user_id]),
+    )
+
+    group = await group_chat_service.create_group(
+        db,
+        tenant_id=tenant_id,
+        creator_participant_id=creator.id,
+        name="Product launch",
+        member_participant_ids=[invited_agent.id, invited_user.id, creator.id],
+    )
+
+    memberships = [value for value in db.added if isinstance(value, GroupMember)]
+    assert [membership.participant_id for membership in memberships] == [
+        creator.id,
+        invited_agent.id,
+        invited_user.id,
+    ]
+    assert [membership.role for membership in memberships] == ["manager", "member", "member"]
+    assert all(membership.group_id == group.id for membership in memberships)
+    # One flush: the group and every initial member commit or roll back together.
+    assert db.flush_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_group_rejects_an_invisible_agent_before_staging_the_group() -> None:
+    tenant_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    creator = _participant("user", user_id)
+    agent_id = uuid.uuid4()
+    invited_agent = _participant("agent", agent_id)
+    target_agent = _agent(tenant_id, agent_id, access_mode="custom")
+    creator_user = User(
+        id=user_id,
+        tenant_id=tenant_id,
+        display_name="Group Creator",
+        role="member",
+        is_active=True,
+    )
+    db = _RecordingDB(
+        _Result([creator]),
+        _Result([user_id]),
+        _Result([invited_agent]),
+        _Result([target_agent]),
+        _Result([creator_user]),
+        _Result([target_agent]),
+        _Result(),
+    )
+
+    with pytest.raises(group_chat_service.GroupChatServiceError) as excinfo:
+        await group_chat_service.create_group(
+            db,
+            tenant_id=tenant_id,
+            creator_participant_id=creator.id,
+            name="Product launch",
+            member_participant_ids=[invited_agent.id],
+        )
+
+    assert excinfo.value.code == "group_participant_invalid"
+    assert db.added == []
+    assert db.flush_count == 0
+
+
+@pytest.mark.asyncio
 async def test_ordinary_human_member_can_invite_a_company_agent() -> None:
     tenant_id = uuid.uuid4()
     actor_user_id = uuid.uuid4()

--- a/frontend/src/pages/groups/CreateGroupModal.tsx
+++ b/frontend/src/pages/groups/CreateGroupModal.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { IconCheck, IconRobot, IconSearch, IconUser, IconX } from '@tabler/icons-react';
+import { groupApi } from '../../services/groupApi';
+import type { GroupMemberCandidate, ParticipantType } from '../../types/group';
+
+interface CreateGroupModalProps {
+    creating: boolean;
+    onCreate: (name: string, memberParticipantIds: string[]) => void;
+    onCancel: () => void;
+}
+
+export default function CreateGroupModal({ creating, onCreate, onCancel }: CreateGroupModalProps) {
+    const { t } = useTranslation();
+    const [name, setName] = useState('');
+    const [tab, setTab] = useState<ParticipantType>('agent');
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<GroupMemberCandidate[]>([]);
+    const nameRef = useRef<HTMLInputElement>(null);
+
+    const { data: backendCandidates = [], isLoading } = useQuery({
+        queryKey: ['tenant-member-candidates', tab],
+        queryFn: () => groupApi.tenantMemberCandidates(tab),
+    });
+
+    const selectedIds = useMemo(
+        () => new Set(selected.map((candidate) => candidate.participant_id)),
+        [selected],
+    );
+
+    const candidates = useMemo(() => {
+        const needle = search.trim().toLowerCase();
+        if (!needle) return backendCandidates;
+        return backendCandidates.filter((candidate) =>
+            [candidate.display_name, candidate.role_description, candidate.title]
+                .some((value) => value?.toLowerCase().includes(needle)),
+        );
+    }, [backendCandidates, search]);
+
+    const toggle = (candidate: GroupMemberCandidate) => {
+        setSelected((previous) =>
+            previous.some((item) => item.participant_id === candidate.participant_id)
+                ? previous.filter((item) => item.participant_id !== candidate.participant_id)
+                : [...previous, candidate],
+        );
+    };
+
+    const canConfirm = Boolean(name.trim()) && !creating;
+    const confirm = () => {
+        if (!canConfirm) return;
+        onCreate(name.trim(), selected.map((candidate) => candidate.participant_id));
+    };
+
+    return (
+        <div className="group-modal-backdrop" onClick={onCancel}>
+            <div className="group-modal" onClick={(event) => event.stopPropagation()}>
+                <div className="group-modal-header">
+                    <h3>{t('groups.create', '创建群聊')}</h3>
+                    <button type="button" className="group-icon-btn" onClick={onCancel}>
+                        <IconX size={16} stroke={1.7} />
+                    </button>
+                </div>
+
+                <div className="group-create-name">
+                    <input
+                        ref={nameRef}
+                        autoFocus
+                        className="input"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        placeholder={t('groups.namePlaceholder', '群名称')}
+                        onKeyDown={(event) => {
+                            // Enter commits an IME candidate before it should submit the form.
+                            if (event.nativeEvent.isComposing) return;
+                            if (event.key === 'Enter') confirm();
+                        }}
+                    />
+                </div>
+
+                <div className="group-tabs">
+                    <button
+                        type="button"
+                        className={`group-tab ${tab === 'agent' ? 'active' : ''}`}
+                        onClick={() => setTab('agent')}
+                    >
+                        {t('groups.tabAgents', '智能体')}
+                    </button>
+                    <button
+                        type="button"
+                        className={`group-tab ${tab === 'user' ? 'active' : ''}`}
+                        onClick={() => setTab('user')}
+                    >
+                        {t('groups.tabPeople', '成员')}
+                    </button>
+                </div>
+
+                <div className="group-search">
+                    <IconSearch size={14} stroke={1.6} />
+                    <input
+                        className="group-search-input"
+                        value={search}
+                        onChange={(event) => setSearch(event.target.value)}
+                        placeholder={t('groups.searchPlaceholder', '搜索名称')}
+                    />
+                </div>
+
+                <div className="group-candidate-list">
+                    {candidates.length === 0 && (
+                        <div className="group-empty-hint">
+                            {isLoading
+                                ? t('common.loading', '加载中...')
+                                : t('groups.noCandidates', '没有可邀请的对象')}
+                        </div>
+                    )}
+                    {candidates.map((candidate) => {
+                        const picked = selectedIds.has(candidate.participant_id);
+                        return (
+                            <div
+                                key={candidate.participant_id}
+                                className={`group-candidate selectable ${picked ? 'picked' : ''}`}
+                                onClick={() => toggle(candidate)}
+                            >
+                                <span className={`group-avatar sm ${candidate.participant_type === 'agent' ? 'agent' : ''}`}>
+                                    {candidate.participant_type === 'agent'
+                                        ? <IconRobot size={14} stroke={1.6} />
+                                        : <IconUser size={14} stroke={1.6} />}
+                                </span>
+                                <div className="group-candidate-body">
+                                    <div className="group-candidate-name">{candidate.display_name}</div>
+                                    {(candidate.role_description || candidate.title) && (
+                                        <div className="group-candidate-hint">
+                                            {candidate.role_description || candidate.title}
+                                        </div>
+                                    )}
+                                </div>
+                                <span className={`group-check ${picked ? 'on' : ''}`}>
+                                    {picked && <IconCheck size={12} stroke={2.4} />}
+                                </span>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="group-create-footer">
+                    <span className="group-create-count">
+                        {t('groups.selectedCount', '已选 {{count}} 位', { count: selected.length })}
+                    </span>
+                    <div className="group-create-actions">
+                        <button type="button" className="btn btn-sm" onClick={onCancel}>
+                            {t('common.cancel', '取消')}
+                        </button>
+                        <button
+                            type="button"
+                            className="btn btn-sm btn-primary"
+                            disabled={!canConfirm}
+                            onClick={confirm}
+                        >
+                            {creating ? t('common.loading', '加载中...') : t('groups.create', '创建群聊')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/groups/GroupsPage.tsx
+++ b/frontend/src/pages/groups/GroupsPage.tsx
@@ -31,6 +31,7 @@ import MessageComposer from './MessageComposer';
 import GroupSidePanel from './GroupSidePanel';
 import GroupSettingsModal from './GroupSettingsModal';
 import InviteMemberModal from './InviteMemberModal';
+import CreateGroupModal from './CreateGroupModal';
 import InlineEdit from './InlineEdit';
 import type { GroupMessage, GroupSession } from '../../types/group';
 import './groups.css';
@@ -91,6 +92,7 @@ export default function GroupsPage() {
     const [showPanel, setShowPanel] = useState(() => readFlag('groups.showPanel', false));
     const [showInvite, setShowInvite] = useState(false);
     const [creatingGroup, setCreatingGroup] = useState(false);
+    const [creatingGroupPending, setCreatingGroupPending] = useState(false);
     // The group a "new session" prompt targets, or null when closed.
     const [creatingSession, setCreatingSession] = useState<string | null>(null);
     // The session whose title is being renamed inline, or null.
@@ -489,15 +491,21 @@ export default function GroupsPage() {
         }
     };
 
-    const createGroup = async (name: string) => {
-        setCreatingGroup(false);
-        if (!name.trim()) return;
+    const createGroup = async (name: string, memberParticipantIds: string[]) => {
+        if (!name.trim() || creatingGroupPending) return;
+        setCreatingGroupPending(true);
         try {
-            const group = await groupApi.create({ name: name.trim() });
+            const group = await groupApi.create({
+                name: name.trim(),
+                member_participant_ids: memberParticipantIds,
+            });
+            setCreatingGroup(false);
             await refetchGroups();
             navigate(`/groups/${group.id}`);
         } catch (error: any) {
             toast.error(error?.message ?? t('groups.createFailed', '建群失败'));
+        } finally {
+            setCreatingGroupPending(false);
         }
     };
 
@@ -841,13 +849,14 @@ export default function GroupsPage() {
                 />
             )}
 
-            <PromptModal
-                open={creatingGroup}
-                title={t('groups.create', '创建群聊')}
-                placeholder={t('groups.namePlaceholder', '群名称')}
-                onConfirm={(value) => void createGroup(value)}
-                onCancel={() => setCreatingGroup(false)}
-            />
+            {creatingGroup && (
+                <CreateGroupModal
+                    creating={creatingGroupPending}
+                    onCreate={(name, memberParticipantIds) =>
+                        void createGroup(name, memberParticipantIds)}
+                    onCancel={() => setCreatingGroup(false)}
+                />
+            )}
 
             <PromptModal
                 open={Boolean(creatingSession)}

--- a/frontend/src/pages/groups/groups.css
+++ b/frontend/src/pages/groups/groups.css
@@ -973,6 +973,56 @@
     padding: 0 var(--space-4);
 }
 
+/* ─── Create group modal (name + members in one step) ── */
+
+.group-create-name {
+    padding: 0 var(--space-5);
+}
+
+.group-candidate.selectable {
+    cursor: pointer;
+    user-select: none;
+}
+
+.group-candidate.picked {
+    background: var(--bg-hover);
+}
+
+.group-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    color: var(--text-inverse, #fff);
+}
+
+.group-check.on {
+    border-color: var(--accent-primary);
+    background: var(--accent-primary);
+}
+
+.group-create-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    padding: 0 var(--space-5);
+}
+
+.group-create-count {
+    font-size: var(--text-xs);
+    color: var(--text-tertiary);
+}
+
+.group-create-actions {
+    display: flex;
+    gap: var(--space-2);
+}
+
 /* ─── Panel top bar (group-scoped label + gear) ───────── */
 
 .group-panel-topbar {

--- a/frontend/src/services/groupApi.ts
+++ b/frontend/src/services/groupApi.ts
@@ -40,7 +40,7 @@ export const groupApi = {
 
     get: (groupId: string) => fetchJson<Group>(`/groups/${groupId}`),
 
-    create: (data: { name: string; description?: string }) =>
+    create: (data: { name: string; description?: string; member_participant_ids?: string[] }) =>
         fetchJson<Group>('/groups', { method: 'POST', body: JSON.stringify(data) }),
 
     update: (groupId: string, data: { name?: string; description?: string }) =>
@@ -49,6 +49,11 @@ export const groupApi = {
     remove: (groupId: string) => fetchJson<void>(`/groups/${groupId}`, { method: 'DELETE' }),
 
     members: (groupId: string) => fetchJson<GroupMember[]>(`/groups/${groupId}/members`),
+
+    tenantMemberCandidates: (participantType: ParticipantType) =>
+        fetchJson<GroupMemberCandidate[]>(
+            `/groups/member-candidates${qs({ participant_type: participantType })}`,
+        ),
 
     memberCandidates: (groupId: string, participantType: ParticipantType) =>
         fetchJson<GroupMemberCandidate[]>(


### PR DESCRIPTION
## Summary

Creating a group only accepted a name, so members and Agents could only be pulled in after the group already existed. This adds member selection to the create flow itself.

The invite API takes a `participant_id`, and the only endpoint exposing those ids (`GET /{group_id}/member-candidates`) requires an existing group — so the create dialog had no way to resolve them. That is why this touches the backend as well as the UI.

### Backend

- `POST /api/groups` accepts an optional `member_participant_ids`. The group and every initial member are staged in **one transaction**, so an invalid member rolls the whole thing back rather than leaving an empty group behind.
- New `GET /api/groups/member-candidates` — tenant-scoped, for use before a group exists. Registered **before** `/{group_id}` so the literal path is not parsed as a group id. Excludes the creator, who joins as manager on create.
- Invite validation extracted into `_invitable_participant`, shared by the create and invite paths, so Agent visibility for the inviter is enforced identically in both.

Fully backward compatible: omitting `member_participant_ids` reproduces the previous behaviour, and the existing per-group candidates and invite endpoints are unchanged.

### Frontend

- New `CreateGroupModal` replaces the name-only prompt: group name, Agent/member tabs, search, multi-select with a live selection count. Selection survives tab switches; the confirm button is disabled while the request is in flight.
- Styled with the existing group modal tokens; verified in both light and dark themes.

## Testing

- `pytest -k group` — 207 passed, including 4 new cases: create-with-members, rollback on an invalid member, audit details recording the invited ids, and a regression guard that `/member-candidates` stays registered ahead of `/{group_id}`.
- `ruff check` clean on the changed backend files.
- `npm run build` (tsc strict) passes.
- Manual end-to-end on a local v1.11.1 deployment: one POST creates a 3-member group; an invalid `participant_id` returns 400 with no group persisted; the UI flow creates the group and navigates into it with all members present.

## Checklist

- [x] Tested locally
- [x] No unrelated changes included