### PR TITLE
fix: handle empty skills and chat responses

### DIFF
--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -236,7 +236,7 @@ async def list_files(
     path_is_dir = await storage.is_dir(storage_key)
     if not path_exists and not path_is_dir:
         if not (
-            normalized_path in {"", "workspace"}
+            normalized_path in {"", "workspace", "skills"}
             or (is_enterprise and normalized_path == "enterprise_info")
         ):
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Path not found")

--- a/backend/app/services/agent_runtime/checkpointer.py
+++ b/backend/app/services/agent_runtime/checkpointer.py
@@ -128,7 +128,9 @@ def _to_psycopg_url(database_url: str) -> str:
         if explicit_sslmode is None:
             other_query_parts.append(f"sslmode={quote(asyncpg_sslmode, safe='')}")
 
-    search_path_option = f"-csearch_path={_CHECKPOINT_SCHEMA}"
+    # Keep public available for extension functions/types referenced by the
+    # unqualified LangGraph migrations while isolating checkpoint tables.
+    search_path_option = f"-c search_path={_CHECKPOINT_SCHEMA},public"
     options = " ".join([option for option in existing_options if option] + [search_path_option])
     encoded_options = quote(options, safe="")
     query = "&".join([*other_query_parts, f"options={encoded_options}"])

--- a/backend/tests/test_agent_runtime_checkpointer.py
+++ b/backend/tests/test_agent_runtime_checkpointer.py
@@ -42,13 +42,13 @@ def test_dedicated_checkpoint_url_wins_and_is_normalized_for_psycopg() -> None:
     )
 
     assert checkpoint_database_url(settings) == (
-        "postgresql://checkpoint:secret@db.example/checkpoints?options=-csearch_path%3Dlanggraph_checkpoint"
+        "postgresql://checkpoint:secret@db.example/checkpoints?options=-c%20search_path%3Dlanggraph_checkpoint%2Cpublic"
     )
 
 
 def test_primary_asyncpg_url_is_the_checkpoint_fallback() -> None:
     assert checkpoint_database_url(_settings()) == (
-        "postgresql://app:secret@db.example/clawith?options=-csearch_path%3Dlanggraph_checkpoint"
+        "postgresql://app:secret@db.example/clawith?options=-c%20search_path%3Dlanggraph_checkpoint%2Cpublic"
     )
 
 
@@ -77,7 +77,7 @@ def test_primary_asyncpg_ssl_query_is_normalized_for_psycopg(
     parsed = conninfo_to_dict(url)
 
     assert parsed["sslmode"] == psycopg_value
-    assert parsed["options"] == "-csearch_path=langgraph_checkpoint"
+    assert parsed["options"] == "-c search_path=langgraph_checkpoint,public"
 
 
 def test_conflicting_asyncpg_ssl_and_psycopg_sslmode_fails_closed() -> None:
@@ -101,7 +101,7 @@ def test_checkpoint_url_preserves_existing_options_and_forces_isolated_schema() 
 
     assert checkpoint_database_url(settings) == (
         "postgresql://checkpoint:secret@db.example/checkpoints?sslmode=require&"
-        "options=-cstatement_timeout%3D5000%20-csearch_path%3Dlanggraph_checkpoint"
+        "options=-cstatement_timeout%3D5000%20-c%20search_path%3Dlanggraph_checkpoint%2Cpublic"
     )
 
 
@@ -114,7 +114,7 @@ def test_psycopg_parses_search_path_as_a_separate_server_option() -> None:
 
     parsed = conninfo_to_dict(checkpoint_database_url(settings))
 
-    assert parsed["options"] == ("-cstatement_timeout=5000 -csearch_path=langgraph_checkpoint")
+    assert parsed["options"] == ("-cstatement_timeout=5000 -c search_path=langgraph_checkpoint,public")
 
 
 def test_installed_saver_uses_unqualified_checkpoint_tables() -> None:
@@ -202,6 +202,6 @@ async def test_factory_is_lazy_and_never_runs_checkpointer_setup() -> None:
 
     factory.assert_called_once()
     call = factory.call_args
-    assert call.args == ("postgresql://app:secret@db.example/clawith?options=-csearch_path%3Dlanggraph_checkpoint",)
+    assert call.args == ("postgresql://app:secret@db.example/clawith?options=-c%20search_path%3Dlanggraph_checkpoint%2Cpublic",)
     assert isinstance(call.kwargs["serde"], JsonPlusSerializer)
     saver.setup.assert_not_awaited()

--- a/backend/tests/test_files_api_storage.py
+++ b/backend/tests/test_files_api_storage.py
@@ -119,6 +119,20 @@ async def test_list_files_allows_empty_workspace_root(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_list_files_allows_empty_skills_root(monkeypatch):
+    agent_id = uuid.uuid4()
+    monkeypatch.setattr(files, "get_storage_backend", lambda: PrefixOnlyStorage())
+
+    async def allow_access(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(files, "check_agent_access", allow_access)
+    user = SimpleNamespace(tenant_id=None)
+
+    assert await files.list_files(agent_id, path="skills", current_user=user, db=None) == []
+
+
+@pytest.mark.asyncio
 async def test_list_files_reports_recursive_directory_total_size(monkeypatch):
     agent_id = uuid.uuid4()
     storage = PrefixOnlyStorage({

--- a/frontend/src/pages/agent-detail/AgentDetailPage.tsx
+++ b/frontend/src/pages/agent-detail/AgentDetailPage.tsx
@@ -6953,7 +6953,15 @@ export default function AgentDetailPage() {
                                                                 continue;
                                                             }
                                                             flushGroup();
-                                                            grouped.push({ type: 'msg', msg, i });
+                                                            const isAssistantEmpty = msg.role === 'assistant'
+                                                                && !msg.content?.trim()
+                                                                && !msg.thinking?.trim()
+                                                                && !msg.runtimeError
+                                                                && !msg.fileName
+                                                                && !msg.imageUrl;
+                                                            if (!isAssistantEmpty) {
+                                                                grouped.push({ type: 'msg', msg, i });
+                                                            }
                                                         }
                                                     }
                                                     flushGroup(); // flush any trailing group

--- a/frontend/tests/agentDetailMessageRendering.test.mjs
+++ b/frontend/tests/agentDetailMessageRendering.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = readFileSync(
+  new URL('../src/pages/agent-detail/AgentDetailPage.tsx', import.meta.url),
+  'utf8',
+);
+
+test('final empty assistant packets do not create a chat bubble', () => {
+  assert.match(source, /const isAssistantEmpty = msg\.role === 'assistant'[\s\S]*?!msg\.content\?\.trim\(\)[\s\S]*?!msg\.thinking\?\.trim\(\)[\s\S]*?!msg\.runtimeError[\s\S]*?!msg\.fileName[\s\S]*?!msg\.imageUrl/);
+  assert.match(source, /if \(!isAssistantEmpty\) \{\s*grouped\.push\(\{ type: 'msg', msg, i \}\);\s*\}/);
+});


### PR DESCRIPTION
## Summary

- return an empty listing when an agent has not created its `skills/` directory yet
- retain `public` in the LangGraph checkpoint connection search path for extension functions and types
- suppress final assistant packets that carry no displayable content

## Root cause

The file API treated the optional `skills/` prefix as a missing path, the checkpoint DSN isolated the schema too aggressively, and the direct-chat renderer unconditionally emitted a final assistant bubble.

## Validation

- `cd backend && python -m pytest tests/test_files_api_storage.py` (9 passed)
- `cd frontend && npm test -- --test-name-pattern='final empty assistant packets'` (87 passed)
- Checkpoint tests could not collect because the shared Python environment has incompatible LangGraph package versions (`Reviver.__init__` rejects `allowed_objects`).
