### PR TITLE
fix: preserve reasoning content in chat history

### DIFF
--- a/backend/app/services/llm/utils.py
+++ b/backend/app/services/llm/utils.py
@@ -136,8 +136,8 @@ def convert_chat_messages_to_llm_format(messages) -> list[dict]:
                 continue  # Skip malformed tool_call records
         else:
             entry: dict = {"role": msg.role, "content": msg.content}
-            if hasattr(msg, "thinking") and msg.thinking:
-                entry["thinking"] = msg.thinking
+            if msg.role == "assistant" and hasattr(msg, "thinking") and msg.thinking:
+                entry["reasoning_content"] = msg.thinking
             result.append(entry)
 
     return result

--- a/backend/tests/test_llm_utils.py
+++ b/backend/tests/test_llm_utils.py
@@ -1,0 +1,20 @@
+from types import SimpleNamespace
+from app.services.llm.utils import convert_chat_messages_to_llm_format
+
+def test_convert_chat_messages_preserves_reasoning_content():
+    message = SimpleNamespace(
+        id="message-1",
+        role="assistant",
+        content="I found the answer.",
+        thinking="I should inspect the evidence first.",
+    )
+
+    result = convert_chat_messages_to_llm_format([message])
+
+    assert result == [
+        {
+            "role": "assistant",
+            "content": "I found the answer.",
+            "reasoning_content": "I should inspect the evidence first.",
+        }
+    ]


### PR DESCRIPTION
## Summary

This PR fixes an issue where assistant reasoning stored in `ChatMessage.thinking` was reconstructed using the wrong field name.

When chat history was rebuilt, the reasoning was sent as `thinking` instead of `reasoning_content`, which could cause thinking-mode requests to fail.

## Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor / chore
* [ ] Documentation

## Changes

* [x] Preserve assistant reasoning as `reasoning_content` when rebuilding chat history
* [x] Only include `reasoning_content` for assistant messages
* [x] Add a regression test for the history conversion

## Testing

* [x] Added `test_convert_chat_messages_preserves_reasoning_content`
* [x] Relevant LLM tests pass locally
* [x] Backend test suite passes locally

## Related issue

Fixes #570
