### PR TITLE
Upgrade release workflow to actions/checkout v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
@@ -467,7 +467,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0


### PR DESCRIPTION
## Summary

- upgrade both release workflow checkout steps from `actions/checkout@v4` to `actions/checkout@v7`
- keep the Clawith project Node.js configuration and release behavior unchanged

## Why

`actions/checkout@v4` targets the deprecated Node.js 20 action runtime, so GitHub-hosted runners emit a warning while forcing it onto Node.js 24. Checkout v7 declares the supported Node.js 24 runtime and is the current stable major recommended by GitHub.

The v7 fork-checkout safeguard applies to `pull_request_target` and `workflow_run`; this workflow uses `workflow_dispatch` and `pull_request: closed`, so its current triggers are unaffected.

## Impact

The release workflow no longer relies on the deprecated Node.js 20 checkout runtime. This does not change the Node.js version used by Clawith itself.

## Validation

- parsed `.github/workflows/release.yml` and asserted both checkout steps use v7
- scanned the repository and confirmed no older `actions/checkout` reference remains
- ran `git diff --check`

The live Release workflow was not triggered because it can create release branches, pull requests, tags, and releases.
