### PR TITLE
Notify Feishu after Drone release results

### DIFF
--- a/.github/drone.yml
+++ b/.github/drone.yml
@@ -306,6 +306,33 @@ steps:
       event:
         - tag
 
+  - name: notify-deployment-success
+    image: curlimages/curl:8.10.1
+    pull: if-not-exists
+    environment:
+      FEISHU_DEPLOY_WEBHOOK:
+        from_secret: FEISHU_DEPLOY_WEBHOOK
+    commands:
+      - |
+        set -eu
+        PAYLOAD="$(
+          printf \
+            '{"msg_type":"text","content":{"text":"✅ Clawith 部署成功\\n版本：%s\\n构建：%s\\n提交：%.8s"}}' \
+            "$DRONE_TAG" "$DRONE_BUILD_LINK" "$DRONE_COMMIT"
+        )"
+        RESPONSE="$(
+          curl --fail-with-body --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            "$FEISHU_DEPLOY_WEBHOOK"
+        )"
+        echo "飞书通知响应: $RESPONSE"
+        printf '%s' "$RESPONSE" |
+          grep -Eq '"code"[[:space:]]*:[[:space:]]*0([,}])'
+    when:
+      event:
+        - tag
+
   - name: cleanup-ci-images
     image: docker:24.0.6
     privileged: true

--- a/.github/drone.yml
+++ b/.github/drone.yml
@@ -306,6 +306,35 @@ steps:
       event:
         - tag
 
+  - name: notify-release-failure
+    image: curlimages/curl:8.10.1
+    pull: if-not-exists
+    environment:
+      FEISHU_DEPLOY_WEBHOOK:
+        from_secret: FEISHU_DEPLOY_WEBHOOK
+    commands:
+      - |
+        set -eu
+        PAYLOAD="$(
+          printf \
+            '{"msg_type":"text","content":{"text":"❌ Clawith 发布失败\\n版本：%s\\n构建：%s\\n提交：%.8s"}}' \
+            "$DRONE_TAG" "$DRONE_BUILD_LINK" "$DRONE_COMMIT"
+        )"
+        RESPONSE="$(
+          curl --fail-with-body --silent --show-error \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            "$FEISHU_DEPLOY_WEBHOOK"
+        )"
+        echo "飞书通知响应: $RESPONSE"
+        printf '%s' "$RESPONSE" |
+          grep -Eq '"code"[[:space:]]*:[[:space:]]*0([,}])'
+    when:
+      event:
+        - tag
+      status:
+        - failure
+
   - name: notify-deployment-success
     image: curlimages/curl:8.10.1
     pull: if-not-exists
@@ -332,6 +361,8 @@ steps:
     when:
       event:
         - tag
+      status:
+        - success
 
   - name: cleanup-ci-images
     image: docker:24.0.6

--- a/deploy/RELEASE_DEPLOYMENT.md
+++ b/deploy/RELEASE_DEPLOYMENT.md
@@ -17,7 +17,7 @@ owns CI validation, artifact transfer, and production deployment.
    - export and transfer the target images;
    - load the images and recreate the production application services;
    - verify the proxied API health endpoint;
-   - send a Feishu notification after deployment succeeds.
+   - send a Feishu notification when the release succeeds or fails.
 5. GitHub Actions publishes the GitHub Release and finishes without waiting for
    Drone. Drone continues the deployment asynchronously and reports its status
    on the tagged commit.
@@ -77,9 +77,12 @@ The remote deployment loads the transferred images and force-recreates only
 are not recreated. Deployment succeeds only after the frontend proxy returns an
 API health response whose status is `ok`.
 
-After the health check succeeds, Drone sends the deployed tag, build link, and
-short commit SHA to the configured Feishu custom bot. A notification API error
-fails the Drone step so the missing notification is visible.
+Drone sends the release result, tag, build link, and short commit SHA to the
+configured Feishu custom bot. The success message is sent only after the health
+check passes. Any failure during a tag pipeline, including build, test,
+transfer, restart, or health-check failures, sends a failure message. A
+notification API error fails the Drone step so the missing notification is
+visible.
 
 If Drone fails, the GitHub tag and Release remain published for investigation.
 Fix or rerun the Drone build for that tag; do not move or reuse a published

--- a/deploy/RELEASE_DEPLOYMENT.md
+++ b/deploy/RELEASE_DEPLOYMENT.md
@@ -16,7 +16,8 @@ owns CI validation, artifact transfer, and production deployment.
    - validate upgrading from the previous stable release;
    - export and transfer the target images;
    - load the images and recreate the production application services;
-   - verify the proxied API health endpoint.
+   - verify the proxied API health endpoint;
+   - send a Feishu notification after deployment succeeds.
 5. GitHub Actions publishes the GitHub Release and finishes without waiting for
    Drone. Drone continues the deployment asynchronously and reports its status
    on the tagged commit.
@@ -36,6 +37,7 @@ Configure these Drone repository secrets:
 | `PROXY` | Optional HTTP/HTTPS proxy used during clone and image builds |
 | `PRIVATE_SERVER_IP` | Production server hostname or IP address |
 | `sshpwd` | Password for the production deployment user |
+| `FEISHU_DEPLOY_WEBHOOK` | Feishu custom bot webhook for successful deployment notifications |
 
 The deployment currently connects as `qinrui` on port `10022` and writes
 release artifacts to `/home/qinrui/clawith_new`.
@@ -74,6 +76,10 @@ The remote deployment loads the transferred images and force-recreates only
 `backend-api`, `backend-worker`, and `frontend`. PostgreSQL, Redis, and MinIO
 are not recreated. Deployment succeeds only after the frontend proxy returns an
 API health response whose status is `ok`.
+
+After the health check succeeds, Drone sends the deployed tag, build link, and
+short commit SHA to the configured Feishu custom bot. A notification API error
+fails the Drone step so the missing notification is visible.
 
 If Drone fails, the GitHub tag and Release remain published for investigation.
 Fix or rerun the Drone build for that tag; do not move or reuse a published


### PR DESCRIPTION
## What changed

- Send a Feishu custom-bot notification for both successful and failed tag release pipelines.
- Send the success message only after the production restart and health check succeed.
- Send the failure message when image build, CI validation, transfer, restart, or health checks fail.
- Include the release tag, Drone build link, and short commit SHA in the notification.
- Validate both the HTTP response and Feishu's JSON `code: 0` result.
- Read the webhook from the `FEISHU_DEPLOY_WEBHOOK` Drone repository secret instead of committing the credential.
- Document the new deployment behavior and required secret.

## Why

Production deployments currently finish without proactively notifying the team. This reports both verified success and failures from any stage of the tag release pipeline.

## Validation

- `drone lint --trusted .github/drone.yml`
- Local shell test for notification payload formatting
- Local shell tests for success and failure message formatting
- Local shell test for Feishu success-response matching
- Confirmed the supplied webhook token is absent from the repository diff
- `git diff --check`

## Required Drone configuration

Add the supplied webhook URL as the `FEISHU_DEPLOY_WEBHOOK` repository secret before the next release tag. The Drone web session available during implementation was not authenticated, so the secret was intentionally not written through the UI or committed to Git.
