### PR TITLE
feat(llm): support Claude Relay Service

### DIFF
--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -2306,6 +2306,8 @@ class ProviderSpec:
 
 # Provider aliases accepted for compatibility
 PROVIDER_ALIASES: dict[str, str] = {
+    "claude-relay": "claude-relay-service",
+    "crs": "claude-relay-service",
     "openai_response": "openai-response",
     "openairesponses": "openai-response",
 }
@@ -2318,6 +2320,14 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
         display_name="Anthropic",
         protocol="anthropic",
         default_base_url="https://api.anthropic.com",
+        supports_tool_choice=False,
+        default_max_tokens=8192,
+    ),
+    "claude-relay-service": ProviderSpec(
+        provider="claude-relay-service",
+        display_name="Claude Relay Service",
+        protocol="anthropic",
+        default_base_url=None,
         supports_tool_choice=False,
         default_max_tokens=8192,
     ),

--- a/backend/tests/test_llm_claude_relay_provider.py
+++ b/backend/tests/test_llm_claude_relay_provider.py
@@ -1,0 +1,55 @@
+"""Regression coverage for Claude Relay Service's native Anthropic API."""
+
+import pytest
+
+from app.services.llm.client import (
+    PROVIDER_REGISTRY,
+    AnthropicClient,
+    create_llm_client,
+    get_provider_manifest,
+    normalize_provider,
+)
+
+
+def test_claude_relay_provider_is_exposed_as_anthropic() -> None:
+    spec = PROVIDER_REGISTRY["claude-relay-service"]
+    manifest = next(
+        item for item in get_provider_manifest() if item["provider"] == "claude-relay-service"
+    )
+
+    assert spec.protocol == "anthropic"
+    assert spec.default_base_url is None
+    assert spec.supports_tool_choice is False
+    assert manifest["protocol"] == "anthropic"
+    assert manifest["default_base_url"] is None
+    assert set(manifest["aliases"]) == {"claude-relay", "crs"}
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ["claude-relay-service", "claude-relay", "crs"],
+)
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://relay.example/claude",
+        "https://relay.example/claude/",
+        "https://relay.example/claude/v1",
+        "https://relay.example/claude/v1/messages",
+    ],
+)
+def test_claude_relay_uses_native_anthropic_client(
+    provider: str,
+    base_url: str,
+) -> None:
+    client = create_llm_client(
+        provider=provider,
+        api_key="cr_test_key",
+        model="claude-sonnet-4-5",
+        base_url=base_url,
+    )
+
+    assert isinstance(client, AnthropicClient)
+    assert client._normalize_base_url() == "https://relay.example/claude"
+    assert client._get_headers()["x-api-key"] == "cr_test_key"
+    assert normalize_provider(provider) == "claude-relay-service"

--- a/frontend/src/pages/enterprise-settings/tabs/LlmTab.tsx
+++ b/frontend/src/pages/enterprise-settings/tabs/LlmTab.tsx
@@ -48,6 +48,7 @@ interface RuntimeModelSettings {
 
 const FALLBACK_LLM_PROVIDERS: LLMProviderSpec[] = [
     { provider: 'anthropic', display_name: 'Anthropic', protocol: 'anthropic', default_base_url: 'https://api.anthropic.com', supports_tool_choice: false, default_max_tokens: 8192 },
+    { provider: 'claude-relay-service', display_name: 'Claude Relay Service', protocol: 'anthropic', default_base_url: '', supports_tool_choice: false, default_max_tokens: 8192 },
     { provider: 'openai', display_name: 'OpenAI', protocol: 'openai_compatible', default_base_url: 'https://api.openai.com/v1', supports_tool_choice: true, default_max_tokens: 16384 },
     { provider: 'azure', display_name: 'Azure OpenAI', protocol: 'openai_compatible', default_base_url: '', supports_tool_choice: true, default_max_tokens: 16384 },
     { provider: 'deepseek', display_name: 'DeepSeek', protocol: 'openai_compatible', default_base_url: 'https://api.deepseek.com/v1', supports_tool_choice: true, default_max_tokens: 8192 },


### PR DESCRIPTION
## Summary
- add Claude Relay Service as a native Anthropic provider with CRS aliases
- expose it in the model settings provider fallback
- cover protocol routing and Relay endpoint normalization

Closes #804

## Validation
- uv run --extra dev python -m pytest tests/test_llm_claude_relay_provider.py tests/test_llm_system_message_shape.py
- npm run build