### PR TITLE
Fix Markdown code fence XSS

### DIFF
--- a/frontend/src/components/MarkdownRenderer.tsx
+++ b/frontend/src/components/MarkdownRenderer.tsx
@@ -25,6 +25,12 @@ function escapeAttribute(str: string): string {
     return escapeHtml(str).replace(/'/g, '&#39;');
 }
 
+function sanitizeCodeLanguage(language: string): string {
+    // A fence info string is untrusted Markdown input. Only retain characters
+    // valid for the single syntax-highlighting class we generate from it.
+    return /^[A-Za-z0-9][A-Za-z0-9_+.#-]{0,63}$/.test(language) ? language : '';
+}
+
 function prepareUrl(url: string, kind: 'link' | 'image' = 'link'): string | null {
     let finalUrl = url.trim().replace(/^<|>$/g, '');
     const lower = finalUrl.toLowerCase();
@@ -163,7 +169,7 @@ function markdownToHtml(md: string, mentionNames: readonly string[] = []): strin
             if (!inCodeBlock) {
                 flushList(); flushBlockquote(); flushTable();
                 inCodeBlock = true;
-                codeLang = line.slice(3).trim();
+                codeLang = sanitizeCodeLanguage(line.slice(3).trim());
                 codeLines = [];
             } else {
                 const codeContent = escapeHtml(codeLines.join('\n'));

--- a/frontend/tests/markdownRendererSecurity.test.mjs
+++ b/frontend/tests/markdownRendererSecurity.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const renderer = readFileSync(
+  new URL('../src/components/MarkdownRenderer.tsx', import.meta.url),
+  'utf8',
+);
+
+test('code fence language is constrained before being interpolated into HTML', () => {
+  assert.match(renderer, /function sanitizeCodeLanguage\(language: string\): string/);
+  assert.match(renderer, /return \/\^\[A-Za-z0-9\]/);
+  assert.match(renderer, /codeLang = sanitizeCodeLanguage\(line\.slice\(3\)\.trim\(\)\)/);
+  assert.match(renderer, /class="language-\$\{codeLang\}"/);
+});


### PR DESCRIPTION
## Summary

Sanitize Markdown fenced-code language identifiers before they are used to form the rendered `language-*` CSS class.

## Root cause

The Markdown renderer copied the complete fence info string into an HTML attribute that is rendered with `dangerouslySetInnerHTML`. A crafted language value could break out of the attribute and execute stored script when the Markdown was viewed.

## Impact

All surfaces that render persisted Markdown through `MarkdownRenderer` are protected. Valid common language identifiers, including `ts`, `c++`, and `c#`, continue to render their CSS class; unsafe or malformed identifiers render as an unlabelled code block.

## Validation

- `npm test` (87 passing)
- `npm run build`
