### PR TITLE
Allow private agents to contact company agents

### DIFF
--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, status
 from sqlalchemy import false, or_, select, exists
 
 from app.models.agent import Agent, AgentPermission
-from app.models.org import AgentAgentRelationship, AgentRelationship, OrgMember
+from app.models.org import OrgMember
 from app.models.user import User
 
 
@@ -178,10 +178,9 @@ def evaluate_roster_agent_visibility(
     visible = False
 
     if source_mode == "private":
-        visible = (
-            target_mode == "private"
-            and getattr(source_agent, "creator_id", None) == getattr(target_agent, "creator_id", None)
-        )
+        # Private Agents may initiate contact with company-visible Agents, but
+        # never expose another private Agent (including one with the same owner).
+        visible = target_mode == "company"
     else:
         visible = target_mode == "company" or (target_mode == "custom" and authorized_custom_target)
 

--- a/backend/app/services/agent_directory.py
+++ b/backend/app/services/agent_directory.py
@@ -247,10 +247,9 @@ def _agent_directory_conditions(
         AgentModel.id != source.id,
     ]
     if source_mode == "private":
-        conditions.extend([
-            AgentModel.access_mode == "private",
-            AgentModel.creator_id == source.creator_id,
-        ])
+        # Keep the query in sync with evaluate_roster_agent_visibility:
+        # a private Agent can only initiate contact with company-visible Agents.
+        conditions.append(AgentModel.access_mode == "company")
     else:
         conditions.append(or_(
             AgentModel.access_mode == "company",

--- a/backend/tests/test_agent_visibility.py
+++ b/backend/tests/test_agent_visibility.py
@@ -254,7 +254,7 @@ def test_evaluate_roster_human_visibility_limits_custom_to_authorized_members():
     assert authorized_custom_visibility.can_contact is True
 
 
-def test_evaluate_roster_agent_visibility_allows_same_creator_private_only():
+def test_evaluate_roster_agent_visibility_enforces_private_to_company_only():
     tenant_id = uuid.uuid4()
     creator_id = uuid.uuid4()
     source = make_agent(tenant_id=tenant_id, creator_id=creator_id, access_mode="private")
@@ -262,9 +262,27 @@ def test_evaluate_roster_agent_visibility_allows_same_creator_private_only():
     other_private = make_agent(tenant_id=tenant_id, creator_id=uuid.uuid4(), access_mode="private")
     company_agent = make_agent(tenant_id=tenant_id, creator_id=creator_id, access_mode="company")
 
-    assert permissions.evaluate_roster_agent_visibility(source, same_creator_private).visible is True
-    assert permissions.evaluate_roster_agent_visibility(source, other_private).visible is False
-    assert permissions.evaluate_roster_agent_visibility(source, company_agent).visible is False
+    same_owner_private = permissions.evaluate_roster_agent_visibility(source, same_creator_private)
+    other_owner_private = permissions.evaluate_roster_agent_visibility(source, other_private)
+    company_visibility = permissions.evaluate_roster_agent_visibility(source, company_agent)
+
+    assert same_owner_private.visible is False
+    assert same_owner_private.can_contact is False
+    assert other_owner_private.visible is False
+    assert other_owner_private.can_contact is False
+    assert company_visibility.visible is True
+    assert company_visibility.can_contact is True
+
+
+def test_evaluate_roster_agent_visibility_blocks_company_to_private():
+    tenant_id = uuid.uuid4()
+    source = make_agent(tenant_id=tenant_id, access_mode="company")
+    private_target = make_agent(tenant_id=tenant_id, access_mode="private")
+
+    visibility = permissions.evaluate_roster_agent_visibility(source, private_target)
+
+    assert visibility.visible is False
+    assert visibility.can_contact is False
 
 
 def test_evaluate_roster_agent_visibility_reports_uncontactable_reason():

--- a/backend/tests/test_query_directory_tool.py
+++ b/backend/tests/test_query_directory_tool.py
@@ -209,6 +209,29 @@ async def test_query_directory_agent_list_uses_sql_offset_and_limit():
     assert "OFFSET" in statement
 
 
+@pytest.mark.asyncio
+async def test_private_agent_directory_queries_company_agents_only():
+    tenant_id = uuid.uuid4()
+    source = _make_agent(tenant_id=tenant_id, access_mode="private")
+    db = RecordingDB(
+        responses=[
+            DummyResult(scalar_value=source),
+            DummyResult(values=[]),
+        ]
+    )
+
+    result = await agent_directory.query_agent_directory(
+        db,
+        source_agent_id=source.id,
+        member_type="agent",
+    )
+
+    assert result["members"] == []
+    compiled = db.statements[1].compile()
+    assert "agents.access_mode = :access_mode_1" in str(compiled)
+    assert compiled.params["access_mode_1"] == "company"
+
+
 def test_format_roster_agent_returns_stable_id_and_contact_tool():
     tenant_id = uuid.uuid4()
     source = _make_agent(tenant_id=tenant_id)


### PR DESCRIPTION
## Summary

- Allow private agents to discover and contact company-visible agents.
- Prevent private-to-private and company-to-private contact in the directory and message authorization paths.
- Add coverage for the communication matrix and private-agent directory query.

## Root cause

The existing visibility rule exposed same-owner private agents and excluded company-visible agents for private sources, which contradicted the requested one-way communication policy.

## Validation

`PYTHONPATH="$PWD" uv run pytest tests/test_agent_visibility.py tests/test_query_directory_tool.py tests/test_agent_directory_api.py`

`PYTHONPATH="$PWD" uv run ruff check app/core/permissions.py app/services/agent_directory.py tests/test_agent_visibility.py tests/test_query_directory_tool.py`

Closes #838
