### PR TITLE
Keep onboarding to one model attempt and Tool counts to one turn

### DIFF
--- a/backend/app/services/agent_runtime/model_step_service.py
+++ b/backend/app/services/agent_runtime/model_step_service.py
@@ -396,6 +396,11 @@ def _is_group_agent_run(state: RuntimeGraphState) -> bool:
     )
 
 
+def _is_onboarding_run(state: RuntimeGraphState) -> bool:
+    target_phase = state["snapshots"].initial_input.get("onboarding_target_phase")
+    return isinstance(target_phase, str) and bool(target_phase.strip())
+
+
 def _is_public_group_chat_run(state: RuntimeGraphState) -> bool:
     initial_input = state["snapshots"].initial_input
     if _is_group_agent_run(state):
@@ -1898,7 +1903,7 @@ class RuntimeModelStepService:
         context: RuntimeContext,
     ) -> LLMCompletionStep:
         """Retry only transient provider failures before model failover."""
-        total_attempts = self._model_retry_attempts + 1
+        total_attempts = 1 if _is_onboarding_run(state) else self._model_retry_attempts + 1
         for attempt in range(1, total_attempts + 1):
             writer = self._answer_stream_writer(
                 state=state,
@@ -1997,7 +2002,8 @@ class RuntimeModelStepService:
         try:
             model, agent, ledger, executions = await self._load(context, state)
             is_native_group = _is_group_agent_run(state)
-            allow_user_wait = not _is_public_group_chat_run(state)
+            onboarding_run = _is_onboarding_run(state)
+            allow_user_wait = not _is_public_group_chat_run(state) and not onboarding_run
             application_tools = (
                 with_group_runtime_tools(
                     await self._tool_provider(agent.id),
@@ -2068,6 +2074,11 @@ class RuntimeModelStepService:
                 )
             except Exception as primary_error:
                 primary_classification = classify_error(primary_error)
+                if onboarding_run:
+                    raise RuntimeModelCallError(
+                        "onboarding_model_call_failed",
+                        _safe_provider_failure_message(primary_error),
+                    ) from primary_error
                 if not is_retryable_classification(primary_classification):
                     logger.error(
                         "[RuntimeModelFailure] run_id={} agent_id={} stage=primary "
@@ -2195,6 +2206,11 @@ class RuntimeModelStepService:
                 allow_user_wait=allow_user_wait,
                 allow_group_handoff=is_native_group,
             )
+            if onboarding_run and result.repair_instruction is not None:
+                result = _error(
+                    "onboarding_model_output_invalid",
+                    "The onboarding model response was incomplete or invalid.",
+                )
             reset_reason = _tool_repair_reset_reason(state)
             if reset_reason is not None:
                 result = replace(result, repair_reset_reason=reset_reason)

--- a/backend/app/services/agent_runtime/verification.py
+++ b/backend/app/services/agent_runtime/verification.py
@@ -747,6 +747,19 @@ class CompletionGateRuntimeVerifier:
         deterministic = await self._deterministic.verify(state, context, candidate)
         if deterministic.outcome != "pass":
             return deterministic
+        onboarding_target_phase = state["snapshots"].initial_input.get(
+            "onboarding_target_phase"
+        )
+        if isinstance(onboarding_target_phase, str) and onboarding_target_phase.strip():
+            return VerificationResult(
+                outcome="pass",
+                details={
+                    "code": "onboarding_deterministic_checks_passed",
+                    "deterministic": dict(deterministic.details),
+                    "artifact_refs": deterministic.details.get("artifact_refs", []),
+                    "evidence_refs": deterministic.details.get("evidence_refs", []),
+                },
+            )
         semantic = await self._completion_gate.verify(state, context, candidate)
         if semantic.outcome != "pass":
             return VerificationResult(

--- a/backend/tests/test_agent_runtime_model_step_service.py
+++ b/backend/tests/test_agent_runtime_model_step_service.py
@@ -3016,6 +3016,74 @@ async def test_retryable_primary_error_rebuilds_budget_for_fallback_once() -> No
 
 
 @pytest.mark.asyncio
+async def test_onboarding_provider_failure_is_not_retried_or_failed_over() -> None:
+    tenant_id = uuid.uuid4()
+    model = _model(tenant_id)
+    fallback = _model(tenant_id)
+    agent = _agent(tenant_id)
+    agent.fallback_model_id = fallback.id
+    state = _state(tenant_id, model, agent)
+    state["snapshots"].initial_input["onboarding_target_phase"] = "greeted"
+    called_models: list[uuid.UUID] = []
+
+    async def complete(model_arg, *args, **kwargs):
+        del args, kwargs
+        called_models.append(model_arg.id)
+        raise TimeoutError("provider timeout")
+
+    result = await _failover_service(
+        model,
+        fallback,
+        agent,
+        _ContextBuilder(_build()),
+        complete,
+    ).complete_once(state, _context(state))
+
+    assert result.intent == "error"
+    assert result.error is not None
+    assert result.error["code"] == "onboarding_model_call_failed"
+    assert called_models == [model.id]
+
+
+@pytest.mark.asyncio
+async def test_onboarding_invalid_output_is_not_sent_to_model_repair() -> None:
+    tenant_id = uuid.uuid4()
+    model = _model(tenant_id)
+    agent = _agent(tenant_id)
+    state = _state(tenant_id, model, agent)
+    state["snapshots"].initial_input.update(
+        {
+            "application_tools_enabled": False,
+            "onboarding_target_phase": "greeted",
+        }
+    )
+    captured_tools: list[list[dict]] = []
+
+    async def complete(*_args, **kwargs):
+        captured_tools.append(kwargs["tools"])
+        return LLMCompletionStep(
+            content="partial greeting",
+            tool_calls=(),
+            reasoning_content=None,
+            retry_instruction=None,
+            usage=TokenUsage(total_tokens=12),
+            finish_reason="length",
+        )
+
+    result = await _service(
+        model,
+        agent,
+        _ContextBuilder(_build()),
+        complete,
+    ).complete_once(state, _context(state))
+
+    assert result.intent == "error"
+    assert result.error is not None
+    assert result.error["code"] == "onboarding_model_output_invalid"
+    assert captured_tools == [[]]
+
+
+@pytest.mark.asyncio
 async def test_retryable_primary_error_recovers_on_same_model_before_fallback() -> None:
     tenant_id = uuid.uuid4()
     model = _model(tenant_id)

--- a/backend/tests/test_agent_runtime_tool_outcome_contract.py
+++ b/backend/tests/test_agent_runtime_tool_outcome_contract.py
@@ -1279,6 +1279,43 @@ async def test_completion_gate_never_bypasses_unsettled_public_group_tool() -> N
     assert result.details["code"] == "unsettled_tool_execution"
 
 
+@pytest.mark.asyncio
+async def test_onboarding_skips_semantic_completion_repairs_after_deterministic_pass() -> None:
+    tenant_id = uuid.uuid4()
+    run_id = uuid.uuid4()
+    deterministic = ToolLedgerRuntimeVerifier(
+        session_factory=_factory(_ManyResult([])),
+    )
+
+    class _NeverCalledCompletionGate:
+        async def verify(self, *_args, **_kwargs):
+            raise AssertionError("onboarding must not enter semantic completion repair")
+
+    verifier = CompletionGateRuntimeVerifier(
+        deterministic=deterministic,
+        completion_gate=_NeverCalledCompletionGate(),  # type: ignore[arg-type]
+    )
+    state = _state(tenant_id, run_id)
+    state["snapshots"] = RunInputSnapshots(
+        session_context={"version": 0},
+        session_context_version=0,
+        recent_session_messages=(),
+        related_run_summaries=(),
+        initial_input={"onboarding_target_phase": "greeted"},
+    )
+
+    result = await verifier.verify(
+        state,
+        _context(tenant_id, run_id),
+        "Welcome to Clawith.",
+    )
+
+    assert result.outcome == "pass"
+    assert result.details["code"] == "onboarding_deterministic_checks_passed"
+    assert result.details["artifact_refs"] == []
+    assert result.details["evidence_refs"] == []
+
+
 async def _true_reference(
     ref: str,
     tenant_id: uuid.UUID,

--- a/frontend/src/pages/agent-detail/AgentDetailPage.tsx
+++ b/frontend/src/pages/agent-detail/AgentDetailPage.tsx
@@ -1219,7 +1219,7 @@ function describeToolResolution(
 }
 
 function AnalysisCard({
-    items, t, expanded, onToggle, isGroupRunning, chatActive, sessionId, totalToolCount,
+    items, t, expanded, onToggle, isGroupRunning, chatActive, sessionId,
     reconciliationsByToolCallId,
 }: {
     items: AnalysisItem[];
@@ -1231,7 +1231,6 @@ function AnalysisCard({
     /** True while the chat is actively streaming/waiting (any turn in flight) */
     chatActive?: boolean;
     sessionId?: string | null;
-    totalToolCount?: number;
     reconciliationsByToolCallId: Map<string, ToolReconciliation>;
 }) {
     // propose_experience_draft is a human-facing proposal, not a reasoning step —
@@ -1246,11 +1245,10 @@ function AnalysisCard({
     const stopped = hasRunningTool && chatActive === false;
     const isRunning = !stopped && (hasRunningTool || (!hasTools && isGroupRunning));
     const runningTool = [...toolItems].reverse().find(tc => tc.status === 'running') ?? null;
-    const resolvedToolCount = Math.max(totalToolCount ?? 0, toolItems.length);
     const headerTitle = isRunning && runningTool
         ? getToolMeta(runningTool).title
-        : totalToolCount != null
-            ? t('agent.chat.toolCallsTotal', { count: resolvedToolCount })
+        : hasTools
+            ? t('agent.chat.toolCallsTotal', { count: toolItems.length })
             : describeAnalysis(items, t);
 
     return (
@@ -7115,9 +7113,6 @@ export default function AgentDetailPage() {
                                                     }
                                                     flushGroup(); // flush any trailing group
 
-                                                    const analysisGroupCount = grouped.filter(entry => entry.type === 'analysis_group').length;
-
-
                                                     return grouped.map((entry, entryIdx) => {
                                                         const previousEntry = grouped[entryIdx - 1];
                                                         const hideAssistantAvatar = entry.type === 'msg'
@@ -7147,11 +7142,6 @@ export default function AgentDetailPage() {
                                                                         isGroupRunning={groupIsRunning}
                                                                         chatActive={isWaiting || isStreaming}
                                                                         sessionId={activeSessionIdRef.current}
-                                                                        totalToolCount={
-                                                                            analysisGroupCount === 1 && !(isWaiting || isStreaming)
-                                                                                ? activeSession?.tool_call_count
-                                                                                : undefined
-                                                                        }
                                                                         reconciliationsByToolCallId={selectedReconciliationsByToolCallId}
                                                                     />
                                                                 </div>

--- a/frontend/tests/directChatObservabilityContract.test.mjs
+++ b/frontend/tests/directChatObservabilityContract.test.mjs
@@ -34,11 +34,10 @@ test('replayed tool packets keep one row by stable tool call id', () => {
   assert.match(source, /toolCallId: m\.toolCallId/);
 });
 
-test('settled single-turn tool totals come from session metadata instead of loaded pages', () => {
-  assert.match(source, /totalToolCount\?: number/);
-  assert.match(source, /activeSession\?\.tool_call_count/);
-  assert.match(source, /analysisGroupCount === 1/);
-  assert.match(source, /agent\.chat\.toolCallsTotal/);
+test('settled tool totals belong to the current user turn', () => {
+  assert.doesNotMatch(source, /totalToolCount\?: number/);
+  assert.doesNotMatch(source, /activeSession\?\.tool_call_count/);
+  assert.match(source, /toolCallsTotal', \{ count: toolItems\.length \}/);
 });
 
 test('an authoritative active run keeps a thinking indicator visible after reload', () => {

--- a/frontend/tests/sessionRuntimeState.test.mjs
+++ b/frontend/tests/sessionRuntimeState.test.mjs
@@ -475,14 +475,12 @@ test('workspace reconciliation keeps decisions in the composer and passive statu
   assert.doesNotMatch(agentDetailSource, /analysis-tool-reconciliation__actions/);
 });
 
-test('loaded Tool rows cannot be hidden behind a stale zero session count', () => {
+test('analysis cards count only Tool rows from their own user turn', () => {
+  assert.doesNotMatch(agentDetailSource, /totalToolCount/);
+  assert.doesNotMatch(agentDetailSource, /activeSession\?\.tool_call_count/);
   assert.match(
     agentDetailSource,
-    /Math\.max\(totalToolCount \?\? 0, toolItems\.length\)/,
-  );
-  assert.match(
-    agentDetailSource,
-    /toolCallsTotal', \{ count: resolvedToolCount \}/,
+    /toolCallsTotal', \{ count: toolItems\.length \}/,
   );
 });
 


### PR DESCRIPTION
## Summary

- Restrict synthetic onboarding to one primary model attempt: no provider retry, fallback, wait Tool, model repair loop, or semantic Completion Gate repair.
- Preserve deterministic completion checks and normal terminal delivery so the streaming bubble and Stop control settle from Runtime truth.
- Display each AnalysisCard Tool count from the current user-turn group instead of the Session-wide aggregate.

## Verification

- Backend Runtime/onboarding/WebSocket: 179 passed
- Frontend: 122 passed
- Frontend production build: passed
- Scoped Ruff: passed
- Architecture Guard P0: passed
- git diff --check: passed

## Release

- After merge, recreate `v1.11.4-fix.1` from the resulting main commit. The prior GitHub Release is deleted; the old remote tag will be removed only after this PR is merged.