### PR TITLE
fix(chat): page agent history by compound cursor, not bare timestamp

### DIFF
--- a/frontend/src/pages/agent-detail/AgentDetailPage.tsx
+++ b/frontend/src/pages/agent-detail/AgentDetailPage.tsx
@@ -2428,8 +2428,11 @@ export default function AgentDetailPage() {
                 }),
             }));
             setChatMessages(parsed);
+            // Round-trip the backend's compound `<created_at>|<id>` cursor. A bare
+            // created_at cannot page past a batch of messages that share one timestamp
+            // (e.g. a burst of tool_call rows), so older messages would never load.
             setChatOldestTimestamp(
-                messages.length > 0 ? messages[0].created_at : null,
+                messages.length > 0 ? (messages[0].cursor ?? messages[0].created_at) : null,
             );
             setChatHistoryHasMore(messages.length >= HISTORY_PAGE_SIZE);
             setMessagesLoadedRuntimeKey(buildSessionRuntimeKey(agentId, sessionId));
@@ -2753,8 +2756,9 @@ export default function AgentDetailPage() {
                 }),
             }));
 
-            // Set the oldest message timestamp for cursor-based pagination
-            const oldestTimestamp = msgs.length > 0 ? msgs[0].created_at : null;
+            // Set the oldest message cursor for pagination. Use the backend's compound
+            // `<created_at>|<id>` cursor so a batch of equal-timestamp messages can be paged past.
+            const oldestTimestamp = msgs.length > 0 ? (msgs[0].cursor ?? msgs[0].created_at) : null;
 
             if (writable) {
                 setChatMessages(preParsed);
@@ -3991,8 +3995,9 @@ export default function AgentDetailPage() {
             const el = historyContainerRef.current;
             const oldScrollHeight = el?.scrollHeight ?? 0;
             setHistoryMsgs(prev => [...preParsed, ...prev]);
-            // Update the oldest timestamp (first message in the new batch, since messages are in chronological order)
-            setHistoryOldestTimestamp(msgs[0].created_at);
+            // Update the oldest cursor (first message in the new batch, since messages are in chronological order).
+            // Round-trip the compound `<created_at>|<id>` cursor so equal-timestamp batches don't stall pagination.
+            setHistoryOldestTimestamp(msgs[0].cursor ?? msgs[0].created_at);
             setHistoryHasMore(msgs.length >= HISTORY_PAGE_SIZE);
             // Restore scroll position after new messages are prepended
             requestAnimationFrame(() => {
@@ -4040,8 +4045,9 @@ export default function AgentDetailPage() {
             const el = chatContainerRef.current;
             const oldScrollHeight = el?.scrollHeight ?? 0;
             setChatMessages(prev => [...preParsed, ...prev]);
-            // Update the oldest timestamp (first message in the new batch, since messages are in chronological order)
-            setChatOldestTimestamp(msgs[0].created_at);
+            // Update the oldest cursor (first message in the new batch, since messages are in chronological order).
+            // Round-trip the compound `<created_at>|<id>` cursor so equal-timestamp batches don't stall pagination.
+            setChatOldestTimestamp(msgs[0].cursor ?? msgs[0].created_at);
             setChatHistoryHasMore(msgs.length >= HISTORY_PAGE_SIZE);
             // Restore scroll position after new messages are prepended
             requestAnimationFrame(() => {


### PR DESCRIPTION
## Problem

In the agent 1:1 chat view, when a conversation contains a burst of messages that were persisted with an **identical `created_at`** (typically a batch of `tool_call` rows written in one turn) and that batch is larger than `HISTORY_PAGE_SIZE` (20), **scrolling up never loads older messages**. The tool count keeps inflating on every scroll (e.g. 23 → 35 → 155 …) and any message older than the batch — including the user's own first message — becomes unreachable. The data is intact; it just can never be paged to.

## Root cause

The frontend derived its `before` pagination cursor from `messages[0].created_at` alone, dropping the `|id` component. The backend's `before` contract is `<created_at>|<id>` and it already emits a ready-to-use `cursor` field on every message (`_base_message_entry`).

For a timestamp-only cursor, `_parse_message_cursor` falls back to `uuid.UUID(int=(1 << 128) - 1)` (max UUID). The filter `tuple_(created_at, id) < (before_created_at, MAX_UUID)` is then **true for every row sharing that timestamp**, so each page re-returns the same equal-timestamp batch. `messages[0].created_at` of the next page is the same timestamp again → the cursor never advances below it. The backend comment already notes: *"Legacy timestamp-only cursors may duplicate equal-timestamp messages … New clients should round-trip the emitted cursor."*

## Fix

Round-trip the backend `cursor` field at all four cursor-set sites in `AgentDetailPage.tsx` (`refreshSessionMessages`, session load, `loadMoreHistoryMessages`, `loadMoreChatHistoryMessages`), falling back to `created_at` only when `cursor` is absent. No backend change.

## Verification

Reproduced on a real conversation with 23 same-timestamp `tool_call` rows:
- **Before**: scroll-up loops, tool count balloons to 155+, first user message never appears.
- **After**: scroll-up terminates with "已加载全部历史消息", tool count is the correct 23, and the first user message + agent greeting load correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)