### PR TITLE
Fail runs when tool repair budget is exhausted

### DIFF
--- a/backend/app/services/agent_runtime/node_executor.py
+++ b/backend/app/services/agent_runtime/node_executor.py
@@ -1051,24 +1051,16 @@ class DeterministicRuntimeNodeExecutor:
             lifecycle.pop("step_tool_context", None)
             lifecycle.update(
                 {
-                    "status": "waiting_user",
-                    "next_route": "wait",
+                    "status": "failed",
+                    "next_route": "terminal",
                     "reason": repair_pause_reason,
                     "pending_tool_calls": [],
-                    "waiting_request": {
-                        "waiting_type": "user",
-                        "correlation_id": _runtime_message_id(
-                            context,
-                            f"tool-repair:{repair_pause_reason}:{repair_pause_tool}",
-                        ),
-                        "reason": repair_pause_reason,
-                        "question": (
-                            f"Tool {repair_pause_tool or 'unknown'} reached its "
-                            "repair safety limit. Provide corrected requirements "
-                            "or arguments to continue."
-                        ),
-                    },
-                    "error": None,
+                    "waiting_request": None,
+                    "error": _error(
+                        repair_pause_reason,
+                        f"Tool {repair_pause_tool or 'unknown'} reached its "
+                        "repair safety limit.",
+                    ),
                 }
             )
         else:

--- a/backend/tests/test_agent_runtime_node_executor.py
+++ b/backend/tests/test_agent_runtime_node_executor.py
@@ -784,7 +784,7 @@ async def test_each_tool_call_gets_an_independent_langgraph_retry_budget(
 
 
 @pytest.mark.asyncio
-async def test_tenth_same_tool_failure_pauses_before_next_model_call() -> None:
+async def test_tenth_same_tool_failure_fails_run_before_next_model_call() -> None:
     run_id = uuid.uuid4()
     proposals = tuple(
         ModelStepResult(
@@ -822,33 +822,23 @@ async def test_tenth_same_tool_failure_pauses_before_next_model_call() -> None:
     result = await _invoke(run_id, executor)
 
     lifecycle = result["lifecycle"]
-    assert lifecycle["status"] == "waiting_user"
+    assert lifecycle["status"] == "failed"
+    assert lifecycle["next_route"] == "terminal"
     assert lifecycle["reason"] == (
         "tool_repair_same_fingerprint_limit_reached"
     )
+    assert lifecycle["error"] == {
+        "code": "tool_repair_same_fingerprint_limit_reached",
+        "message": "Tool read_file reached its repair safety limit.",
+    }
+    assert lifecycle["pending_tool_calls"] == []
+    assert lifecycle.get("waiting_request") is None
     assert lifecycle["model_step_count"] == 10
     repair_episode = lifecycle["tool_repair_episodes"]["by_tool"]["read_file"]
     assert repair_episode["total_failures"] == 10
     assert repair_episode["same_fingerprint_failures"] == 10
     assert model.calls == 10
     assert len(tools.calls) == 10
-
-    resumed = await executor.execute(
-        "wait",
-        cast(RuntimeGraphState, result),
-        _context(run_id, executor, "command-user-correction"),
-        resume_value={
-            "resume_type": "user_input",
-            "payload": {"content": "Use README.md as the path."},
-        },
-    )
-    assert resumed["lifecycle"]["tool_repair_episodes"] == {
-        "version": 1,
-        "by_tool": {},
-    }
-    assert resumed["lifecycle"]["tool_repair_reset"]["reason"] == (
-        "explicit_user_correction"
-    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Change Tool repair-budget exhaustion from `waiting_user` to terminal `failed`.
- Clear pending Tool calls and waiting state when the limit is reached.
- Preserve the specific repair-limit reason as a structured Runtime error.
- Update the Runtime regression test to require terminal failure and prevent another model call.

## Why

The previous behavior left the Run parked in `waiting_user`. The backend delivered a plain assistant message, while the UI could continue looking active and the Run retained its lane. A depleted repair budget is an execution failure and should use the existing `run_failed` and frontend runtime-error path.

## Compatibility

The legacy resume handler remains in place so already-persisted repair-limit `waiting_user` checkpoints can still be resumed. New runs terminate instead.

## Validation

- 62 Runtime node, checkpoint, chat stream, and repair-budget tests passed
- Scoped Ruff passed
- `git diff --check` passed

## Known gap

Live WebSocket rendering against the deployed frontend was not exercised.