### PR TITLE
Hide internal system tools from company settings

### DIFF
--- a/frontend/src/pages/EnterpriseSettings.tsx
+++ b/frontend/src/pages/EnterpriseSettings.tsx
@@ -1257,6 +1257,8 @@ export default function EnterpriseSettings() {
                                                 return aMeta.label.localeCompare(bMeta.label);
                                             })
                                             .map(([category, catTools]) => {
+                                            // System tools are Runtime protocol details, not company-managed capabilities.
+                                            if (category === 'system') return null;
                                             const allCatTools = allGrouped[category] || catTools;
                                             const meta = getToolGroupMeta(category, allCatTools);
                                             const hasCategoryConfig = !!GLOBAL_CATEGORY_CONFIG_SCHEMAS[meta.configCategory];

--- a/frontend/tests/enterpriseToolVisibility.test.mjs
+++ b/frontend/tests/enterpriseToolVisibility.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(
+  new URL('../src/pages/EnterpriseSettings.tsx', import.meta.url),
+  'utf8',
+);
+
+test('company settings do not render the protocol-level system tools group', () => {
+  assert.match(source, /if \(category === 'system'\) return null/);
+  assert.doesNotMatch(source, /visibleGlobalTools/);
+});


### PR DESCRIPTION
## What changed

- Stop rendering the `system` tool category in Company Settings.
- Add a frontend contract test covering the render guard.

## Why

`Finish` and other system-category entries are Runtime protocol details, not company-managed capabilities. The legacy database row can still appear in the tools response, which caused Company Settings to expose a misleading category and toggle.

## Impact

Company administrators no longer see the `System` tools group. The underlying tools collection, displayed global count, search behavior, backend records, and Runtime behavior remain unchanged.

## Validation

- `npm test` — 86 passed
- `npm run build` — passed

## Not tested

- Browser E2E against a deployed tenant
