### PR TITLE
Retry truncated write_file calls before failing runs

### DIFF
--- a/backend/app/services/agent_runtime/model_step_service.py
+++ b/backend/app/services/agent_runtime/model_step_service.py
@@ -697,12 +697,14 @@ def _repair(
     instruction: str,
     *,
     repair_code: str | None = None,
+    repair_tool_name: str | None = None,
 ) -> ModelStepResult:
     return ModelStepResult(
         intent="text",
         assistant_message=_assistant_message(state, context, step),
         repair_instruction=instruction,
         repair_code=repair_code,
+        repair_tool_name=repair_tool_name,
     )
 
 
@@ -716,12 +718,14 @@ def _parse_step(
     allow_group_handoff: bool,
 ) -> ModelStepResult:
     if step.retry_instruction:
+        retry_tool_name = step.retry_tool_name
         return _repair(
             state,
             context,
             step,
             step.retry_instruction,
             repair_code="invalid_tool_call",
+            repair_tool_name=retry_tool_name,
         )
     if not step.tool_calls:
         content = (step.content or "").strip()

--- a/backend/app/services/agent_runtime/node_executor.py
+++ b/backend/app/services/agent_runtime/node_executor.py
@@ -21,6 +21,11 @@ from app.services.agent_runtime.state import (
     RuntimeStateUpdate,
     runtime_messages_as_json,
 )
+from app.services.llm.caller import (
+    WRITE_FILE_PROTOCOL_FAILURE_MESSAGE,
+    WRITE_FILE_PROTOCOL_REPAIR_COUNTER_KEY,
+    WRITE_FILE_PROTOCOL_REPAIR_LIMIT,
+)
 from app.services.llm.finish import FINISH_PROTOCOL_REMINDER
 
 
@@ -69,6 +74,7 @@ class ModelStepResult:
     finish_delivery_intent: JsonObject | None = None
     repair_instruction: str | None = None
     repair_code: str | None = None
+    repair_tool_name: str | None = None
     error: JsonObject | None = None
 
 
@@ -650,11 +656,34 @@ class DeterministicRuntimeNodeExecutor:
                         "model repair_code must not be blank",
                     )
                 repairs = _model_protocol_repairs(state["lifecycle"])
-                if repairs.get(repair_code, 0) >= 1:
+                is_write_file_repair = (
+                    repair_code == "invalid_tool_call"
+                    and result.repair_tool_name == "write_file"
+                )
+                repair_limit = (
+                    WRITE_FILE_PROTOCOL_REPAIR_LIMIT
+                    if is_write_file_repair
+                    else 1
+                )
+                repair_counter_key = (
+                    WRITE_FILE_PROTOCOL_REPAIR_COUNTER_KEY
+                    if is_write_file_repair
+                    else repair_code
+                )
+                if repairs.get(repair_counter_key, 0) >= repair_limit:
                     violation_code = (
                         "finish_protocol_violation"
                         if repair_code == "missing_finish"
                         else "model_tool_protocol_violation"
+                    )
+                    error_message = (
+                        WRITE_FILE_PROTOCOL_FAILURE_MESSAGE
+                        if is_write_file_repair
+                        else (
+                            f"The model repeated the {repair_code!r} protocol "
+                            f"error after {repair_limit} bounded repair attempt(s). "
+                            "Native tool calling is not working for this Run."
+                        )
                     )
                     lifecycle.update(
                         {
@@ -664,16 +693,14 @@ class DeterministicRuntimeNodeExecutor:
                             "pending_tool_calls": [],
                             "error": _error(
                                 violation_code,
-                                (
-                                    f"The model repeated the {repair_code!r} protocol "
-                                    "error after one bounded repair. Native tool "
-                                    "calling is not working for this Run."
-                                ),
+                                error_message,
                             ),
                         }
                     )
                 else:
-                    repairs[repair_code] = repairs.get(repair_code, 0) + 1
+                    repairs[repair_counter_key] = (
+                        repairs.get(repair_counter_key, 0) + 1
+                    )
                     new_messages.append(
                         {
                             "id": _runtime_message_id(

--- a/backend/app/services/llm/caller.py
+++ b/backend/app/services/llm/caller.py
@@ -59,13 +59,34 @@ TOOLS_REQUIRING_ARGS = frozenset({
     "send_message_to_agent", "send_feishu_message", "send_email"
 })
 
+WRITE_FILE_PROTOCOL_REPAIR_LIMIT = 3
+WRITE_FILE_PROTOCOL_REPAIR_COUNTER_KEY = "invalid_tool_call:write_file"
+WRITE_FILE_PROTOCOL_REPAIR_INSTRUCTION = (
+    "Your previous `write_file` call was not executed because `function.arguments` "
+    "was invalid JSON or was truncated. Retry `write_file` with "
+    "`function.arguments` as one valid JSON object string. Do not repeat the same "
+    "oversized whole-file content; reduce the content in this call and continue with "
+    "later normal tool calls if needed. Do not explain; only retry with a valid tool call."
+)
+WRITE_FILE_PROTOCOL_FAILURE_MESSAGE = (
+    "本次文件生成未完成：write_file 工具参数无效或被截断，连续重试后仍无法执行。"
+    "请回复「重新生成」，我会基于当前对话重新尝试。"
+)
 
-def _sanitize_tool_calls_for_context(tool_calls: list[dict]) -> tuple[list[dict] | None, str | None]:
-    """Return OpenAI-compatible tool calls, or a retry instruction if args are invalid."""
+
+def _sanitize_tool_calls_for_context(
+    tool_calls: list[dict],
+) -> tuple[list[dict] | None, str | None, str | None]:
+    """Return normalized calls plus bounded-repair details for invalid arguments."""
     sanitized: list[dict] = []
     for tc in tool_calls:
         fn = tc.get("function") or {}
-        tool_name = fn.get("name") or ""
+        raw_tool_name = fn.get("name")
+        tool_name = (
+            raw_tool_name.strip()
+            if isinstance(raw_tool_name, str) and raw_tool_name.strip()
+            else ""
+        )
         raw_args = fn.get("arguments", "{}")
 
         if raw_args is None or raw_args == "":
@@ -80,22 +101,26 @@ def _sanitize_tool_calls_for_context(tool_calls: list[dict]) -> tuple[list[dict]
                     exc.msg,
                     exc.pos,
                 )
+                if tool_name == "write_file":
+                    return None, WRITE_FILE_PROTOCOL_REPAIR_INSTRUCTION, tool_name
                 return None, (
                     "Your previous tool call arguments were not valid JSON. "
                     f"The affected tool was `{tool_name or 'unknown'}`. "
                     "Retry the tool call now with `function.arguments` as one valid JSON object string. "
                     "Escape all quotes and newlines inside long HTML, CSS, JavaScript, or markdown content. "
                     "Do not explain; only retry with a valid tool call."
-                )
+                ), tool_name or None
             args_str = raw_args
         elif isinstance(raw_args, (dict, list)):
             args_str = json.dumps(raw_args, ensure_ascii=False)
         else:
+            if tool_name == "write_file":
+                return None, WRITE_FILE_PROTOCOL_REPAIR_INSTRUCTION, tool_name
             return None, (
                 "Your previous tool call arguments had an unsupported type. "
                 f"The affected tool was `{tool_name or 'unknown'}`. "
                 "Retry the tool call with `function.arguments` as one valid JSON object string."
-            )
+            ), tool_name or None
 
         new_tc = {
             "id": tc.get("id", ""),
@@ -109,7 +134,7 @@ def _sanitize_tool_calls_for_context(tool_calls: list[dict]) -> tuple[list[dict]
             new_tc["_gemini_extra"] = tc["_gemini_extra"]
         sanitized.append(new_tc)
 
-    return sanitized, None
+    return sanitized, None, None
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -563,9 +588,14 @@ async def call_llm(
     max_tokens = get_max_tokens(model.provider, model.model, getattr(model, 'max_output_tokens', None))
     _accumulated_usage = TokenUsage()
     _unsaved_usage = TokenUsage()
-    _protocol_repairs: set[str] = set()
+    _protocol_repairs: dict[str, int] = {}
 
-    async def _protocol_violation(repair_code: str) -> str:
+    async def _protocol_violation(
+        repair_code: str,
+        *,
+        repair_tool_name: str | None = None,
+        repair_limit: int = 1,
+    ) -> str:
         if agent_id and _unsaved_usage.total_tokens > 0:
             await record_token_usage(agent_id, _unsaved_usage)
         await client.close()
@@ -574,10 +604,13 @@ async def call_llm(
             if repair_code == "missing_finish"
             else f"{repair_code}_protocol_violation"
         )
+        if repair_tool_name == "write_file":
+            return f"[Error] {error_code}: {WRITE_FILE_PROTOCOL_FAILURE_MESSAGE}"
+        repair_label = "repair" if repair_limit == 1 else "repairs"
         return (
             f"[Error] {error_code}: The model repeated the {repair_code!r} "
-            "tool protocol error after one bounded repair. Native tool calling "
-            "is not working for this request."
+            f"tool protocol error after {repair_limit} bounded {repair_label}. "
+            "Native tool calling is not working for this request."
         )
 
     # Tool-calling loop
@@ -659,19 +692,36 @@ async def call_llm(
         if not response.tool_calls:
             if response.content:
                 api_messages.append(LLMMessage(role="assistant", content=response.content))
-            if "missing_finish" in _protocol_repairs:
+            if _protocol_repairs.get("missing_finish", 0) >= 1:
                 return await _protocol_violation("missing_finish")
             api_messages.append(LLMMessage(role="user", content=FINISH_PROTOCOL_REMINDER))
-            _protocol_repairs.add("missing_finish")
+            _protocol_repairs["missing_finish"] = 1
             continue
 
         # Execute tool calls
         logger.info(f"[LLM] Round {round_i+1}: {len(response.tool_calls)} tool call(s)")
-        sanitized_tool_calls, retry_instruction = _sanitize_tool_calls_for_context(response.tool_calls)
+        sanitized_tool_calls, retry_instruction, retry_tool_name = (
+            _sanitize_tool_calls_for_context(response.tool_calls)
+        )
         if retry_instruction:
-            if "invalid_tool_call" in _protocol_repairs:
-                return await _protocol_violation("invalid_tool_call")
-            _protocol_repairs.add("invalid_tool_call")
+            repair_limit = (
+                WRITE_FILE_PROTOCOL_REPAIR_LIMIT
+                if retry_tool_name == "write_file"
+                else 1
+            )
+            repair_counter_key = (
+                WRITE_FILE_PROTOCOL_REPAIR_COUNTER_KEY
+                if retry_tool_name == "write_file"
+                else "invalid_tool_call"
+            )
+            repair_count = _protocol_repairs.get(repair_counter_key, 0)
+            if repair_count >= repair_limit:
+                return await _protocol_violation(
+                    "invalid_tool_call",
+                    repair_tool_name=retry_tool_name,
+                    repair_limit=repair_limit,
+                )
+            _protocol_repairs[repair_counter_key] = repair_count + 1
             api_messages.append(LLMMessage(role="user", content=retry_instruction))
             continue
 
@@ -683,9 +733,9 @@ async def call_llm(
                 await client.close()
                 return finish_call.content
 
-            if "invalid_finish" in _protocol_repairs:
+            if _protocol_repairs.get("invalid_finish", 0) >= 1:
                 return await _protocol_violation("invalid_finish")
-            _protocol_repairs.add("invalid_finish")
+            _protocol_repairs["invalid_finish"] = 1
 
             api_messages.append(LLMMessage(
                 role="assistant",

--- a/backend/app/services/llm/single_step.py
+++ b/backend/app/services/llm/single_step.py
@@ -30,6 +30,7 @@ class LLMCompletionStep:
     reasoning_content: str | None
     retry_instruction: str | None
     usage: TokenUsage
+    retry_tool_name: str | None = None
 
 
 async def complete_llm_once(
@@ -73,14 +74,18 @@ async def complete_llm_once(
 
     sanitized_tool_calls: list[dict] | None = []
     retry_instruction = None
+    retry_tool_name = None
     if response.tool_calls:
-        sanitized_tool_calls, retry_instruction = _sanitize_tool_calls_for_context(response.tool_calls)
+        sanitized_tool_calls, retry_instruction, retry_tool_name = (
+            _sanitize_tool_calls_for_context(response.tool_calls)
+        )
     return LLMCompletionStep(
         content=response.content,
         tool_calls=tuple(sanitized_tool_calls or ()),
         reasoning_content=response.reasoning_content,
         retry_instruction=retry_instruction,
         usage=usage,
+        retry_tool_name=retry_tool_name,
     )
 
 

--- a/backend/tests/test_agent_runtime_delivery.py
+++ b/backend/tests/test_agent_runtime_delivery.py
@@ -992,6 +992,54 @@ async def test_runtime_failure_delivers_backend_error_code_and_run_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_write_file_protocol_failure_guides_user_to_regenerate() -> None:
+    tenant_id = uuid.uuid4()
+    group_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    session = _session(tenant_id=tenant_id, agent_id=None, group_id=group_id)
+    run = _run(tenant_id=tenant_id, session=session, agent_id=agent_id)
+    participant = _participant(agent_id)
+    membership = GroupMember(
+        group_id=group_id,
+        participant_id=participant.id,
+        role="member",
+        removed_at=None,
+    )
+    db = _RecordingDB(
+        run,
+        None,
+        session,
+        _agent(tenant_id, agent_id),
+        participant,
+        _group(tenant_id, group_id),
+        membership,
+    )
+
+    receipt = await deliver_runtime_message(
+        db,
+        _terminal_request(
+            run,
+            status="failed",
+            failure_code="model_tool_protocol_violation",
+            failure_message=(
+                "本次文件生成未完成：write_file 工具参数无效或被截断，连续重试后仍无法执行。"
+                "请回复「重新生成」，我会基于当前对话重新尝试。"
+            ),
+        ),
+        clock=lambda: NOW,
+    )
+
+    assert receipt.status == "delivered"
+    assert _added(db, ChatMessage)[0].content == (
+        "任务执行未完成。\n"
+        "错误：本次文件生成未完成：write_file 工具参数无效或被截断，连续重试后仍无法执行。"
+        "请回复「重新生成」，我会基于当前对话重新尝试。\n"
+        "错误码：model_tool_protocol_violation\n"
+        f"Run ID：{run.id}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_removed_group_agent_fails_without_writing_a_message() -> None:
     tenant_id = uuid.uuid4()
     agent_id = uuid.uuid4()

--- a/backend/tests/test_agent_runtime_model_step_service.py
+++ b/backend/tests/test_agent_runtime_model_step_service.py
@@ -369,6 +369,36 @@ async def test_normal_tool_proposal_is_stable_and_does_not_execute_in_model_step
 
 
 @pytest.mark.asyncio
+async def test_invalid_write_file_arguments_request_three_protocol_repairs() -> None:
+    tenant_id = uuid.uuid4()
+    model = _model(tenant_id)
+    agent = _agent(tenant_id)
+    state = _state(tenant_id, model, agent)
+
+    async def complete(*args, **kwargs):
+        del args, kwargs
+        return LLMCompletionStep(
+            content="",
+            tool_calls=(),
+            reasoning_content=None,
+            retry_instruction="Retry write_file with valid JSON.",
+            usage=TokenUsage(total_tokens=10),
+            retry_tool_name="write_file",
+        )
+
+    result = await _service(
+        model,
+        agent,
+        _ContextBuilder(_build()),
+        complete,
+    ).complete_once(state, _context(state))
+
+    assert result.intent == "text"
+    assert result.repair_code == "invalid_tool_call"
+    assert result.repair_tool_name == "write_file"
+
+
+@pytest.mark.asyncio
 async def test_new_run_treats_unreceived_calls_from_cancelled_prior_run_as_not_started() -> None:
     tenant_id = uuid.uuid4()
     model = _model(tenant_id)

--- a/backend/tests/test_agent_runtime_node_executor.py
+++ b/backend/tests/test_agent_runtime_node_executor.py
@@ -1057,6 +1057,64 @@ async def test_repeated_model_tool_protocol_repair_code_fails_explicitly(
 
 
 @pytest.mark.asyncio
+async def test_write_file_protocol_repair_uses_three_attempts_then_guides_user() -> None:
+    run_id = uuid.uuid4()
+    repair = ModelStepResult(
+        intent="text",
+        assistant_message={"role": "assistant", "content": "bad write_file call"},
+        repair_instruction="Retry write_file with valid JSON.",
+        repair_code="invalid_tool_call",
+        repair_tool_name="write_file",
+    )
+    model = ModelService(repair, repair, repair, repair)
+    executor = _executor(model)
+
+    result = await _invoke(run_id, executor, model_turn_limit=50)
+
+    lifecycle = result["lifecycle"]
+    assert lifecycle["status"] == "failed"
+    assert lifecycle["reason"] == "model_tool_protocol_violation"
+    assert lifecycle["error"] == {
+        "code": "model_tool_protocol_violation",
+        "message": (
+            "本次文件生成未完成：write_file 工具参数无效或被截断，连续重试后仍无法执行。"
+            "请回复「重新生成」，我会基于当前对话重新尝试。"
+        ),
+    }
+    assert lifecycle["model_protocol_repairs"] == {
+        "invalid_tool_call:write_file": 3,
+    }
+    assert lifecycle["model_step_count"] == 4
+    assert model.calls == 4
+
+
+@pytest.mark.asyncio
+async def test_write_file_protocol_can_recover_on_the_third_repair() -> None:
+    run_id = uuid.uuid4()
+    repair = ModelStepResult(
+        intent="text",
+        repair_instruction="Retry write_file with valid JSON.",
+        repair_code="invalid_tool_call",
+        repair_tool_name="write_file",
+    )
+    model = ModelService(
+        repair,
+        repair,
+        repair,
+        ModelStepResult(intent="finish", finish_content="Recovered"),
+    )
+    executor = _executor(model)
+
+    result = await _invoke(run_id, executor, model_turn_limit=50)
+
+    assert result["lifecycle"]["status"] == "completed"
+    assert result["lifecycle"]["model_protocol_repairs"] == {
+        "invalid_tool_call:write_file": 3,
+    }
+    assert model.calls == 4
+
+
+@pytest.mark.asyncio
 async def test_business_repairs_are_not_counted_as_model_tool_protocol_failures() -> None:
     run_id = uuid.uuid4()
     model = ModelService(

--- a/backend/tests/test_finish_protocol.py
+++ b/backend/tests/test_finish_protocol.py
@@ -588,6 +588,62 @@ async def test_repeated_invalid_tool_json_is_bounded_by_protocol_code(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_invalid_write_file_json_gets_three_bounded_repairs(monkeypatch):
+    from app.services.llm import caller
+    from app.services.llm.client import LLMResponse
+
+    invalid = LLMResponse(
+        content="",
+        tool_calls=[
+            {
+                "id": "call-bad-write-json",
+                "type": "function",
+                "function": {
+                    "name": "write_file",
+                    "arguments": '{"path":"page.html","content":"<html>',
+                },
+            }
+        ],
+    )
+    fake_client = FakeStreamClient([invalid, invalid, invalid, invalid])
+    monkeypatch.setattr(caller, "_get_agent_config", lambda _agent_id: _async_return((50, None)))
+    monkeypatch.setattr(caller, "_get_user_name", lambda _user_id: _async_return("Ray"))
+    monkeypatch.setattr(
+        "app.services.agent_context.build_agent_context",
+        lambda *_args, **_kwargs: _async_return(("static", "dynamic")),
+    )
+    monkeypatch.setattr(caller, "get_agent_tools_for_llm", lambda _agent_id: _async_return([
+        {
+            "type": "function",
+            "function": {
+                "name": "write_file",
+                "description": "Write a file",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]))
+    monkeypatch.setattr(caller, "create_llm_client", lambda **_kwargs: fake_client)
+    monkeypatch.setattr(caller, "record_token_usage", lambda *_args, **_kwargs: _async_return(None))
+
+    result = await caller.call_llm(
+        _model(),
+        [{"role": "user", "content": "create a long page"}],
+        "Agent",
+        "",
+        agent_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+    )
+
+    assert result == (
+        "[Error] invalid_tool_call_protocol_violation: "
+        "本次文件生成未完成：write_file 工具参数无效或被截断，连续重试后仍无法执行。"
+        "请回复「重新生成」，我会基于当前对话重新尝试。"
+    )
+    assert len(fake_client.messages_seen) == 4
+    assert fake_client.closed is True
+
+
+@pytest.mark.asyncio
 async def test_skip_tools_still_exposes_finish(monkeypatch):
     from app.services.llm import caller
 

--- a/backend/tests/test_llm_single_step.py
+++ b/backend/tests/test_llm_single_step.py
@@ -204,6 +204,9 @@ async def test_complete_once_returns_a_bounded_repair_instruction_for_invalid_ar
     assert result.tool_calls == ()
     assert result.retry_instruction is not None
     assert "valid JSON" in result.retry_instruction
+    assert "not executed" in result.retry_instruction
+    assert "same oversized whole-file content" in result.retry_instruction
+    assert result.retry_tool_name == "write_file"
     assert client.closed is True
 
 


### PR DESCRIPTION
## Summary

- detect invalid or truncated `write_file` arguments and return a dedicated repair instruction
- allow up to three repair attempts scoped only to `write_file`, while keeping the existing one-attempt limit for other tool protocol errors
- deliver a concrete terminal message that asks the user to reply `重新生成` and retry from the current conversation

## Root cause

Large HTML and other oversized `write_file` payloads can be truncated while the model is streaming `function.arguments`. The resulting malformed JSON is rejected before the tool executes. The previous generic single repair could cause the model to resend the same oversized payload and then fail the Run.

## Behavior and boundaries

- invalid arguments never execute the write
- retries are fixed and bounded at three
- no automatic chunking, file skeletons, `edit_file` orchestration, waiting state, or resume protocol is added
- exhausted retries terminate with `model_tool_protocol_violation` and a user-visible regeneration prompt

## Validation

- `115 passed` across the focused LLM, protocol, Runtime, and delivery test files
- Ruff checks passed for all changed Python files
- `git diff --check` passed

## Not tested

- live Qwen 3.6 Plus truncation against a provider endpoint
