### PR TITLE
feat: add OrcaRouter as a named LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Each agent has a `soul.md` (personality), `memory.md` (long-term memory), and a 
 - Network access to LLM API endpoints
 
 > **Note:** Clawith does not run any AI models locally — all LLM inference is handled by external API providers (OpenAI, Anthropic, etc.). The local deployment is a standard web application with Docker orchestration.
+>
+> **OrcaRouter** is available as a first-class provider: in the enterprise LLM settings, add a model with provider **OrcaRouter** (base URL `https://api.orcarouter.ai/v1`) and any `sk-orca-...` key. See [orcarouter.ai](https://www.orcarouter.ai). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
 
 #### Recommended Configurations
 

--- a/backend/app/services/llm/client.py
+++ b/backend/app/services/llm/client.py
@@ -2376,6 +2376,13 @@ PROVIDER_REGISTRY: dict[str, ProviderSpec] = {
         default_base_url="https://openrouter.ai/api/v1",
         default_max_tokens=4096,
     ),
+    "orcarouter": ProviderSpec(
+        provider="orcarouter",
+        display_name="OrcaRouter",
+        protocol="openai_compatible",
+        default_base_url="https://api.orcarouter.ai/v1",
+        default_max_tokens=16384,
+    ),
     "zhipu": ProviderSpec(
         provider="zhipu",
         display_name="Zhipu",

--- a/backend/tests/test_orcarouter_provider.py
+++ b/backend/tests/test_orcarouter_provider.py
@@ -1,0 +1,55 @@
+"""Provider registry tests for the OrcaRouter integration."""
+
+from app.services.llm.client import (
+    PROVIDER_REGISTRY,
+    create_llm_client,
+    get_provider_base_url,
+    get_provider_manifest,
+    normalize_provider,
+)
+
+
+def test_orcarouter_registered_in_provider_registry() -> None:
+    spec = PROVIDER_REGISTRY.get("orcarouter")
+    assert spec is not None
+    assert spec.provider == "orcarouter"
+    assert spec.display_name == "OrcaRouter"
+    assert spec.protocol == "openai_compatible"
+    assert spec.default_base_url == "https://api.orcarouter.ai/v1"
+    assert spec.supports_tool_choice is True
+    assert spec.default_max_tokens > 0
+
+
+def test_orcarouter_manifest_round_trip() -> None:
+    manifest = {entry["provider"]: entry for entry in get_provider_manifest()}
+    entry = manifest.get("orcarouter")
+    assert entry is not None
+    assert entry["display_name"] == "OrcaRouter"
+    assert entry["default_base_url"] == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_base_url_resolution() -> None:
+    assert get_provider_base_url("orcarouter") == "https://api.orcarouter.ai/v1"
+    # explicit custom base_url takes precedence
+    assert get_provider_base_url("orcarouter", "https://example.com/v1") == "https://example.com/v1"
+    # aliases normalize to the canonical provider id
+    assert normalize_provider("OrcaRouter") == "orcarouter"
+
+
+def test_create_orcarouter_client_uses_openai_compatible_protocol() -> None:
+    client = create_llm_client(
+        provider="orcarouter",
+        api_key="sk-orca-test",
+        model="orcarouter/auto",
+    )
+    try:
+        assert client.base_url == "https://api.orcarouter.ai/v1"
+        assert client.model == "orcarouter/auto"
+        assert client.supports_tool_choice is True
+        # Bearer auth headers for the OpenAI-compatible gateway
+        headers = client._get_headers()
+        assert headers["Authorization"] == "Bearer sk-orca-test"
+    finally:
+        import asyncio
+
+        asyncio.run(client.close())

--- a/frontend/src/pages/enterprise-settings/tabs/LlmTab.tsx
+++ b/frontend/src/pages/enterprise-settings/tabs/LlmTab.tsx
@@ -57,6 +57,7 @@ const FALLBACK_LLM_PROVIDERS: LLMProviderSpec[] = [
     { provider: 'baidu', display_name: 'Baidu (Qianfan)', protocol: 'openai_compatible', default_base_url: 'https://qianfan.baidubce.com/v2', supports_tool_choice: false, default_max_tokens: 4096 },
     { provider: 'gemini', display_name: 'Gemini', protocol: 'gemini', default_base_url: 'https://generativelanguage.googleapis.com/v1beta', supports_tool_choice: true, default_max_tokens: 8192 },
     { provider: 'openrouter', display_name: 'OpenRouter', protocol: 'openai_compatible', default_base_url: 'https://openrouter.ai/api/v1', supports_tool_choice: true, default_max_tokens: 4096 },
+    { provider: 'orcarouter', display_name: 'OrcaRouter', protocol: 'openai_compatible', default_base_url: 'https://api.orcarouter.ai/v1', supports_tool_choice: true, default_max_tokens: 16384 },
     { provider: 'kimi', display_name: 'Kimi (Moonshot)', protocol: 'openai_compatible', default_base_url: 'https://api.moonshot.cn/v1', supports_tool_choice: true, default_max_tokens: 8192 },
     { provider: 'vllm', display_name: 'vLLM', protocol: 'openai_compatible', default_base_url: 'http://localhost:8000/v1', supports_tool_choice: true, default_max_tokens: 4096 },
     { provider: 'ollama', display_name: 'Ollama', protocol: 'openai_compatible', default_base_url: 'http://localhost:11434/v1', supports_tool_choice: true, default_max_tokens: 4096 },


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a first-class, named LLM provider.

OrcaRouter is an OpenAI-compatible LLM gateway (`https://api.orcarouter.ai/v1`, keys prefixed `sk-orca-`) that routes to leading models behind one endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This change mirrors the existing `openrouter` wiring:

- `backend/app/services/llm/client.py` — register `orcarouter` in `PROVIDER_REGISTRY` (openai-compatible protocol, `default_base_url=https://api.orcarouter.ai/v1`, `supports_tool_choice=True`, `default_max_tokens=16384`).
- `frontend/src/pages/enterprise-settings/tabs/LlmTab.tsx` — add `orcarouter` to `FALLBACK_LLM_PROVIDERS` so it appears in the Enterprise → LLM provider picker (the live `/enterprise/llm-providers` endpoint serves the same registry).
- `backend/tests/test_orcarouter_provider.py` — new tests pinning the registry entry, manifest round-trip, base-url resolution, and client creation.
- `README.md` — document the OrcaRouter provider.

No database migration is needed: provider ids are stored as strings and the registry is the single source of truth for base URL / protocol.

## Checklist

- [x] Tested locally
- [x] No unrelated changes included

## Verification

- `pytest tests/test_orcarouter_provider.py` → 4 passed; full suite → 2177 passed, 2 pre-existing `html_to_pdf` env failures (missing `libgobject-2.0-0`) + 1 pre-existing `test_sso_toggle` collection error (missing `tests.test_auth`), both present on clean `main`.
- Frontend `tsc --noEmit` → clean; existing 8 test failures are pre-existing on `main`.
- Live call through the repo's own `create_llm_client(provider="orcarouter", ...)` against `https://api.orcarouter.ai/v1/chat/completions` → HTTP 200, model `orcarouter/auto` → `qwen3.6-flash`, returned `ORCA-OK`; streaming SSE path also returns 200.

Disclosure: I'm an engineer on the OrcaRouter team.
