### PR TITLE
fix: reject traversal in agent file delivery

### DIFF
--- a/backend/app/services/agent_tools.py
+++ b/backend/app/services/agent_tools.py
@@ -9256,6 +9256,11 @@ async def _resolve_a2a_target_by_id(
     return target, None
 
 
+def _has_parent_path_segment(path: str) -> bool:
+    """Return whether a user-supplied storage-relative path traverses upward."""
+    return any(segment == ".." for segment in path.replace("\\", "/").split("/"))
+
+
 async def _send_file_to_agent_outcome(
     from_agent_id: uuid.UUID,
     args: dict,
@@ -9289,6 +9294,11 @@ async def _send_file_to_agent_outcome(
         return _typed_failure(
             "send_file_to_agent requires target_agent_id and file_path.",
             "invalid_tool_arguments",
+        )
+    if _has_parent_path_segment(rel_path):
+        return _typed_failure(
+            "send_file_to_agent file_path must not contain parent directory traversal.",
+            "workspace_path_invalid",
         )
 
     storage = get_storage_backend()

--- a/backend/tests/test_agent_tools_remaining_typed_outcomes.py
+++ b/backend/tests/test_agent_tools_remaining_typed_outcomes.py
@@ -120,6 +120,33 @@ async def test_remaining_default_tools_have_native_typed_validation_failures(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "file_path",
+    (
+        "../other-agent/workspace/secret.txt",
+        "workspace/../../other-agent/workspace/secret.txt",
+        r"workspace\\..\\..\\other-agent\\workspace\\secret.txt",
+    ),
+)
+async def test_send_file_to_agent_rejects_parent_traversal_before_storage_access(
+    monkeypatch,
+    file_path: str,
+) -> None:
+    def forbidden_storage_access():
+        raise AssertionError("storage must not be accessed for a traversal path")
+
+    monkeypatch.setattr(agent_tools, "get_storage_backend", forbidden_storage_access)
+
+    outcome = await agent_tools._send_file_to_agent_outcome(
+        uuid.uuid4(),
+        {"target_agent_id": str(uuid.uuid4()), "file_path": file_path},
+    )
+
+    assert outcome.status == "failed"
+    assert outcome.error_code == "workspace_path_invalid"
+
+
+@pytest.mark.asyncio
 async def test_duckduckgo_uses_http_and_parse_facts_and_timeout_is_retryable(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Reject parent-directory segments in `send_file_to_agent` file paths before storage access.
- Add regression coverage for Unix and Windows traversal forms.

## Root cause

The A2A file-delivery path was normalized only after prefixing it with the source Agent ID. `..` segments could therefore remove that prefix and resolve to another Agent's stored file.

## Impact

File delivery now fails closed with `workspace_path_invalid` when `file_path` contains `..`; valid relative paths retain their existing behavior.

## Validation

- `uv run --extra dev python -m pytest tests/test_agent_tools_remaining_typed_outcomes.py` (26 passed)
- `git diff --check`

Multica issue: AND-154
