### PR TITLE
fix(api): restore Depends(get_db) — `db: Any = None` is never injected

### DIFF
--- a/backend/app/api/activity.py
+++ b/backend/app/api/activity.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Activity log API — view agent work history."""
 
 import uuid
@@ -19,7 +18,7 @@ async def get_agent_activity(
     agent_id: uuid.UUID,
     limit: int = Query(50, le=200),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get recent activity logs for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -45,7 +44,7 @@ async def get_agent_activity(
 async def list_conversations(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all conversation partners for this agent (web users + other agents)."""
     await check_agent_access(db, current_user, agent_id)
@@ -59,7 +58,7 @@ async def get_conversation_messages(
     conv_id: str,
     limit: int = Query(100, le=500),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get messages for a specific conversation."""
     await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -4,7 +4,6 @@ Provides endpoints for platform admins to manage companies, view stats,
 and control platform-level settings.
 """
 
-from typing import Any
 import secrets
 import uuid
 from datetime import datetime
@@ -70,7 +69,7 @@ class PlatformSettingsUpdate(BaseModel):
 @router.get("/companies", response_model=list[CompanyStats])
 async def list_companies(
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all companies with stats."""
     tenants = await query_dao.execute(db, select(Tenant).order_by(Tenant.created_at.desc()))
@@ -143,7 +142,7 @@ async def list_companies(
 async def create_company(
     data: CompanyCreateRequest,
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new company and generate an admin invitation code (max_uses=1)."""
     import re
@@ -184,7 +183,7 @@ async def create_company(
 async def toggle_company(
     company_id: uuid.UUID,
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Enable or disable a company."""
     result = await query_dao.execute(db, select(Tenant).where(Tenant.id == company_id))
@@ -221,7 +220,7 @@ async def get_platform_timeseries(
     start_date: datetime,
     end_date: datetime,
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get daily platform metrics within a date range.
 
@@ -386,7 +385,7 @@ async def get_platform_timeseries(
 @router.get("/metrics/leaderboards")
 async def get_platform_leaderboards(
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get Top 20 token consuming companies and agents."""
     # Top 20 Companies by total tokens
@@ -438,7 +437,7 @@ async def get_platform_leaderboards(
 @router.get("/metrics/enhanced")
 async def get_enhanced_metrics(
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Enhanced platform metrics: retention, avg tokens/session,
     channel distribution, tool categories, and churn warnings.
@@ -589,7 +588,7 @@ async def get_enhanced_metrics(
 @router.get("/platform-settings", response_model=PlatformSettingsOut)
 async def get_platform_settings(
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get platform-level settings."""
     settings: dict[str, bool] = {}
@@ -610,7 +609,7 @@ async def get_platform_settings(
 async def update_platform_settings(
     data: PlatformSettingsUpdate,
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update platform-level settings."""
     updates = data.model_dump(exclude_unset=True)

--- a/backend/app/api/advanced.py
+++ b/backend/app/api/advanced.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Agent collaboration and template market API routes."""
 
 import uuid
@@ -37,7 +36,7 @@ class InterAgentMessage(BaseModel):
 async def list_collaborators(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List agents that can collaborate with this agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -49,7 +48,7 @@ async def delegate_task(
     agent_id: uuid.UUID,
     data: DelegateRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delegate a task from one agent to another."""
     await check_agent_access(db, current_user, agent_id)
@@ -67,7 +66,7 @@ async def send_inter_agent_message(
     agent_id: uuid.UUID,
     data: InterAgentMessage,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Send a message between agents."""
     await check_agent_access(db, current_user, agent_id)
@@ -164,7 +163,7 @@ async def handover_agent(
     agent_id: uuid.UUID,
     data: HandoverRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Transfer ownership of a digital employee to another user."""
     from app.models.audit import AuditLog
@@ -206,7 +205,7 @@ async def handover_agent(
 async def get_agent_metrics(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get observability metrics for an agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/agent_credentials.py
+++ b/backend/app/api/agent_credentials.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Agent Credentials CRUD API routes.
 
 Provides endpoints for managing encrypted session cookies
@@ -53,7 +52,7 @@ def _to_response(cred: AgentCredential) -> dict:
 async def list_credentials(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all credentials for an agent (sensitive data excluded)."""
     # Verify the user has manage-level access to this agent
@@ -73,7 +72,7 @@ async def create_credential(
     agent_id: uuid.UUID,
     data: AgentCredentialCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new credential for an agent.
 
@@ -122,7 +121,7 @@ async def update_credential(
     credential_id: uuid.UUID,
     data: AgentCredentialUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update an existing credential.
 
@@ -178,7 +177,7 @@ async def delete_credential(
     agent_id: uuid.UUID,
     credential_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete a credential."""
     _agent, access_level = await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/agentbay_control.py
+++ b/backend/app/api/agentbay_control.py
@@ -14,7 +14,7 @@ import logging
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -626,7 +626,7 @@ async def control_current_url(
     agent_id: uuid.UUID,
     data: CurrentUrlRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get the current page URL from the active browser session via CDP.
 
@@ -676,7 +676,7 @@ async def control_click(
     agent_id: uuid.UUID,
     data: ClickRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Forward a mouse click to the AgentBay session.
 
@@ -709,7 +709,7 @@ async def control_type(
     agent_id: uuid.UUID,
     data: TypeRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Forward text input to the AgentBay session."""
     _agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -736,7 +736,7 @@ async def control_press_keys(
     agent_id: uuid.UUID,
     data: PressKeysRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Forward keyboard key presses to the AgentBay session."""
     _agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -763,7 +763,7 @@ async def control_drag(
     agent_id: uuid.UUID,
     data: DragRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Simulate a human-like mouse drag in the AgentBay session.
 
@@ -799,7 +799,7 @@ async def control_screenshot(
     agent_id: uuid.UUID,
     data: ScreenshotRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get an immediate screenshot from the AgentBay session.
 
@@ -846,7 +846,7 @@ async def control_lock(
     agent_id: uuid.UUID,
     data: LockRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Enter Take Control mode — locks the session against automatic tool execution.
 
@@ -888,7 +888,7 @@ async def control_unlock(
     agent_id: uuid.UUID,
     data: UnlockRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Exit Take Control mode — unlock session and optionally export cookies.
 

--- a/backend/app/api/agents.py
+++ b/backend/app/api/agents.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Agent (Digital Employee) API routes."""
 
 import hashlib
@@ -137,7 +136,7 @@ def _serialize_agent_out(agent: Agent, unread_count: int = 0) -> AgentOut:
 @router.get("/templates")
 async def list_templates(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all available agent templates."""
     from app.models.agent import AgentTemplate
@@ -196,7 +195,7 @@ async def _agents_to_out(
 @router.get("/", response_model=list[AgentOut])
 async def list_agents(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all agents the current user has access to."""
     stmt = build_visible_agents_query(
@@ -391,7 +390,7 @@ async def create_agent(
     data: AgentCreate,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new digital employee (any authenticated user)."""
     # Check agent creation quota
@@ -574,7 +573,7 @@ async def create_agent(
 async def get_agent(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get agent details."""
     agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -608,7 +607,7 @@ async def get_agent(
 async def get_agent_permissions(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get agent permission scope."""
     agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -706,7 +705,7 @@ async def update_agent_permissions(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update agent permission scope (owner or platform_admin only)."""
     agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -804,7 +803,7 @@ async def get_agent_permission_candidates(
     agent_id: uuid.UUID,
     search: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return org members that can be granted custom access.
 
@@ -885,7 +884,7 @@ async def update_agent(
     agent_id: uuid.UUID,
     data: AgentUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update agent settings (creator or admin)."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -1001,7 +1000,7 @@ async def update_agent(
 async def delete_agent(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Logically delete an Agent while retaining its history and Workspace."""
     agent, _access = await check_agent_access(
@@ -1092,7 +1091,7 @@ async def delete_agent(
 async def start_agent(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Start an agent's container."""
     agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -1110,7 +1109,7 @@ async def start_agent(
 async def stop_agent(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Stop an agent's container."""
     agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -1132,7 +1131,7 @@ async def list_agent_approvals(
     agent_id: uuid.UUID,
     status_filter: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List approval requests for a specific agent. Only creator or admin can view."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -1171,7 +1170,7 @@ async def resolve_agent_approval(
     approval_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Approve or reject a pending approval for a specific agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -1199,7 +1198,7 @@ async def resolve_agent_approval(
 async def generate_or_reset_api_key(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Generate or regenerate API key for an OpenClaw agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -1219,7 +1218,7 @@ async def generate_or_reset_api_key(
 async def list_gateway_messages(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List recent gateway messages for an OpenClaw agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/atlassian.py
+++ b/backend/app/api/atlassian.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Atlassian Rovo MCP Channel API routes.
 
 Provides per-agent Atlassian integration configuration.
@@ -32,7 +31,7 @@ async def configure_atlassian_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure Atlassian Rovo MCP for an agent.
 
@@ -91,7 +90,7 @@ async def configure_atlassian_channel(
 async def get_atlassian_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await query_dao.execute(db, 
@@ -110,7 +109,7 @@ async def get_atlassian_channel(
 async def delete_atlassian_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -132,7 +131,7 @@ async def delete_atlassian_channel(
 async def test_atlassian_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Test connectivity to Atlassian Rovo MCP and list available tools."""
     await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/chat_sessions.py
+++ b/backend/app/api/chat_sessions.py
@@ -6,7 +6,7 @@ import json
 import re
 import uuid
 from datetime import UTC, datetime
-from typing import Any, Annotated, Literal
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
@@ -218,7 +218,7 @@ async def list_sessions(
     agent_id: uuid.UUID,
     scope: Annotated[str, Query(description="'mine' or 'all'")] = "mine",
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List active sessions on the legacy Agent session surface."""
     agent, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)
@@ -360,7 +360,7 @@ async def create_session(
     agent_id: uuid.UUID,
     body: CreateSessionIn = CreateSessionIn(),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a direct session for the active current-tenant User."""
     _, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)
@@ -402,7 +402,7 @@ async def get_session_runtime_state(
     agent_id: uuid.UUID,
     session_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ) -> SessionRuntimeStateOut:
     """Return the one exact Direct Chat lane holder, if one exists."""
     _agent, tenant_id = await _check_direct_agent_access(
@@ -570,7 +570,7 @@ async def reconcile_direct_tool_execution(
     execution_id: uuid.UUID,
     body: ReconcileToolExecutionIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ) -> ReconcileToolExecutionOut:
     """Settle a Direct Chat unknown receipt before the user resumes its Run."""
     agent, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)
@@ -673,7 +673,7 @@ async def rename_session(
     session_id: uuid.UUID,
     body: PatchSessionIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Rename one active direct session."""
     agent, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)
@@ -699,7 +699,7 @@ async def delete_session(
     agent_id: uuid.UUID,
     session_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Soft-delete a direct session and cancel only its foreground collaboration."""
     agent, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)
@@ -799,7 +799,7 @@ async def get_session_messages(
         Query(description="Cursor '<created_at>|<id>' for the first excluded position"),
     ] = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return associated session messages by authoritative `(created_at, id)` position."""
     agent, tenant_id = await _check_direct_agent_access(db, current_user, agent_id)

--- a/backend/app/api/dingtalk.py
+++ b/backend/app/api/dingtalk.py
@@ -1,4 +1,3 @@
-from typing import Any
 """DingTalk Channel API routes.
 
 Provides Config CRUD and message handling for DingTalk bots using Stream mode.
@@ -32,7 +31,7 @@ async def configure_dingtalk_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure DingTalk bot for an agent. Fields: app_key, app_secret, agent_id (optional)."""
     agent, _ = await check_agent_access(db, current_user, agent_id)
@@ -100,7 +99,7 @@ async def configure_dingtalk_channel(
 async def get_dingtalk_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
@@ -119,7 +118,7 @@ async def get_dingtalk_channel(
 async def delete_dingtalk_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -272,7 +271,7 @@ async def process_dingtalk_message(
 async def dingtalk_callback(
     authCode: str, # DingTalk uses authCode parameter
     state: str = None,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Callback for DingTalk OAuth2 login."""
     from app.models.identity import SSOScanSession

--- a/backend/app/api/directory.py
+++ b/backend/app/api/directory.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Read-only agent directory API."""
 
 import uuid
@@ -56,7 +55,7 @@ async def get_agent_directory(
     limit: int = 50,
     offset: int = 0,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return the people and agents the source agent can currently contact."""
     await check_agent_access(db, current_user, agent_id)
@@ -79,7 +78,7 @@ async def get_agent_directory(
 async def get_custom_directory_humans(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return explicitly authorized human members in a custom Directory."""
     agent = await _require_custom_directory_manager(db, current_user, agent_id)
@@ -127,7 +126,7 @@ async def get_custom_directory_human_candidates(
     limit: int = 50,
     offset: int = 0,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return paginated human candidates that can be added to a custom Directory."""
     _validate_pagination(limit, offset)
@@ -184,7 +183,7 @@ async def add_custom_directory_human(
     agent_id: uuid.UUID,
     payload: CustomHumanDirectoryIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Add a human platform user to a custom Directory with use access."""
     agent = await _require_custom_directory_manager(db, current_user, agent_id)
@@ -216,7 +215,7 @@ async def remove_custom_directory_human(
     agent_id: uuid.UUID,
     user_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Remove a use-level human from a custom Directory."""
     await _require_custom_directory_manager(db, current_user, agent_id)
@@ -243,7 +242,7 @@ async def remove_custom_directory_human(
 async def get_custom_directory_agents(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return explicitly linked digital employees in a custom Directory."""
     await _require_custom_directory_manager(db, current_user, agent_id)
@@ -275,7 +274,7 @@ async def get_custom_directory_agent_candidates(
     limit: int = 50,
     offset: int = 0,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return paginated digital employee candidates for a custom Directory."""
     _validate_pagination(limit, offset)
@@ -321,7 +320,7 @@ async def add_custom_directory_agent(
     agent_id: uuid.UUID,
     payload: CustomAgentDirectoryIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Add a digital employee to a custom Directory."""
     agent = await _require_custom_directory_manager(db, current_user, agent_id)
@@ -361,7 +360,7 @@ async def remove_custom_directory_agent(
     agent_id: uuid.UUID,
     target_agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Remove a digital employee from a custom Directory."""
     await _require_custom_directory_manager(db, current_user, agent_id)

--- a/backend/app/api/discord_bot.py
+++ b/backend/app/api/discord_bot.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Discord Bot Channel API routes (slash command interactions)."""
 
 import uuid
@@ -28,7 +27,7 @@ async def configure_discord_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure Discord bot for an agent.
 
@@ -98,7 +97,7 @@ async def configure_discord_channel(
 async def get_discord_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
@@ -114,7 +113,7 @@ async def get_discord_channel(
 
 
 @router.get("/agents/{agent_id}/discord-channel/webhook-url")
-async def get_discord_webhook_url(agent_id: uuid.UUID, request: Request, db: Any = None):
+async def get_discord_webhook_url(agent_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
     from app.services.platform_service import platform_service
     public_base = await platform_service.get_public_base_url(db, request)
     return {"webhook_url": f"{public_base}/api/channel/discord/{agent_id}/webhook"}
@@ -124,7 +123,7 @@ async def get_discord_webhook_url(agent_id: uuid.UUID, request: Request, db: Any
 async def delete_discord_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -199,7 +198,7 @@ def _verify_discord_signature(public_key: str, body: bytes, headers: dict) -> bo
 async def discord_interaction_webhook(
     agent_id: uuid.UUID,
     request: Request,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle Discord Interaction webhooks (PING + slash commands)."""
     body_bytes = await request.body()

--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Enterprise management API routes: LLM pool, enterprise info, approvals, audit logs."""
 
 import uuid
@@ -115,7 +114,7 @@ class CheckEmailRequest(BaseModel):
 @router.post("/check-email-exists")
 async def check_email_exists(
     data: CheckEmailRequest,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Public endpoint — check if an email address is already registered on this platform.
 
@@ -388,7 +387,7 @@ async def test_llm_model(
 async def list_llm_models(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List LLM models scoped to the selected tenant."""
     tid = _llm_management_tenant_id(current_user, tenant_id)
@@ -415,7 +414,7 @@ async def add_llm_model(
     data: LLMModelCreate,
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Add a new LLM model to the tenant's pool (admin)."""
     tid = _llm_management_tenant_id(current_user, tenant_id)
@@ -452,7 +451,7 @@ async def add_llm_model(
 async def set_default_llm_model(
     model_id: uuid.UUID,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Mark this model as the tenant's default for new agents."""
     result = await db.execute(_llm_model_scope(model_id, current_user))
@@ -501,7 +500,7 @@ async def set_default_llm_model(
 async def remove_llm_model(
     model_id: uuid.UUID,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Logically delete an LLM model while retaining every historical reference."""
     query = select(LLMModel).where(LLMModel.id == model_id)
@@ -536,7 +535,7 @@ async def update_llm_model(
     model_id: uuid.UUID,
     data: LLMModelUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update an existing LLM model in the pool (admin)."""
     result = await db.execute(_llm_model_scope(model_id, current_user))
@@ -590,7 +589,7 @@ async def update_llm_model(
 @router.get("/info", response_model=list[EnterpriseInfoOut])
 async def list_enterprise_info(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List enterprise information entries for current tenant."""
     if not current_user.tenant_id:
@@ -608,7 +607,7 @@ async def update_enterprise_info(
     info_type: str,
     data: EnterpriseInfoUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create or update enterprise information for current tenant. Triggers sync to tenant agents."""
     if not current_user.tenant_id:
@@ -629,7 +628,7 @@ async def list_approvals(
     tenant_id: str | None = None,
     status_filter: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List approval requests scoped to a tenant."""
     query = select(ApprovalRequest)
@@ -670,7 +669,7 @@ async def resolve_approval(
     approval_id: uuid.UUID,
     data: ApprovalAction,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Approve or reject a pending approval request."""
     try:
@@ -690,7 +689,7 @@ async def list_audit_logs(
     tenant_id: str | None = None,
     limit: int = 50,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List audit logs scoped to a tenant (admin only)."""
     query = select(AuditLog).order_by(AuditLog.created_at.desc()).limit(limit)
@@ -711,7 +710,7 @@ async def list_audit_logs(
 async def get_enterprise_stats(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get enterprise dashboard statistics, optionally scoped to a tenant."""
     # Determine which tenant to filter by
@@ -771,7 +770,7 @@ class TenantQuotaUpdate(BaseModel):
 @router.get("/tenant-quotas")
 async def get_tenant_quotas(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get tenant quota defaults and heartbeat settings."""
     if not current_user.tenant_id:
@@ -797,7 +796,7 @@ async def get_tenant_quotas(
 async def update_tenant_quotas(
     data: TenantQuotaUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update tenant quota defaults (admin only). Enforces heartbeat floor on existing agents."""
     if not current_user.tenant_id:
@@ -854,7 +853,7 @@ class TestEmailRequest(BaseModel):
 async def send_test_email_endpoint(
     data: TestEmailRequest,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Send a test email to verify SMTP configuration (admin only)."""
     import smtplib
@@ -890,7 +889,7 @@ async def send_test_email_endpoint(
 @router.get("/email-templates")
 async def get_email_templates_endpoint(
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get email templates (current values + available variables per scenario)."""
     from app.services.system_email_service import (
@@ -915,7 +914,7 @@ class EmailTemplatesUpdate(BaseModel):
 async def update_email_templates_endpoint(
     data: EmailTemplatesUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Save email templates (admin only)."""
     from app.services.system_email_service import EMAIL_TEMPLATE_VARIABLES
@@ -1033,7 +1032,7 @@ async def _runtime_model_settings_payload(db: AsyncSession, *, tenant_id: uuid.U
 async def get_runtime_model_settings(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return the selected tenant's eligible Group Runtime model choices."""
     resolved_tenant_id = _runtime_settings_tenant_id(current_user, tenant_id)
@@ -1045,7 +1044,7 @@ async def update_runtime_model_settings(
     data: RuntimeModelSettingsUpdate,
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Persist tenant-scoped Group Runtime models, effective immediately."""
     resolved_tenant_id = _runtime_settings_tenant_id(current_user, tenant_id)
@@ -1086,7 +1085,7 @@ async def update_runtime_model_settings(
 
 @router.get("/system-settings/notification_bar/public")
 async def get_notification_bar_public(
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Public (no auth) endpoint to read the notification bar config."""
     result = await db.execute(
@@ -1106,7 +1105,7 @@ async def get_notification_bar_public(
 async def get_system_setting(
     key: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get a system setting by key."""
     _require_system_setting_access(key, current_user)
@@ -1122,7 +1121,7 @@ async def update_system_setting(
     key: str,
     data: SettingUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create or update a system setting."""
     _require_system_setting_access(key, current_user)
@@ -1240,7 +1239,7 @@ async def list_identity_providers(
     tenant_id: str | None = None,
     global_only: bool = False,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List identity providers configured for the tenant."""
     # Authorization: non-platform admins can only see their own tenant's providers
@@ -1394,7 +1393,7 @@ def _identity_provider_response(provider: IdentityProvider, sso_domain: str | No
 async def create_identity_provider(
     data: IdentityProviderCreate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new identity provider (Admin only)."""
     from app.services.auth_registry import auth_provider_registry
@@ -1445,7 +1444,7 @@ async def create_identity_provider(
 async def create_oauth2_provider(
     data: IdentityProviderOAuth2Create,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new OAuth2 identity provider with simplified fields (app_id, app_secret, authorize_url, etc.)."""
     from app.services.auth_registry import auth_provider_registry
@@ -1511,7 +1510,7 @@ async def update_oauth2_provider(
     provider_id: uuid.UUID,
     data: OAuth2ConfigUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update an OAuth2 identity provider with simplified fields."""
     from app.services.auth_registry import auth_provider_registry
@@ -1579,7 +1578,7 @@ async def update_identity_provider(
     provider_id: uuid.UUID,
     data: IdentityProviderUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update an existing identity provider."""
     from app.services.auth_registry import auth_provider_registry
@@ -1636,7 +1635,7 @@ async def update_identity_provider(
 async def delete_identity_provider(
     provider_id: uuid.UUID,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete an identity provider."""
     result = await db.execute(select(IdentityProvider).where(IdentityProvider.id == provider_id))
@@ -1675,7 +1674,7 @@ async def list_org_departments(
     tenant_id: str | None = None,
     provider_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all departments, optionally filtered by tenant or provider."""
     # Tenant isolation rules:
@@ -1742,7 +1741,7 @@ async def list_org_members(
     tenant_id: str | None = None,
     provider_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List org members, optionally filtered by department, search, tenant, or provider."""
     # Tenant isolation rules:
@@ -1825,7 +1824,7 @@ async def list_org_members(
 async def trigger_org_sync(
     provider_id: str | None = None,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Manually trigger org structure sync from a specific identity provider."""
     from app.services.org_sync_service import org_sync_service
@@ -1859,7 +1858,7 @@ async def wecom_org_sync_verify(
     timestamp: str = "",
     nonce: str = "",
     echostr: str = "",
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle WeCom receive-message-server URL verification for the org sync app.
 
@@ -2004,7 +2003,7 @@ async def _ensure_invitation_email_enabled(db: AsyncSession) -> None:
 async def create_invitation_codes(
     data: InvitationCodeCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Batch-create invitation codes for the current user's company."""
     _require_tenant_admin(current_user)
@@ -2033,7 +2032,7 @@ async def invite_users(
     data: UserInviteRequest,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Batch-invite users via email to the current user's company."""
     _require_tenant_admin(current_user)
@@ -2099,7 +2098,7 @@ async def list_invitation_codes(
     page_size: int = 20,
     search: str = "",
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List invitation codes for the current user's company."""
     _require_tenant_admin(current_user)
@@ -2143,7 +2142,7 @@ async def list_invitation_codes(
 @router.get("/invitation-codes/export")
 async def export_invitation_codes_csv(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Export invitation codes for the current user's company as CSV."""
     _require_tenant_admin(current_user)
@@ -2182,7 +2181,7 @@ async def export_invitation_codes_csv(
 async def deactivate_invitation_code(
     code_id: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Deactivate an invitation code (must belong to current user's company)."""
     _require_tenant_admin(current_user)

--- a/backend/app/api/feishu.py
+++ b/backend/app/api/feishu.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Feishu OAuth and Channel API routes."""
 
 import uuid
@@ -39,7 +38,7 @@ _USER_RESOLUTION_ERROR_TIP = (
 async def feishu_oauth_callback(
     code: str, 
     state: str = None, 
-    db: Any = None
+    db: AsyncSession = Depends(get_db)
 ):
     """Handle Feishu OAuth callback — exchange code for user session."""
     # Parse state if it's a UUID (session ID) or other context
@@ -133,7 +132,7 @@ async def configure_channel(
     agent_id: uuid.UUID,
     data: ChannelConfigCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure Feishu bot credentials for a digital employee (wizard step 5)."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -193,7 +192,7 @@ async def configure_channel(
 async def get_channel_config(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get Feishu channel configuration for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -208,7 +207,7 @@ async def get_channel_config(
 
 
 @router.get("/agents/{agent_id}/channel/webhook-url")
-async def get_webhook_url(agent_id: uuid.UUID, request: Request, db: Any = None):
+async def get_webhook_url(agent_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
     """Get the webhook URL for this agent's Feishu bot."""
     from app.services.platform_service import platform_service
     public_base = await platform_service.get_public_base_url(db, request)
@@ -219,7 +218,7 @@ async def get_webhook_url(agent_id: uuid.UUID, request: Request, db: Any = None)
 async def delete_channel_config(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Remove Feishu bot configuration for an agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/files.py
+++ b/backend/app/api/files.py
@@ -1,4 +1,3 @@
-from typing import Any
 """File management API routes for agent workspaces."""
 
 import asyncio
@@ -227,7 +226,7 @@ async def list_files(
     agent_id: uuid.UUID,
     path: str = "",
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List files and directories in an agent's file system."""
     await check_agent_access(db, current_user, agent_id)
@@ -293,7 +292,7 @@ async def read_file(
     agent_id: uuid.UUID,
     path: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Read the content of a file."""
     await check_agent_access(db, current_user, agent_id)
@@ -432,7 +431,7 @@ async def preview_file(
     agent_id: uuid.UUID,
     path: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return a browser-friendly preview payload for Workspace files."""
     await check_agent_access(db, current_user, agent_id)
@@ -563,7 +562,7 @@ async def download_file(
     token: str = "",
     inline: bool = False,
     credentials: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Download / serve a file from the agent workspace (browser-friendly).
     
@@ -624,7 +623,7 @@ async def write_file(
     path: str,
     data: FileWrite,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Write content to a file (create or overwrite)."""
     await check_agent_access(db, current_user, agent_id)
@@ -669,7 +668,7 @@ async def lock_file(
     agent_id: uuid.UUID,
     data: FileLockBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Acquire or refresh a short-lived human editing lock for a file."""
     await check_agent_access(db, current_user, agent_id)
@@ -691,7 +690,7 @@ async def unlock_file(
     agent_id: uuid.UUID,
     path: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Release the current user's edit lock for a file."""
     await check_agent_access(db, current_user, agent_id)
@@ -705,7 +704,7 @@ async def get_file_revisions(
     agent_id: uuid.UUID,
     path: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List version history for the currently opened Workspace file."""
     await check_agent_access(db, current_user, agent_id)
@@ -736,7 +735,7 @@ async def restore_file_revision(
     agent_id: uuid.UUID,
     data: RestoreRevisionBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Restore a file to a previous revision's after-content."""
     await check_agent_access(db, current_user, agent_id)
@@ -776,7 +775,7 @@ async def delete_file(
     path: str,
     expected_version_token: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete a file."""
     await _require_agent_file_delete_access(db, current_user, agent_id)
@@ -816,7 +815,7 @@ async def import_skill_to_agent(
     agent_id: uuid.UUID,
     body: ImportSkillBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Import a global skill into this agent's skills/ workspace folder.
 
@@ -866,7 +865,7 @@ async def upload_file_to_workspace(
     file: UploadFileType = FastFile(...),
     path: str = "workspace/knowledge_base",
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Upload a binary file to agent workspace."""
     await check_agent_access(db, current_user, agent_id)
@@ -1079,7 +1078,7 @@ async def agent_import_from_clawhub(
     agent_id: uuid.UUID,
     body: ClawhubImportBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Import a skill from ClawHub directly into this agent's skills/ workspace."""
     await check_agent_access(db, current_user, agent_id)
@@ -1134,7 +1133,7 @@ async def agent_import_from_url(
     agent_id: uuid.UUID,
     body: UrlImportBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Import a skill from a GitHub URL directly into this agent's skills/ workspace."""
     await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/focus.py
+++ b/backend/app/api/focus.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Structured Focus API for Aware."""
 
 import uuid
@@ -48,7 +47,7 @@ async def list_agent_focus(
     agent_id: uuid.UUID,
     include_completed: bool = True,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     return await list_focus_items(agent_id, include_completed=include_completed)
@@ -59,7 +58,7 @@ async def upsert_agent_focus(
     agent_id: uuid.UUID,
     body: FocusUpsertBody,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     if body.status not in {"in_progress", "completed"}:
@@ -83,7 +82,7 @@ async def complete_agent_focus(
     agent_id: uuid.UUID,
     key: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     item = await complete_focus_item(agent_id, key=key)

--- a/backend/app/api/gateway.py
+++ b/backend/app/api/gateway.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Gateway API for OpenClaw agent communication.
 
 OpenClaw agents authenticate via X-Api-Key header and use these endpoints
@@ -63,7 +62,7 @@ async def _get_agent_by_key(api_key: str, db: AsyncSession) -> Agent:
 @router.get("/poll", response_model=GatewayPollResponse)
 async def poll_messages(
     x_api_key: str = Header(..., alias="X-Api-Key"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """OpenClaw agent polls for pending messages.
 
@@ -219,7 +218,7 @@ async def poll_messages(
 async def report_result(
     body: GatewayReportRequest,
     x_api_key: str = Header(None, alias="X-Api-Key"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """OpenClaw agent reports the result of a processed message."""
     if not x_api_key:
@@ -344,7 +343,7 @@ async def report_result(
 @router.post("/heartbeat")
 async def heartbeat(
     x_api_key: str = Header(..., alias="X-Api-Key"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Pure heartbeat ping — keeps the OpenClaw agent marked as online."""
     agent = await _get_agent_by_key(x_api_key, db)
@@ -360,7 +359,7 @@ async def heartbeat(
 async def send_message(
     body: GatewaySendMessageRequest,
     x_api_key: str = Header(..., alias="X-Api-Key"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """OpenClaw agent sends a message to a person or another agent.
 
@@ -572,7 +571,7 @@ async def get_setup_guide(
     agent_id: uuid.UUID,
     x_api_key: str = Header(..., alias="X-Api-Key"),
     accept_language: str | None = Header(None, alias="Accept-Language"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return the pre-filled Skill file and Heartbeat instruction for this agent."""
     agent = await _get_agent_by_key(x_api_key, db)

--- a/backend/app/api/google_workspace.py
+++ b/backend/app/api/google_workspace.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Google Workspace OAuth callback routes."""
 
 import uuid
@@ -39,7 +38,7 @@ async def get_google_workspace_sync_authorize_url(
     provider_id: uuid.UUID,
     request: Request,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     provider = await get_google_provider(db, provider_id)
     if current_user.role != "platform_admin" and provider.tenant_id != current_user.tenant_id:
@@ -195,7 +194,7 @@ async def google_workspace_callback(
     code: str,
     state: str | None = None,
     request: Request = None,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Unified callback for Google Workspace SSO login and admin authorization."""
     parsed_state = parse_google_oauth_state(state) if state else None

--- a/backend/app/api/groups.py
+++ b/backend/app/api/groups.py
@@ -512,7 +512,7 @@ async def _message_outputs(
 async def create_group(
     body: CreateGroupIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -545,7 +545,7 @@ async def create_group(
 @router.get("", response_model=list[GroupOut])
 async def list_groups(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -562,7 +562,7 @@ async def list_tenant_member_candidates(
     participant_type: Annotated[Literal["user", "agent"], Query()],
     limit: Annotated[int, Query(ge=1, le=100)] = 100,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Candidates for the create-group flow, before any group exists."""
     tenant_id = _tenant_id(current_user)
@@ -586,7 +586,7 @@ async def list_tenant_member_candidates(
 async def get_group(
     group_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -606,7 +606,7 @@ async def patch_group(
     group_id: uuid.UUID,
     body: PatchGroupIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     if "name" not in body.model_fields_set and "description" not in body.model_fields_set:
         raise HTTPException(status_code=400, detail="At least one field must be supplied")
@@ -639,7 +639,7 @@ async def patch_group(
 async def delete_group(
     group_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -666,7 +666,7 @@ async def delete_group(
 async def list_group_members(
     group_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -691,7 +691,7 @@ async def list_group_member_candidates(
     participant_type: Annotated[Literal["user", "agent"], Query()],
     limit: Annotated[int, Query(ge=1, le=100)] = 100,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -722,7 +722,7 @@ async def invite_group_member(
     group_id: uuid.UUID,
     body: InviteGroupMemberIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -755,7 +755,7 @@ async def remove_group_member(
     group_id: uuid.UUID,
     member_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -784,7 +784,7 @@ async def remove_group_member(
 async def list_group_sessions(
     group_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -819,7 +819,7 @@ async def create_group_session(
     group_id: uuid.UUID,
     body: CreateGroupSessionIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -850,7 +850,7 @@ async def patch_group_session(
     session_id: uuid.UUID,
     body: PatchGroupSessionIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -884,7 +884,7 @@ async def delete_group_session(
     group_id: uuid.UUID,
     session_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -924,7 +924,7 @@ async def mark_group_session_read(
     session_id: uuid.UUID,
     body: MarkGroupSessionReadIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -963,7 +963,7 @@ async def list_group_messages(
         Query(description="Cursor '<created_at>|<id>' for the last seen position"),
     ] = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -994,7 +994,7 @@ async def create_group_message(
     body: CreateGroupMessageIn,
     request: Request,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1052,7 +1052,7 @@ async def list_active_group_runs(
     group_id: uuid.UUID,
     session_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return exact non-terminal Runs that should animate this group Session."""
     tenant_id = _tenant_id(current_user)
@@ -1119,7 +1119,7 @@ async def get_group_run_state(
     session_id: uuid.UUID,
     run_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1158,7 +1158,7 @@ async def cancel_group_run(
     session_id: uuid.UUID,
     run_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1203,7 +1203,7 @@ async def cancel_group_run(
 async def get_group_announcement(
     group_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1226,7 +1226,7 @@ async def put_group_announcement(
     group_id: uuid.UUID,
     body: GroupTextFileIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1259,7 +1259,7 @@ async def get_group_agent_memory(
     group_id: uuid.UUID,
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1284,7 +1284,7 @@ async def put_group_agent_memory(
     agent_id: uuid.UUID,
     body: GroupTextFileIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1325,7 +1325,7 @@ async def delete_group_agent_memory(
     agent_id: uuid.UUID,
     expected_version_token: Annotated[str | None, Query()] = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1361,7 +1361,7 @@ async def get_group_session_summary(
     group_id: uuid.UUID,
     session_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1394,7 +1394,7 @@ async def list_group_workspace(
     group_id: uuid.UUID,
     path: Annotated[str, Query(max_length=500)] = "",
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1418,7 +1418,7 @@ async def get_group_workspace_file(
     group_id: uuid.UUID,
     path: Annotated[str, Query(min_length=1, max_length=500)],
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1443,7 +1443,7 @@ async def put_group_workspace_file(
     body: GroupWorkspaceFileIn,
     path: Annotated[str, Query(min_length=1, max_length=500)],
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)
@@ -1484,7 +1484,7 @@ async def upload_group_workspace_file(
     expected_version_token: Annotated[str | None, Query()] = None,
     require_absent: Annotated[bool, Query()] = False,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Upload one group workspace file without converting binary bytes to text."""
     tenant_id = _tenant_id(current_user)
@@ -1561,7 +1561,7 @@ async def download_group_workspace_file(
     token: str = "",
     inline: bool = False,
     credentials: HTTPAuthorizationCredentials | None = Depends(HTTPBearer(auto_error=False)),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Download a group workspace file with membership authorization."""
     current_user = await _download_user(token=token, credentials=credentials, db=db)
@@ -1613,7 +1613,7 @@ async def delete_group_workspace_file(
     path: Annotated[str, Query(min_length=1, max_length=500)],
     expected_version_token: Annotated[str | None, Query()] = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     tenant_id = _tenant_id(current_user)
     participant = await _current_participant(db, current_user)

--- a/backend/app/api/messages.py
+++ b/backend/app/api/messages.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Messages API — inbox, unread count, mark as read.
 
 After the Participant abstraction migration, agent-to-agent messages are stored
@@ -27,7 +26,7 @@ router = APIRouter(tags=["messages"])
 async def get_inbox(
     limit: int = Query(50, le=200),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get agent-to-agent messages for agents the current user manages.
 
@@ -85,7 +84,7 @@ async def get_inbox(
 @router.get("/messages/unread-count")
 async def get_unread_count(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get count of unread agent-to-agent messages for the current user's agents."""
     agent_ids_q = await query_dao.execute(db, select(Agent.id).where(Agent.creator_id == current_user.id))

--- a/backend/app/api/notification.py
+++ b/backend/app/api/notification.py
@@ -1,7 +1,7 @@
 """Notification API — list, count, mark-read, and broadcast."""
 
 import uuid
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -39,7 +39,7 @@ async def list_notifications(
     unread_only: bool = Query(False),
     category: Optional[str] = Query(None),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List notifications for the current user, newest first."""
     query = select(Notification).where(Notification.user_id == current_user.id)
@@ -69,7 +69,7 @@ async def list_notifications(
 async def get_unread_count(
     category: Optional[str] = Query(None),
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get the number of unread notifications for the current user."""
     query = select(func.count(Notification.id)).where(
@@ -85,7 +85,7 @@ async def get_unread_count(
 async def mark_read(
     notification_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Mark a single notification as read."""
     await query_dao.execute(db, 
@@ -100,7 +100,7 @@ async def mark_read(
 @router.post("/notifications/read-all")
 async def mark_all_read(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Mark all notifications as read for the current user."""
     await query_dao.execute(db, 
@@ -125,7 +125,7 @@ async def broadcast_notification(
     req: BroadcastRequest,
     background_tasks: BackgroundTasks,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Send a notification to all users and agents in the current tenant.
     Requires org_admin or platform_admin role."""

--- a/backend/app/api/onboarding.py
+++ b/backend/app/api/onboarding.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Company onboarding APIs."""
 
 import uuid
@@ -177,7 +176,7 @@ async def _create_personal_assistant(
 @router.get("/status")
 async def get_onboarding_status(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return onboarding state for the current user/company."""
     return _status_payload(await _get_row(db, current_user))
@@ -187,7 +186,7 @@ async def get_onboarding_status(
 async def start_onboarding(
     data: OnboardingStartRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Start or resume onboarding for the current user/company."""
     row = await _ensure_row(db, current_user, data.entry_mode)
@@ -199,7 +198,7 @@ async def start_onboarding(
 async def create_personal_assistant(
     data: PersonalAssistantRequest,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create the user's private assistant and advance onboarding."""
     row = await _ensure_row(db, current_user, "join")
@@ -228,7 +227,7 @@ async def create_personal_assistant(
 @router.post("/complete")
 async def complete_onboarding(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Mark the current user/company onboarding as completed."""
     row = await _get_row(db, current_user)

--- a/backend/app/api/organization.py
+++ b/backend/app/api/organization.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Organization management API routes (users only)."""
 
 import uuid
@@ -29,7 +28,7 @@ def _is_platform_admin(user: User) -> bool:
 async def list_users(
     tenant_id: uuid.UUID | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List users, optionally filtered by tenant."""
     query = (
@@ -54,7 +53,7 @@ async def admin_update_user(
     user_id: uuid.UUID,
     data: UserUpdate,
     current_user: User = Depends(get_current_admin),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Admin update user profile."""
     query = (

--- a/backend/app/api/pages.py
+++ b/backend/app/api/pages.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Public pages API — serves published HTML without authentication."""
 
 import uuid
@@ -24,7 +23,7 @@ router = APIRouter(prefix="/pages", tags=["pages"])
 # ── Public render (NO auth) ────────────────────────────
 
 @public_router.get("/p/{short_id}")
-async def render_page(short_id: str, db: Any = None):
+async def render_page(short_id: str, db: AsyncSession = Depends(get_db)):
     """Serve a published HTML page. No authentication required."""
     result = await query_dao.execute(db, 
         select(PublishedPage).where(PublishedPage.short_id == short_id)
@@ -64,7 +63,7 @@ async def render_page(short_id: str, db: Any = None):
 async def list_pages(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List published pages for an agent."""
     from app.core.permissions import check_agent_access

--- a/backend/app/api/relationships.py
+++ b/backend/app/api/relationships.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Legacy agent relationship management API.
 
 These endpoints are retained for OKR, gateway, and historical compatibility.
@@ -130,7 +129,7 @@ def _dedupe_agent_relationships(items: list[AgentRelationshipIn], agent_id: uuid
 async def get_relationships(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: get manually stored human relationship rows for this agent."""
     from app.models.identity import IdentityProvider
@@ -188,7 +187,7 @@ async def search_human_relationship_candidates(
     agent_id: uuid.UUID,
     search: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: search org members that can be stored as relationship rows."""
     from app.models.identity import IdentityProvider
@@ -298,7 +297,7 @@ async def save_relationships(
     agent_id: uuid.UUID,
     data: RelationshipBatchIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: replace all manually stored human relationship rows."""
     _agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -380,7 +379,7 @@ async def delete_relationship(
     agent_id: uuid.UUID,
     rel_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete a single human relationship."""
     _agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -406,7 +405,7 @@ async def search_visible_agents(
     agent_id: uuid.UUID,
     search: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Search manageable agent candidates for relationship creation."""
     source_agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -446,7 +445,7 @@ async def search_visible_agents(
 async def get_agent_relationships(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: get manually stored agent-to-agent relationship rows."""
     await check_agent_access(db, current_user, agent_id)
@@ -481,7 +480,7 @@ async def get_agent_relationships(
 async def get_agent_relationship_candidates(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: backward-compatible alias for searchable agent candidates."""
     return await search_visible_agents(
@@ -497,7 +496,7 @@ async def save_agent_relationships(
     agent_id: uuid.UUID,
     data: AgentRelationshipBatchIn,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: replace all manually stored agent-to-agent relationship rows."""
     source_agent, access_level = await check_agent_access(db, current_user, agent_id)
@@ -542,7 +541,7 @@ async def delete_agent_relationship(
     agent_id: uuid.UUID,
     rel_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Legacy: delete a single manually stored agent-to-agent relationship row."""
     _agent, access_level = await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/schedules.py
+++ b/backend/app/api/schedules.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Schedule API — CRUD for agent cron jobs."""
 
 import uuid
@@ -56,7 +55,7 @@ class ScheduleOut(BaseModel):
 async def list_schedules(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all schedules for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -85,7 +84,7 @@ async def create_schedule(
     agent_id: uuid.UUID,
     data: ScheduleCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new schedule for an agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -117,7 +116,7 @@ async def update_schedule(
     schedule_id: uuid.UUID,
     data: ScheduleUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update a schedule."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -151,7 +150,7 @@ async def delete_schedule(
     agent_id: uuid.UUID,
     schedule_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete a schedule."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -174,7 +173,7 @@ async def trigger_schedule(
     agent_id: uuid.UUID,
     schedule_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Manually trigger a schedule execution."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -217,7 +216,7 @@ async def get_schedule_history(
     agent_id: uuid.UUID,
     schedule_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get execution history for a schedule from activity logs."""
     await check_agent_access(db, current_user, agent_id)

--- a/backend/app/api/slack.py
+++ b/backend/app/api/slack.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Slack Bot Channel API routes."""
 
 import hashlib
@@ -35,7 +34,7 @@ async def configure_slack_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure Slack bot for an agent. Fields: bot_token, signing_secret."""
     agent, _ = await check_agent_access(db, current_user, agent_id)
@@ -78,7 +77,7 @@ async def configure_slack_channel(
 async def get_slack_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
@@ -94,7 +93,7 @@ async def get_slack_channel(
 
 
 @router.get("/agents/{agent_id}/slack-channel/webhook-url")
-async def get_slack_webhook_url(agent_id: uuid.UUID, request: Request, db: Any = None):
+async def get_slack_webhook_url(agent_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
     from app.services.platform_service import platform_service
     public_base = await platform_service.get_public_base_url(db, request)
     return {"webhook_url": f"{public_base}/api/channel/slack/{agent_id}/webhook"}
@@ -104,7 +103,7 @@ async def get_slack_webhook_url(agent_id: uuid.UUID, request: Request, db: Any =
 async def delete_slack_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -157,7 +156,7 @@ async def _send_slack_messages(bot_token: str, channel: str, text: str) -> None:
 async def slack_event_webhook(
     agent_id: uuid.UUID,
     request: Request,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle Slack Event API callbacks."""
     body_bytes = await request.body()

--- a/backend/app/api/sso.py
+++ b/backend/app/api/sso.py
@@ -1,4 +1,3 @@
-from typing import Any
 import uuid
 from datetime import datetime, timedelta, timezone
 from urllib.parse import quote
@@ -17,7 +16,7 @@ router = APIRouter(tags=["sso"])
 @router.post("/sso/session")
 async def create_sso_session(
     tenant_id: uuid.UUID | None = None,
-    db: Any = None
+    db: AsyncSession = Depends(get_db)
 ):
     """Create a new SSO scan session for QR code login."""
     session = SSOScanSession(
@@ -31,7 +30,7 @@ async def create_sso_session(
     return {"session_id": str(session.id), "expires_at": session.expires_at}
 
 @router.get("/sso/session/{sid}/status")
-async def get_sso_session_status(sid: uuid.UUID, db: Any = None):
+async def get_sso_session_status(sid: uuid.UUID, db: AsyncSession = Depends(get_db)):
     """Check the status of an SSO scan session."""
     result = await query_dao.execute(db, select(SSOScanSession).where(SSOScanSession.id == sid))
     session = result.scalar_one_or_none()
@@ -72,7 +71,7 @@ async def get_sso_session_status(sid: uuid.UUID, db: Any = None):
     return response
 
 @router.put("/sso/session/{sid}/scan")
-async def mark_sso_session_scanned(sid: uuid.UUID, db: Any = None):
+async def mark_sso_session_scanned(sid: uuid.UUID, db: AsyncSession = Depends(get_db)):
     """Optional: Mark session as 'scanned' when the landing page loads on mobile."""
     result = await query_dao.execute(db, select(SSOScanSession).where(SSOScanSession.id == sid))
     session = result.scalar_one_or_none()
@@ -82,7 +81,7 @@ async def mark_sso_session_scanned(sid: uuid.UUID, db: Any = None):
     return {"status": "ok"}
 
 @router.get("/sso/config")
-async def get_sso_config(sid: uuid.UUID, request: Request, db: Any = None):
+async def get_sso_config(sid: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
     """List active SSO providers with their redirect URLs for the specified session ID."""
     # 1. Resolve session to get tenant context
     res = await query_dao.execute(db, select(SSOScanSession).where(SSOScanSession.id == sid))

--- a/backend/app/api/tasks.py
+++ b/backend/app/api/tasks.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Task management API routes."""
 
 import uuid
@@ -35,7 +34,7 @@ async def list_tasks(
     status_filter: str | None = None,
     type_filter: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List tasks for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -66,7 +65,7 @@ async def create_task(
     agent_id: uuid.UUID,
     data: TaskCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new task for an agent."""
     agent, _access = await check_agent_access(db, current_user, agent_id)
@@ -115,7 +114,7 @@ async def update_task(
     task_id: uuid.UUID,
     data: TaskUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update a task."""
     await check_agent_access(db, current_user, agent_id)
@@ -135,7 +134,7 @@ async def get_task_logs(
     agent_id: uuid.UUID,
     task_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get progress logs for a task."""
     await check_agent_access(db, current_user, agent_id)
@@ -151,7 +150,7 @@ async def add_task_log(
     task_id: uuid.UUID,
     data: TaskLogCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Add a progress log entry to a task."""
     await check_agent_access(db, current_user, agent_id)
@@ -166,7 +165,7 @@ async def trigger_task(
     agent_id: uuid.UUID,
     task_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Manually trigger a supervision task execution (for testing)."""
     from app.core.permissions import is_agent_expired

--- a/backend/app/api/teams.py
+++ b/backend/app/api/teams.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Microsoft Teams Bot Channel API routes."""
 
 import json
@@ -219,7 +218,7 @@ async def configure_teams_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure Microsoft Teams bot for an agent. Fields: app_id, app_secret."""
     agent, _ = await check_agent_access(db, current_user, agent_id)
@@ -281,7 +280,7 @@ async def configure_teams_channel(
 async def get_teams_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get Microsoft Teams channel configuration for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -302,7 +301,7 @@ async def get_teams_webhook_url(
     agent_id: uuid.UUID,
     request: Request,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get the Microsoft Teams webhook URL for an agent."""
     await check_agent_access(db, current_user, agent_id)
@@ -315,7 +314,7 @@ async def get_teams_webhook_url(
 async def delete_teams_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete Microsoft Teams channel configuration for an agent."""
     agent, _ = await check_agent_access(db, current_user, agent_id)
@@ -343,7 +342,7 @@ _processed_teams_events: set[str] = set()
 async def teams_event_webhook(
     agent_id: uuid.UUID,
     request: Request,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle Microsoft Teams Bot Framework callbacks."""
     try:

--- a/backend/app/api/tenants.py
+++ b/backend/app/api/tenants.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Tenant (Company) management API.
 
 Public endpoints for self-service company creation and joining.
@@ -154,7 +153,7 @@ class SelfCreateResponse(BaseModel):
 async def self_create_company(
     data: TenantCreate,
     current_user: User = Depends(get_authenticated_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new company (self-service). The creator becomes org_admin.
 
@@ -255,7 +254,7 @@ class JoinResponse(BaseModel):
 async def join_company(
     data: JoinRequest,
     current_user: User = Depends(get_authenticated_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Join an existing company using an invitation code.
 
@@ -377,7 +376,7 @@ async def join_company(
 # ─── Registration Config ───────────────────────────────
 
 @router.get("/registration-config")
-async def get_registration_config(db: Any = None):
+async def get_registration_config(db: AsyncSession = Depends(get_db)):
     """Public — returns whether self-creation of companies is allowed."""
     from app.models.system_settings import SystemSetting
     result = await query_dao.execute(db, 
@@ -393,7 +392,7 @@ async def get_registration_config(db: Any = None):
 @router.get("/resolve-by-domain")
 async def resolve_tenant_by_domain(
     domain: str,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Resolve a tenant by its sso_domain or subdomain slug.
 
@@ -461,7 +460,7 @@ async def resolve_tenant_by_domain(
 @router.get("/", response_model=list[TenantOut])
 async def list_tenants(
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all tenants (platform_admin only)."""
     result = await query_dao.execute(db, select(Tenant).order_by(Tenant.created_at.desc()))
@@ -471,7 +470,7 @@ async def list_tenants(
 @router.get("/me", response_model=TenantOut)
 async def get_my_tenant(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return the current user's own tenant. Any authenticated member can read
     this — the wizard and the chat model switcher need default_model_id, which
@@ -489,7 +488,7 @@ async def get_my_tenant(
 @router.get("/me/token-usage")
 async def get_my_tenant_token_usage(
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Return aggregate token and prompt-cache usage for the current company."""
     if not current_user.tenant_id:
@@ -530,7 +529,7 @@ async def get_my_tenant_token_usage(
 async def get_tenant(
     tenant_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get tenant details. Platform admins can view any; org_admins only their own."""
     if current_user.role not in ("platform_admin", "org_admin"):
@@ -552,7 +551,7 @@ async def update_tenant(
     tenant_id: uuid.UUID,
     data: TenantUpdate,
     current_user: User = Depends(require_role("org_admin", "platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update tenant settings. Platform admins can update any; org_admins only their own."""
     if current_user.role == "org_admin":
@@ -595,7 +594,7 @@ async def upload_tenant_logo(
     tenant_id: uuid.UUID,
     file: UploadFile = File(...),
     current_user: User = Depends(require_role("org_admin", "platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Upload a cropped square company logo.
 
@@ -637,7 +636,7 @@ async def upload_tenant_logo(
 async def delete_tenant_logo(
     tenant_id: uuid.UUID,
     current_user: User = Depends(require_role("org_admin", "platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Remove a custom company logo and fall back to the generated default."""
     tenant = await _get_updateable_tenant(tenant_id, current_user, db)
@@ -660,7 +659,7 @@ async def assign_user_to_tenant(
     user_id: uuid.UUID,
     role: str = "member",
     current_user: User = Depends(require_role("platform_admin")),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Assign a user to a tenant with a specific role."""
     # Verify tenant
@@ -689,7 +688,7 @@ async def assign_user_to_tenant(
 async def delete_tenant(
     tenant_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Permanently delete a company and ALL its data.
 

--- a/backend/app/api/tools.py
+++ b/backend/app/api/tools.py
@@ -1,4 +1,3 @@
-from typing import Any
 """Tool management API — CRUD for tools and per-agent assignments."""
 
 import uuid
@@ -229,7 +228,7 @@ class CategoryConfigUpdate(BaseModel):
 async def list_tools(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List platform tools scoped by tenant (builtin + tenant-specific)."""
     _require_tool_manager(current_user)
@@ -274,7 +273,7 @@ async def list_tools(
 async def create_tool(
     data: ToolCreate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Create a new tool (typically MCP).
 
@@ -327,7 +326,7 @@ class BulkToolUpdateItem(BaseModel):
 async def update_tools_bulk(
     updates: list[BulkToolUpdateItem],
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Bulk update the enabled status of multiple tools."""
     _require_tool_manager(current_user)
@@ -351,7 +350,7 @@ async def update_tool(
     tool_id: uuid.UUID,
     data: ToolUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update a tool."""
     _require_tool_manager(current_user)
@@ -386,7 +385,7 @@ async def update_tool(
 async def delete_tool(
     tool_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Delete a tool (only non-builtin)."""
     _require_tool_manager(current_user)
@@ -409,7 +408,7 @@ async def delete_tool(
 async def get_agent_tools(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get tools for a specific agent with their enabled status."""
     # Determine if this is a system agent (e.g. OKR Agent).
@@ -498,7 +497,7 @@ async def update_agent_tools(
     agent_id: uuid.UUID,
     updates: list[AgentToolUpdate],
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update tool assignments for an agent."""
     agent_obj = await _require_agent_tool_manager(db, current_user, agent_id)
@@ -542,7 +541,7 @@ async def get_mcp_authorization_status(
     tool_id: uuid.UUID,
     response: Response,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Read one assigned Smithery connection for an authorized manager."""
     response.headers["Cache-Control"] = "no-store"
@@ -653,7 +652,7 @@ class MCPServerUpdate(BaseModel):
 async def update_mcp_server(
     data: MCPServerUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Bulk-update the Server URL and API Key for all tools from an MCP server.
 
@@ -705,7 +704,7 @@ async def update_mcp_server(
 async def list_agent_installed_tools(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Admin endpoint: list user-installed tools scoped by tenant."""
     _require_tool_manager(current_user)
@@ -757,7 +756,7 @@ async def list_agent_installed_tools(
 async def delete_agent_tool(
     agent_tool_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Admin: remove an agent-tool assignment. Also deletes the tool record if no other agents use it."""
     _require_tool_manager(current_user)
@@ -791,7 +790,7 @@ async def get_agent_tool_config(
     agent_id: uuid.UUID,
     tool_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get merged tool config (global defaults + agent overrides) and config_schema.
 
@@ -836,7 +835,7 @@ async def update_agent_tool_config(
     tool_id: uuid.UUID,
     data: AgentToolConfigUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Save per-agent config override for a tool."""
     agent = await _require_agent_tool_manager(db, current_user, agent_id)
@@ -874,7 +873,7 @@ async def update_agent_tool_config(
 async def get_agent_tools_with_config(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get agent's enabled tools with per-agent config info and config_schema for settings UI.
 
@@ -1017,7 +1016,7 @@ async def get_category_config(
     agent_id: uuid.UUID,
     category: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Get shared configuration for a tool category.
 
@@ -1100,7 +1099,7 @@ async def update_category_config(
     category: str,
     data: CategoryConfigUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update or create shared configuration for a tool category."""
     from app.core.permissions import is_agent_creator
@@ -1157,7 +1156,7 @@ async def delete_category_config(
     agent_id: uuid.UUID,
     category: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Remove shared configuration for a tool category."""
     from app.core.permissions import is_agent_creator
@@ -1181,7 +1180,7 @@ async def test_category_config(
     agent_id: uuid.UUID,
     category: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Test connectivity for a tool category."""
     await _require_agent_tool_manager(db, current_user, agent_id)

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,4 +1,3 @@
-from typing import Any
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -52,7 +51,7 @@ class UserOut(BaseModel):
 async def list_users(
     tenant_id: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """List all users in the specified tenant (admin only)."""
     if current_user.role not in ("platform_admin", "org_admin"):
@@ -107,7 +106,7 @@ async def update_user_quota(
     user_id: uuid.UUID,
     data: UserQuotaUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Update a user's quota settings (admin only)."""
     if current_user.role not in ("platform_admin", "org_admin"):
@@ -169,7 +168,7 @@ async def update_user_role(
     user_id: uuid.UUID,
     data: RoleUpdate,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Change a user's role within the same company.
 

--- a/backend/app/api/wechat.py
+++ b/backend/app/api/wechat.py
@@ -1,7 +1,6 @@
 """WeChat iLink Bot channel API routes."""
 
 from __future__ import annotations
-from typing import Any
 
 import asyncio
 import uuid
@@ -58,7 +57,7 @@ async def create_wechat_qrcode(
     agent_id: uuid.UUID,
     data: dict | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -85,7 +84,7 @@ async def get_wechat_qrcode_status(
     qrcode: str,
     route_tag: str | None = None,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -158,7 +157,7 @@ async def get_wechat_qrcode_image(
     agent_id: uuid.UUID,
     url: str,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -178,7 +177,7 @@ async def get_wechat_qrcode_image(
 async def get_wechat_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await query_dao.execute(db, 
@@ -197,7 +196,7 @@ async def get_wechat_channel(
 async def delete_wechat_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):

--- a/backend/app/api/wecom.py
+++ b/backend/app/api/wecom.py
@@ -1,4 +1,3 @@
-from typing import Any
 """WeCom (企业微信) Channel API routes.
 
 Provides Config CRUD and webhook-based message handling with AES encryption.
@@ -112,7 +111,7 @@ _VERIFY_FILENAME_RE = re.compile(r"^WW_verify_[A-Za-z0-9_]{1,64}\.txt$")
 @router.get("/wecom-verify/{filename}")
 async def serve_wecom_verify_file(
     filename: str,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Serve a WeCom domain verification file.
 
@@ -156,7 +155,7 @@ async def configure_wecom_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Configure WeCom bot for an agent.
 
@@ -247,7 +246,7 @@ async def configure_wecom_channel(
 async def get_wecom_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
@@ -272,7 +271,7 @@ async def get_wecom_channel(
 async def get_wecom_webhook_url(
     agent_id: uuid.UUID,
     request: Request,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     public_base = await platform_service.get_public_base_url(db, request)
     return {"webhook_url": f"{public_base}/api/channel/wecom/{agent_id}/webhook"}
@@ -282,7 +281,7 @@ async def get_wecom_webhook_url(
 async def delete_wecom_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -314,7 +313,7 @@ async def wecom_verify_webhook(
     timestamp: str = "",
     nonce: str = "",
     echostr: str = "",
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle WeCom callback URL verification (GET request)."""
     result = await db.execute(
@@ -352,7 +351,7 @@ async def wecom_event_webhook(
     msg_signature: str = "",
     timestamp: str = "",
     nonce: str = "",
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     """Handle WeCom message callback (POST request with encrypted XML)."""
     body_bytes = await request.body()
@@ -608,7 +607,7 @@ async def _process_wecom_text(
 async def wecom_callback(
     code: str,
     state: str = None,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     # 1. Resolve session to get tenant context
     tenant_id = None

--- a/backend/app/api/whatsapp.py
+++ b/backend/app/api/whatsapp.py
@@ -1,7 +1,6 @@
 """WhatsApp Cloud API channel routes."""
 
 from __future__ import annotations
-from typing import Any
 
 import hashlib
 import hmac
@@ -54,7 +53,7 @@ async def configure_whatsapp_channel(
     agent_id: uuid.UUID,
     data: dict,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -106,7 +105,7 @@ async def configure_whatsapp_channel(
 async def get_whatsapp_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     await check_agent_access(db, current_user, agent_id)
     result = await db.execute(
@@ -122,7 +121,7 @@ async def get_whatsapp_channel(
 
 
 @router.get("/agents/{agent_id}/whatsapp-channel/webhook-url")
-async def get_whatsapp_webhook_url(agent_id: uuid.UUID, request: Request, db: Any = None):
+async def get_whatsapp_webhook_url(agent_id: uuid.UUID, request: Request, db: AsyncSession = Depends(get_db)):
     from app.services.platform_service import platform_service
 
     public_base = await platform_service.get_public_base_url(db, request)
@@ -133,7 +132,7 @@ async def get_whatsapp_webhook_url(agent_id: uuid.UUID, request: Request, db: An
 async def delete_whatsapp_channel(
     agent_id: uuid.UUID,
     current_user: User = Depends(get_current_user),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     agent, _ = await check_agent_access(db, current_user, agent_id)
     if not is_agent_creator(current_user, agent):
@@ -157,7 +156,7 @@ async def whatsapp_verify_webhook(
     hub_mode: str = Query("", alias="hub.mode"),
     hub_verify_token: str = Query("", alias="hub.verify_token"),
     hub_challenge: str = Query("", alias="hub.challenge"),
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     result = await db.execute(
         select(ChannelConfig).where(
@@ -178,7 +177,7 @@ async def whatsapp_verify_webhook(
 async def whatsapp_event_webhook(
     agent_id: uuid.UUID,
     request: Request,
-    db: Any = None,
+    db: AsyncSession = Depends(get_db),
 ):
     body = await request.body()
     result = await db.execute(


### PR DESCRIPTION
f0874c39 ("convert `Depends(get_db)` to `db: Any = None` across API endpoints to release connection pool early") changed 275 endpoint signatures but only touched `app/api/**`; no mechanism was added to supply the session.

FastAPI treats an un-annotated `db: Any = None` parameter as an optional **query** parameter, so `db` is always `None` at runtime and every endpoint that touches it raises:

```
AttributeError: 'NoneType' object has no attribute 'execute'
AttributeError: 'NoneType' object has no attribute 'add'
```

### Reproduction

Confirmed on a deployment running current `main`. Both are public, unauthenticated endpoints:

```
POST /api/enterprise/check-email-exists   -> 500
POST /api/sso/session                     -> 500
```

### Why it is easy to miss

Endpoints that never declared a `db` parameter and open their own transaction — e.g. `POST /api/auth/login` — are unaffected, so basic email/password login keeps working.

`POST /api/sso/session` breaking is the most damaging case: the login page calls it before `/sso/config` (`frontend/src/pages/Login.tsx`), so the entire SSO provider section silently fails to render with no visible error.

### This PR

Reverts f0874c39 to restore working behaviour.

If the connection-pool optimisation is still wanted, each converted endpoint needs to actually acquire a session in its body (e.g. `async with transaction() as db:`) rather than only changing the signature. That is a substantially larger change and would benefit from tests that exercise the converted endpoints — none currently cover them, which is why this shipped.