### PR TITLE
fix(sandbox): proxy pass-through + bwrap compat on CentOS 7 / kernel 3.10

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -47,6 +47,7 @@ COPY . .
 RUN useradd --create-home clawith && \
     mkdir -p /data/agents && \
     chmod +x /app/entrypoint.sh && \
+    chmod u+s /usr/bin/bwrap && \
     chown -R clawith:clawith /app /data
 
 # Note: USER is removed to allow entrypoint.sh to fix permissions of mounted volumes

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -171,6 +171,8 @@ class Settings(BaseSettings):
     FEISHU_REDIRECT_URI: str = ""
     PUBLIC_BASE_URL: str = ""
     HTTP_PROXY: str = ""
+    HTTPS_PROXY: str = ""
+    NO_PROXY: str = ""
 
     # CORS
     CORS_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:5173"]
@@ -192,6 +194,9 @@ class Settings(BaseSettings):
     SANDBOX_ALLOW_UNSAFE_FALLBACK_WHEN_BWRAP_MISSING: bool = _default_allow_unsafe_bwrap_fallback()
     SANDBOX_DEFAULT_TIMEOUT: int = 30
     SANDBOX_MAX_TIMEOUT: int = 60
+    SANDBOX_HTTP_PROXY: str = ""
+    SANDBOX_HTTPS_PROXY: str = ""
+    SANDBOX_NO_PROXY: str = ""
 
     @field_validator(
         "LANGGRAPH_CHECKPOINT_DATABASE_URL",
@@ -256,4 +261,7 @@ def get_sandbox_config() -> SandboxConfig:
         allow_unsafe_fallback_when_bwrap_missing=settings.SANDBOX_ALLOW_UNSAFE_FALLBACK_WHEN_BWRAP_MISSING,
         default_timeout=settings.SANDBOX_DEFAULT_TIMEOUT,
         max_timeout=settings.SANDBOX_MAX_TIMEOUT,
+        http_proxy=settings.SANDBOX_HTTP_PROXY or settings.HTTP_PROXY or None,
+        https_proxy=settings.SANDBOX_HTTPS_PROXY or settings.HTTPS_PROXY or None,
+        no_proxy=settings.SANDBOX_NO_PROXY or settings.NO_PROXY or None,
     )

--- a/backend/app/services/sandbox/config.py
+++ b/backend/app/services/sandbox/config.py
@@ -38,6 +38,11 @@ class SandboxConfig(BaseModel):
     default_timeout: int = Field(default=30, ge=1, le=3600)
     max_timeout: int = Field(default=60, ge=1, le=3600)
 
+    # Proxy options
+    http_proxy: Optional[str] = None
+    https_proxy: Optional[str] = None
+    no_proxy: Optional[str] = None
+
     # Language mapping for API sandboxes
     # Maps our internal language names to API-specific language IDs
     language_mapping: dict[str, str] = Field(default_factory=lambda: {
@@ -113,5 +118,8 @@ class SandboxConfig(BaseModel):
             ),
             default_timeout=get_value("default_timeout", 30),
             max_timeout=get_value("max_timeout", 60),
+            http_proxy=get_value("http_proxy", None),
+            https_proxy=get_value("https_proxy", None),
+            no_proxy=get_value("no_proxy", None),
         )
         return result

--- a/backend/app/services/sandbox/local/docker_backend.py
+++ b/backend/app/services/sandbox/local/docker_backend.py
@@ -1,7 +1,7 @@
 """Local docker-based sandbox backend."""
 
+import os
 import time
-from pathlib import Path
 
 from app.services.sandbox.base import BaseSandboxBackend, ExecutionResult, SandboxCapabilities
 from app.services.sandbox.config import SandboxConfig
@@ -109,6 +109,18 @@ class DockerBackend(BaseSandboxBackend):
             "HOME": "/root",
             "PYTHONDONTWRITEBYTECODE": "1",
         }
+        http_proxy = self.config.http_proxy or os.environ.get("http_proxy") or os.environ.get("HTTP_PROXY")
+        https_proxy = self.config.https_proxy or os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+        no_proxy = self.config.no_proxy or os.environ.get("no_proxy") or os.environ.get("NO_PROXY")
+        if http_proxy:
+            env["http_proxy"] = http_proxy
+            env["HTTP_PROXY"] = http_proxy
+        if https_proxy:
+            env["https_proxy"] = https_proxy
+            env["HTTPS_PROXY"] = https_proxy
+        if no_proxy:
+            env["no_proxy"] = no_proxy
+            env["NO_PROXY"] = no_proxy
 
         # Build docker run command
         if language == "python":
@@ -179,7 +191,7 @@ class DockerBackend(BaseSandboxBackend):
         except Exception as e:
             duration_ms = int((time.time() - start_time) * 1000)
             error_msg = str(e)
-            logger.exception(f"[Docker] Execution error")
+            logger.exception("[Docker] Execution error")
 
             # Handle timeout specifically
             if "timeout" in error_msg.lower():

--- a/backend/app/services/sandbox/local/subprocess_backend.py
+++ b/backend/app/services/sandbox/local/subprocess_backend.py
@@ -144,6 +144,18 @@ class SubprocessBackend(BaseSandboxBackend):
             "PIP_CACHE_DIR": str(workspace_tmp / "pip-cache"),
             "PIP_DISABLE_PIP_VERSION_CHECK": "1",
         }
+        http_proxy = self.config.http_proxy or os.environ.get("http_proxy") or os.environ.get("HTTP_PROXY")
+        https_proxy = self.config.https_proxy or os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+        no_proxy = self.config.no_proxy or os.environ.get("no_proxy") or os.environ.get("NO_PROXY")
+        if http_proxy:
+            env["http_proxy"] = http_proxy
+            env["HTTP_PROXY"] = http_proxy
+        if https_proxy:
+            env["https_proxy"] = https_proxy
+            env["HTTPS_PROXY"] = https_proxy
+        if no_proxy:
+            env["no_proxy"] = no_proxy
+            env["NO_PROXY"] = no_proxy
         return env
 
     def _bind_if_exists(self, host_path: str, guest_path: str | None = None, *, read_only: bool = True) -> list[str]:
@@ -288,11 +300,10 @@ class SubprocessBackend(BaseSandboxBackend):
             bwrap,
             "--die-with-parent",
             "--new-session",
-            "--unshare-user",
             "--unshare-ipc",
             "--unshare-pid",
             "--unshare-uts",
-            "--unshare-cgroup",
+            "--unshare-cgroup-try",
             *base_binds,
             "--bind", "/data/agents/.uv-cache", "/uv-cache",
             "--bind", str(work_path), "/workspace",
@@ -312,8 +323,19 @@ class SubprocessBackend(BaseSandboxBackend):
             "--setenv", "PIP_CACHE_DIR", "/workspace/.tmp/pip-cache",
             "--setenv", "PIP_DISABLE_PIP_VERSION_CHECK", "1",
             "--setenv", "UV_CACHE_DIR", "/uv-cache",
-            "--chdir", "/workspace",
         ]
+        http_proxy = self.config.http_proxy or os.environ.get("http_proxy") or os.environ.get("HTTP_PROXY")
+        https_proxy = self.config.https_proxy or os.environ.get("https_proxy") or os.environ.get("HTTPS_PROXY")
+        no_proxy = self.config.no_proxy or os.environ.get("no_proxy") or os.environ.get("NO_PROXY")
+        if http_proxy:
+            cmd.extend(["--setenv", "http_proxy", http_proxy, "--setenv", "HTTP_PROXY", http_proxy])
+        if https_proxy:
+            cmd.extend(["--setenv", "https_proxy", https_proxy, "--setenv", "HTTPS_PROXY", https_proxy])
+        if no_proxy:
+            cmd.extend(["--setenv", "no_proxy", no_proxy, "--setenv", "NO_PROXY", no_proxy])
+
+        cmd.append("--chdir")
+        cmd.append("/workspace")
         if not self.config.allow_network:
             cmd.append("--unshare-net")
         cmd.extend(command)

--- a/backend/tests/test_sandbox_subprocess_backend.py
+++ b/backend/tests/test_sandbox_subprocess_backend.py
@@ -73,3 +73,53 @@ async def test_workspace_venv_timeout_terminates_child(monkeypatch, tmp_path: Pa
         await backend._ensure_workspace_venv(tmp_path / ".venv")
 
     assert terminated == [456]
+
+
+def test_subprocess_backend_proxy_env_propagation(tmp_path: Path) -> None:
+    config = SandboxConfig(
+        http_proxy="http://127.0.0.1:8080",
+        https_proxy="http://127.0.0.1:8081",
+        no_proxy="localhost,127.0.0.1",
+    )
+    backend = SubprocessBackend(config)
+    env = backend._build_safe_env(tmp_path)
+
+    assert env.get("http_proxy") == "http://127.0.0.1:8080"
+    assert env.get("HTTP_PROXY") == "http://127.0.0.1:8080"
+    assert env.get("https_proxy") == "http://127.0.0.1:8081"
+    assert env.get("HTTPS_PROXY") == "http://127.0.0.1:8081"
+    assert env.get("no_proxy") == "localhost,127.0.0.1"
+    assert env.get("NO_PROXY") == "localhost,127.0.0.1"
+
+
+def test_subprocess_backend_proxy_bwrap_command(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("shutil.which", lambda cmd: "/usr/bin/bwrap" if cmd == "bwrap" else None)
+    config = SandboxConfig(
+        http_proxy="http://proxy.example.com:8080",
+        https_proxy="http://proxy.example.com:8443",
+    )
+    backend = SubprocessBackend(config)
+    cmd = backend._build_bwrap_command(["python3", "-c", "print(1)"], tmp_path, tmp_path / ".venv")
+
+    assert cmd is not None
+    assert "--unshare-cgroup-try" in cmd
+    assert "--unshare-cgroup" not in cmd
+    assert "--unshare-user" not in cmd
+    assert "--setenv" in cmd
+    idx_http = cmd.index("http_proxy")
+    assert cmd[idx_http + 1] == "http://proxy.example.com:8080"
+    idx_https = cmd.index("https_proxy")
+    assert cmd[idx_https + 1] == "http://proxy.example.com:8443"
+
+
+def test_sandbox_config_proxy_parsing() -> None:
+    data = {
+        "http_proxy": "http://10.0.0.1:3128",
+        "https_proxy": "http://10.0.0.1:3128",
+        "no_proxy": ".local,10.0.0.0/8",
+    }
+    config = SandboxConfig.from_dict(data)
+    assert config.http_proxy == "http://10.0.0.1:3128"
+    assert config.https_proxy == "http://10.0.0.1:3128"
+    assert config.no_proxy == ".local,10.0.0.0/8"
+


### PR DESCRIPTION
## 问题

在 CentOS 7（Linux 内核 3.10）环境下运行 bubblewrap 沙箱时报错：

```
bwrap: Cannot create new cgroup namespace because the kernel does not support it.
```

根本原因有三：
1. `--unshare-cgroup` 要求 Linux ≥ 4.6，旧内核不支持 cgroup namespace。
2. `--unshare-user` 在 `user.max_user_namespaces=0` 或未设置 `namespace.unpriv_enable=1` 时无法创建 user namespace。
3. Dockerfile 安装了 bubblewrap 但未设 setuid 位，在 user namespace 不可用时无法以特权方式运行。

此外，subprocess 子进程缺乏 http_proxy / https_proxy 代理环境变量透传机制。

## 修改内容

### bwrap 旧内核兼容性
- 将 `--unshare-cgroup` 替换为 `--unshare-cgroup-try`（内核不支持时优雅跳过）
- 移除 `--unshare-user`（在无 unprivileged namespace 支持的系统上阻塞启动）
- 在 `backend/Dockerfile` 中为 `/usr/bin/bwrap` 增加 SetUID 位，支持无 user namespace 的宿主机环境

### 代理透传
- 在 `SandboxConfig` 新增 `http_proxy`、`https_proxy`、`no_proxy` 字段，`from_dict()` 同步支持 fallback 解析
- 在 `Settings` 新增 `HTTPS_PROXY`、`NO_PROXY`、`SANDBOX_HTTP_PROXY`、`SANDBOX_HTTPS_PROXY`、`SANDBOX_NO_PROXY` 配置项
- `get_sandbox_config()` 优先使用 `SANDBOX_*` 环境变量，回退到全局 `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
- `SubprocessBackend._build_safe_env()` 将代理变量注入子进程环境（同时写大小写两个变体）
- `SubprocessBackend._build_bwrap_command()` 通过 `--setenv` 将代理变量透传进 bubblewrap 沙箱内部
- `DockerBackend` 容器 env 同步注入代理变量

### 测试
新增单元测试覆盖：
- `_build_safe_env` 中代理变量注入
- `_build_bwrap_command` 中 bwrap flag 和代理 `--setenv` 验证（含断言 `--unshare-cgroup-try` 在、`--unshare-user` / `--unshare-cgroup` 不在）
- `SandboxConfig.from_dict` 代理字段解析

所有测试通过（5/5），Ruff 检查干净。