### PR TITLE
fix(api): correct tenant_id UUID handling in two list endpoints

### DIFF
--- a/backend/app/api/enterprise.py
+++ b/backend/app/api/enterprise.py
@@ -398,7 +398,7 @@ async def list_llm_models(
         .order_by(LLMModel.created_at.desc())
     )
     if tid:
-        query = query.where(LLMModel.tenant_id == uuid.UUID(tid))
+        query = query.where(LLMModel.tenant_id == tid)
     result = await db.execute(query)
     models = []
     for m in result.scalars().all():


### PR DESCRIPTION
## Summary## Summary

`GET /api/enterprise/llm-models` returns HTTP 500 on upstream `main` even with a valid tenant and row in the DB.

Root cause: `backend/app/api/enterprise.py:401` wraps the path parameter `tid` (already typed `uuid.UUID`, so FastAPI has already converted it) with `uuid.UUID()` again:

```python
query = query.where(LLMModel.tenant_id == uuid.UUID(tid))   # ❌
# AttributeError: 'UUID' object has no attribute 'replace'
Fix (single line):

python
query = query.where(LLMModel.tenant_id == tid)             # ✅
No migration, no new dependency, no behaviour change for valid inputs. Independent of the db: Any = None regression (#841, being fixed by #847).

## Checklist

- [ ] Tested locally
- [ ] No unrelated changes included
