### PR TITLE
fix(sso): honour sso_custom_domain_redirect_enabled in /sso/config

### DIFF
--- a/backend/app/api/sso.py
+++ b/backend/app/api/sso.py
@@ -111,7 +111,16 @@ async def get_sso_config(sid: uuid.UUID, request: Request, db: Any = None):
         from app.models.tenant import Tenant
         tenant_result = await query_dao.execute(db, select(Tenant).where(Tenant.id == session.tenant_id))
         tenant_obj = tenant_result.scalar_one_or_none()
-        public_base = await platform_service.get_tenant_sso_base_url(db, tenant_obj, request)
+        # get_tenant_sso_base_url() expects the caller to pre-resolve this flag
+        # (see its docstring); app/api/auth.py does so already. Without it the
+        # default of True is used and the admin-facing
+        # `sso_custom_domain_redirect_enabled` setting is silently ignored.
+        from app.dao import system_setting_dao
+
+        sso_redirect_enabled = await system_setting_dao.is_sso_custom_domain_redirect_enabled()
+        public_base = await platform_service.get_tenant_sso_base_url(
+            db, tenant_obj, request, sso_redirect_enabled=sso_redirect_enabled
+        )
     else:
         public_base = await platform_service.get_public_base_url(db, request)
     


### PR DESCRIPTION
`get_sso_config()` calls `get_tenant_sso_base_url()` without passing `sso_redirect_enabled`, so the parameter defaults to `True` and the `sso_custom_domain_redirect_enabled` platform setting is ignored on this path.

The method's own docstring states the caller should pre-resolve the flag via `system_setting_dao.is_sso_custom_domain_redirect_enabled()`, and `app/api/auth.py` already does exactly that — `/sso/config` is inconsistent with it.

### Impact

For single-domain deployments (one host serving the platform, admin has turned the setting **off**), `get_tenant_sso_base_url()` falls through to the tenant-subdomain branch and rewrites `app.example.com` into `{tenant.slug}.example.com`. Every SSO button on the login page then points at a host that does not exist, and turning the setting off has no effect because this call site never reads it.

### This PR

Resolves the flag the same way `auth.py` does and passes it through. One call site, no behaviour change for deployments that leave the setting enabled.