### PR TITLE
fix(security): isolate HTML preview origin

### DIFF
--- a/frontend/src/components/WorkspaceOperationPanel.tsx
+++ b/frontend/src/components/WorkspaceOperationPanel.tsx
@@ -368,11 +368,13 @@ function HtmlPreviewFrame({
         if (fitRafRef.current != null) cancelAnimationFrame(fitRafRef.current);
     }, []);
 
+    // Keep untrusted agent HTML in an opaque origin: combining scripts and same-origin
+    // would let it access the application's storage and authenticated browser state.
     return (
         <div className="workspace-op-html-fit" ref={containerRef}>
             <iframe
                 ref={frameRef}
-                sandbox="allow-same-origin allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-pointer-lock allow-top-navigation-by-user-activation"
+                sandbox="allow-scripts allow-forms allow-modals allow-popups allow-downloads allow-pointer-lock allow-top-navigation-by-user-activation"
                 src={src}
                 srcDoc={src ? undefined : renderContent}
                 title={title}

--- a/frontend/tests/htmlPreviewSandboxContract.test.mjs
+++ b/frontend/tests/htmlPreviewSandboxContract.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const workspacePanel = readFileSync(
+  new URL('../src/components/WorkspaceOperationPanel.tsx', import.meta.url),
+  'utf8',
+);
+
+test('HTML preview keeps agent-generated scripts in an opaque-origin sandbox', () => {
+  const sandboxMatch = workspacePanel.match(/sandbox="([^"]+)"/);
+
+  assert.ok(sandboxMatch, 'HTML preview iframe must declare a sandbox');
+  assert.match(sandboxMatch[1], /\ballow-scripts\b/);
+  assert.doesNotMatch(sandboxMatch[1], /\ballow-same-origin\b/);
+});


### PR DESCRIPTION
## Summary
- remove `allow-same-origin` from agent-generated HTML preview iframe
- retain script support while forcing the preview into an opaque origin
- add a regression contract preventing the unsafe sandbox combination

## Verification
- `npm test -- --test-name-pattern="HTML preview"`
- `npm run build`

